### PR TITLE
MultiPortGraph layer for implicit copies

### DIFF
--- a/src/hugr/multiportgraph.rs
+++ b/src/hugr/multiportgraph.rs
@@ -1,13 +1,15 @@
 //! Wrapper around a portgraph providing multiports via implicit copy nodes
 
-use bitvec::vec::BitVec;
+mod iter;
 
-use itertools::Itertools;
 use portgraph::{
-    portgraph::{NodePortOffsets, NodePorts},
+    portgraph::{NodePortOffsets, NodePorts, PortOperation},
     Direction, LinkError, NodeIndex, PortGraph, PortIndex, PortOffset, SecondaryMap,
 };
 
+use self::iter::{Neighbours, NodeConnections, NodeLinks, NodeSubports, Nodes, PortLinks, Ports};
+use bitvec::vec::BitVec;
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 /// An unlabelled port graph that allows multiple links to the same ports.
@@ -104,6 +106,8 @@ impl MultiPortGraph {
     /// g.link_ports(g.outputs(node1).nth(0).unwrap(), g.inputs(node0).nth(0).unwrap());
     /// g.remove_node(node0);
     /// assert!(!g.contains_node(node0));
+    /// assert!(g.port_link(g.outputs(node1).nth(0).unwrap()).is_none());
+    /// assert!(g.port_link(g.inputs(node1).nth(0).unwrap()).is_none());
     /// ```
     pub fn remove_node(&mut self, node: NodeIndex) {
         for port in self.graph.all_ports(node) {
@@ -127,6 +131,8 @@ impl MultiPortGraph {
     /// let node0_output = g.output(node0, 0).unwrap();
     /// let node1_input = g.input(node1, 0).unwrap();
     /// g.link_ports(node0_output, node1_input).unwrap();
+    /// assert_eq!(g.port_link(node0_output), Some(node1_input));
+    /// assert_eq!(g.port_link(node1_input), Some(node0_output));
     /// ```
     ///
     /// # Errors
@@ -194,6 +200,74 @@ impl MultiPortGraph {
         self.get_subport_from_index(link)
     }
 
+    /// Returns an iterator over every pair of matching ports connecting `from`
+    /// with `to`.
+    ///
+    /// # Example
+    /// ```
+    /// # use portgraph::{PortGraph, NodeIndex, PortIndex, Direction};
+    /// let mut g = PortGraph::new();
+    /// let a = g.add_node(0, 2);
+    /// let b = g.add_node(2, 0);
+    ///
+    /// g.link_nodes(a, 0, b, 0).unwrap();
+    /// g.link_nodes(a, 1, b, 1).unwrap();
+    ///
+    /// let mut connections = g.get_connections(a, b);
+    /// assert_eq!(connections.next(), Some((g.output(a,0).unwrap(), g.input(b,0).unwrap())));
+    /// assert_eq!(connections.next(), Some((g.output(a,1).unwrap(), g.input(b,1).unwrap())));
+    /// assert_eq!(connections.next(), None);
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn get_connections(&self, from: NodeIndex, to: NodeIndex) -> NodeConnections<'_> {
+        NodeConnections::new(self, to, self.output_links(from))
+    }
+
+    /// Checks whether there is a directed link between the two nodes and
+    /// returns the first matching pair of ports.
+    ///
+    /// # Example
+    /// ```
+    /// # use portgraph::{PortGraph, NodeIndex, PortIndex, Direction};
+    /// let mut g = PortGraph::new();
+    /// let a = g.add_node(0, 2);
+    /// let b = g.add_node(2, 0);
+    ///
+    /// g.link_nodes(a, 0, b, 0).unwrap();
+    /// g.link_nodes(a, 1, b, 1).unwrap();
+    ///
+    /// assert_eq!(g.get_connection(a, b), Some((g.output(a,0).unwrap(), g.input(b,0).unwrap())));
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn get_connection(
+        &self,
+        from: NodeIndex,
+        to: NodeIndex,
+    ) -> Option<(SubportIndex, SubportIndex)> {
+        self.get_connections(from, to).next()
+    }
+
+    /// Checks whether there is a directed link between the two nodes.
+    ///
+    /// # Example
+    /// ```
+    /// # use portgraph::{PortGraph, NodeIndex, PortIndex, Direction};
+    /// let mut g = PortGraph::new();
+    /// let a = g.add_node(0, 2);
+    /// let b = g.add_node(2, 0);
+    ///
+    /// g.link_nodes(a, 0, b, 0).unwrap();
+    ///
+    /// assert!(g.connected(a, b));
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn connected(&self, from: NodeIndex, to: NodeIndex) -> bool {
+        self.get_connection(from, to).is_some()
+    }
+
     /// Links two nodes at an input and output port offsets.
     pub fn link_nodes(
         &mut self,
@@ -236,6 +310,19 @@ impl MultiPortGraph {
     #[must_use]
     pub fn port_index(&self, node: NodeIndex, offset: PortOffset) -> Option<PortIndex> {
         self.graph.port_index(node, offset)
+    }
+
+    /// Returns the port that the given `port` is linked to.
+    #[inline]
+    pub fn port_links(&self, port: PortIndex) -> PortLinks {
+        PortLinks::new(self, port)
+    }
+
+    /// Return the link to the provided port, if not connected return None.
+    /// If this port has multiple connected subports, an arbitrary one is returned.
+    #[inline]
+    pub fn port_link(&self, port: PortIndex) -> Option<SubportIndex> {
+        self.port_links(port).next().map(|(_, p)| p)
     }
 
     /// Return the subport linked to the given `port`. If the port is not
@@ -310,6 +397,32 @@ impl MultiPortGraph {
         self.graph.num_ports(node, direction)
     }
 
+    /// Iterates over all the ports of the `node` in the given `direction`.
+    pub fn subports(&self, node: NodeIndex, direction: Direction) -> NodeSubports {
+        NodeSubports::new(self, self.graph.ports(node, direction))
+    }
+
+    /// Iterates over the input and output ports of the `node` in sequence.
+    pub fn all_subports(&self, node: NodeIndex) -> NodeSubports {
+        NodeSubports::new(self, self.graph.all_ports(node))
+    }
+
+    /// Iterates over all the input ports of the `node`.
+    ///
+    /// Shorthand for [`MultiPortGraph::subports`].
+    #[inline]
+    pub fn subport_inputs(&self, node: NodeIndex) -> NodeSubports {
+        self.subports(node, Direction::Incoming)
+    }
+
+    /// Iterates over all the output ports of the `node`.
+    ///
+    /// Shorthand for [`MultiPortGraph::subports`].
+    #[inline]
+    pub fn subport_outputs(&self, node: NodeIndex) -> NodeSubports {
+        self.subports(node, Direction::Outgoing)
+    }
+
     /// Iterates over all the port offsets of the `node` in the given `direction`.
     pub fn port_offsets(&self, node: NodeIndex, direction: Direction) -> NodePortOffsets {
         self.graph.port_offsets(node, direction)
@@ -335,6 +448,63 @@ impl MultiPortGraph {
     #[inline]
     pub fn all_port_offsets(&self, node: NodeIndex) -> NodePortOffsets {
         self.graph.all_port_offsets(node)
+    }
+
+    /// Iterates over the connected links of the `node` in the given
+    /// `direction`.
+    ///
+    /// In contrast to [`PortGraph::links`], this iterator only returns linked
+    /// subports, and includes the source subport.
+    ///
+    /// [`PortGraph::links`]: portgraph::PortGraph::links
+    #[inline]
+    pub fn links(&self, node: NodeIndex, direction: Direction) -> NodeLinks<'_> {
+        NodeLinks::new(self, self.ports(node, direction))
+    }
+
+    /// Iterates over the connected input links of the `node`. Shorthand for
+    /// [`MultiPortGraph::links`].
+    #[inline]
+    pub fn input_links(&self, node: NodeIndex) -> NodeLinks<'_> {
+        self.links(node, Direction::Incoming)
+    }
+
+    /// Iterates over the connected output links of the `node`. Shorthand for
+    /// [`MultiPortGraph::links`].
+    #[inline]
+    pub fn output_links(&self, node: NodeIndex) -> NodeLinks<'_> {
+        self.links(node, Direction::Outgoing)
+    }
+
+    /// Iterates over the connected input and output links of the `node` in sequence.
+    #[inline]
+    pub fn all_links(&self, node: NodeIndex) -> NodeLinks<'_> {
+        NodeLinks::new(self, self.all_ports(node))
+    }
+
+    /// Iterates over neighbour nodes in the given `direction`.
+    /// May contain duplicates if the graph has multiple links between nodes.
+    #[inline]
+    pub fn neighbours(&self, node: NodeIndex, direction: Direction) -> Neighbours<'_> {
+        Neighbours::new(self, self.subports(node, direction))
+    }
+
+    /// Iterates over the input neighbours of the `node`. Shorthand for [`MultiPortGraph::neighbours`].
+    #[inline]
+    pub fn input_neighbours(&self, node: NodeIndex) -> Neighbours<'_> {
+        self.neighbours(node, Direction::Incoming)
+    }
+
+    /// Iterates over the output neighbours of the `node`. Shorthand for [`MultiPortGraph::neighbours`].
+    #[inline]
+    pub fn output_neighbours(&self, node: NodeIndex) -> Neighbours<'_> {
+        self.neighbours(node, Direction::Outgoing)
+    }
+
+    /// Iterates over the input and output neighbours of the `node` in sequence.
+    #[inline]
+    pub fn all_neighbours(&self, node: NodeIndex) -> Neighbours<'_> {
+        Neighbours::new(self, self.all_subports(node))
     }
 
     /// Returns whether the port graph contains the `node`.
@@ -375,6 +545,22 @@ impl MultiPortGraph {
     pub fn link_count(&self) -> usize {
         // Do not count the links between copy nodes and their main nodes.
         self.graph.link_count() - self.copy_node_count
+    }
+
+    /// Iterates over the nodes in the port graph.
+    #[inline]
+    pub fn nodes_iter(&self) -> Nodes<'_> {
+        self::iter::Nodes {
+            multigraph: self,
+            iter: self.graph.nodes_iter(),
+            len: self.node_count(),
+        }
+    }
+
+    /// Iterates over the ports in the port graph.
+    #[inline]
+    pub fn ports_iter(&self) -> Ports<'_> {
+        Ports::new(self, self.graph.ports_iter())
     }
 
     /// Removes all nodes and ports from the port graph.
@@ -434,22 +620,31 @@ impl MultiPortGraph {
         outgoing: usize,
         mut rekey: F,
     ) where
-        F: FnMut(PortIndex, Option<PortIndex>),
+        F: FnMut(PortIndex, PortOperation),
     {
         let mut dropped_ports = Vec::new();
-        let rekey_wrapper = |port, op: Option<PortIndex>| {
-            if op.is_none() {
-                dropped_ports.push(port);
+        let rekey_wrapper = |port, op| {
+            if let PortOperation::Removed { old_link } = op {
+                dropped_ports.push((port, old_link))
             }
             rekey(port, op);
         };
         self.graph
             .set_num_ports(node, incoming, outgoing, rekey_wrapper);
-        for port in dropped_ports {
-            // TODO: Delete any copy node. That requires https://github.com/CQCL/portgraph/pull/57.
-            self.multiport.set(port, false);
+        for (port, old_link) in dropped_ports {
+            if self.is_multiport(port) {
+                self.multiport.set(port, false);
+                let link = old_link.expect("Multiport node has no link");
+                let copy_node = self.graph.port_node(link).unwrap();
+                self.remove_copy_node(copy_node, link)
+            }
         }
     }
+
+    /* TODO:
+        compact_nodes
+        compact_ports
+    */
 
     /// Shrinks the underlying buffers to the fit the data.
     ///
@@ -727,6 +922,8 @@ pub mod test {
         assert_eq!(graph.node_count(), 0);
         assert_eq!(graph.port_count(), 0);
         assert_eq!(graph.link_count(), 0);
+        assert_eq!(graph.nodes_iter().count(), 0);
+        assert_eq!(graph.ports_iter().count(), 0);
     }
 
     #[test]
@@ -737,6 +934,10 @@ pub mod test {
         let node0_output = g.output(node0, 0).unwrap();
         let node1_input = g.input(node1, 0).unwrap();
         assert_eq!(g.link_count(), 0);
+        assert!(!g.connected(node0, node1));
+        assert!(!g.connected(node1, node0));
+        assert_eq!(g.get_connections(node0, node1).count(), 0);
+        assert_eq!(g.get_connection(node0, node1), None);
 
         // Link the same ports thrice
         let (from0, to0) = g.link_ports(node0_output, node1_input).unwrap();
@@ -751,9 +952,57 @@ pub mod test {
         assert_eq!(g.link_count(), 3);
         assert_eq!(g.subport_link(from0), Some(to0));
         assert_eq!(g.subport_link(to1), Some(from1));
+        assert_eq!(
+            g.port_links(node0_output).collect_vec(),
+            vec![(from0, to0), (from1, to1), (from2, to2)]
+        );
+        assert_eq!(
+            g.get_connections(node0, node1).collect_vec(),
+            vec![(from0, to0), (from1, to1), (from2, to2)]
+        );
+        assert_eq!(g.get_connection(node0, node1), Some((from0, to0)));
+        assert!(g.connected(node0, node1));
+        assert!(!g.connected(node1, node0));
 
         let unlinked_to0 = g.unlink_subport(from0).unwrap();
         assert_eq!(unlinked_to0, to0);
         assert_eq!(g.link_count(), 2);
+        assert_eq!(
+            g.get_connections(node0, node1).collect_vec(),
+            vec![(from1, to1), (from2, to2)]
+        );
+        assert_eq!(g.get_connection(node0, node1), Some((from1, to1)));
+        assert!(g.connected(node0, node1));
+    }
+
+    #[test]
+    fn link_iterators() {
+        let mut g = MultiPortGraph::new();
+        let node0 = g.add_node(1, 2);
+        let node1 = g.add_node(2, 1);
+        let node0_output0 = g.output(node0, 0).unwrap();
+        let node1_input0 = g.input(node1, 0).unwrap();
+
+        assert!(g.input_links(node0).eq([]));
+        assert!(g.output_links(node0).eq([]));
+        assert!(g.all_links(node0).eq([]));
+        assert!(g.input_neighbours(node0).eq([]));
+        assert!(g.output_neighbours(node0).eq([]));
+        assert!(g.all_neighbours(node0).eq([]));
+
+        g.link_nodes(node0, 0, node1, 0).unwrap();
+
+        assert!(g.input_links(node0).eq([]));
+        assert!(g.output_links(node0).eq([(
+            SubportIndex::new_unique(node0_output0),
+            SubportIndex::new_unique(node1_input0)
+        )]));
+        assert!(g.all_links(node0).eq([(
+            SubportIndex::new_unique(node0_output0),
+            SubportIndex::new_unique(node1_input0)
+        )]));
+        assert!(g.input_neighbours(node0).eq([]));
+        assert!(g.output_neighbours(node0).eq([node1]));
+        assert!(g.all_neighbours(node0).eq([node1]));
     }
 }

--- a/src/hugr/multiportgraph.rs
+++ b/src/hugr/multiportgraph.rs
@@ -917,6 +917,27 @@ impl MultiPortGraph {
     }
 }
 
+impl From<PortGraph> for MultiPortGraph {
+    fn from(graph: PortGraph) -> Self {
+        let node_count = graph.node_count();
+        let port_count = graph.port_count();
+        Self {
+            graph,
+            multiport: BitVec::with_capacity(port_count),
+            copy_node: BitVec::with_capacity(node_count),
+            copy_node_count: 0,
+            subport_count: 0,
+        }
+    }
+}
+
+impl From<MultiPortGraph> for PortGraph {
+    fn from(multi: MultiPortGraph) -> Self {
+        // Return the internal graph, exposing the copy nodes
+        multi.graph
+    }
+}
+
 impl SubportIndex {
     /// Creates a new multiport index for a port without a copy node.
     #[inline]

--- a/src/hugr/multiportgraph.rs
+++ b/src/hugr/multiportgraph.rs
@@ -663,10 +663,37 @@ impl MultiPortGraph {
         }
     }
 
-    /* TODO:
-        compact_nodes
-        compact_ports
-    */
+    /// Compacts the storage of nodes in the portgraph. Note that indices won't
+    /// necessarily be consecutively after this process, as there may be
+    /// hidden copy nodes.
+    ///
+    /// Every time a node is moved, the `rekey` function will be called with its
+    /// old and new index.
+    pub fn compact_nodes<F>(&mut self, mut rekey: F)
+    where
+        F: FnMut(NodeIndex, NodeIndex),
+    {
+        self.graph.compact_nodes(|node, new_node| {
+            self.copy_node.swap(node, new_node);
+            rekey(node, new_node);
+        });
+    }
+
+    /// Compacts the storage of ports in the portgraph. Note that indices won't
+    /// necessarily be consecutively after this process, as there may be hidden
+    /// copy nodes.
+    ///
+    /// Every time a port is moved, the `rekey` function will be called with is
+    /// old and new index.
+    pub fn compact_ports<F>(&mut self, mut rekey: F)
+    where
+        F: FnMut(PortIndex, PortIndex),
+    {
+        self.graph.compact_ports(|port, new_port| {
+            self.multiport.swap(port, new_port);
+            rekey(port, new_port);
+        });
+    }
 
     /// Shrinks the underlying buffers to the fit the data.
     ///

--- a/src/hugr/multiportgraph.rs
+++ b/src/hugr/multiportgraph.rs
@@ -204,17 +204,24 @@ impl MultiPortGraph {
     ///
     /// # Example
     /// ```
-    /// # use portgraph::{PortGraph, NodeIndex, PortIndex, Direction};
-    /// let mut g = PortGraph::new();
+    /// # use hugr::hugr::multiportgraph::{MultiPortGraph, SubportIndex};
+    /// # use portgraph::{NodeIndex, PortIndex, Direction};
+    /// let mut g = MultiPortGraph::new();
     /// let a = g.add_node(0, 2);
     /// let b = g.add_node(2, 0);
     ///
     /// g.link_nodes(a, 0, b, 0).unwrap();
+    /// g.link_nodes(a, 0, b, 1).unwrap();
     /// g.link_nodes(a, 1, b, 1).unwrap();
     ///
     /// let mut connections = g.get_connections(a, b);
-    /// assert_eq!(connections.next(), Some((g.output(a,0).unwrap(), g.input(b,0).unwrap())));
-    /// assert_eq!(connections.next(), Some((g.output(a,1).unwrap(), g.input(b,1).unwrap())));
+    /// let out0 = g.output(a, 0).unwrap();
+    /// let out1 = g.output(a, 1).unwrap();
+    /// let in0 = g.input(b, 0).unwrap();
+    /// let in1 = g.input(b, 1).unwrap();
+    /// assert_eq!(connections.next().unwrap(), (SubportIndex::new_multi(out0,0), SubportIndex::new_multi(in0,0)));
+    /// assert_eq!(connections.next().unwrap(), (SubportIndex::new_multi(out0,1), SubportIndex::new_multi(in1,0)));
+    /// assert_eq!(connections.next().unwrap(), (SubportIndex::new_multi(out1,0), SubportIndex::new_multi(in1,1)));
     /// assert_eq!(connections.next(), None);
     /// ```
     #[must_use]
@@ -228,15 +235,18 @@ impl MultiPortGraph {
     ///
     /// # Example
     /// ```
-    /// # use portgraph::{PortGraph, NodeIndex, PortIndex, Direction};
-    /// let mut g = PortGraph::new();
+    /// # use hugr::hugr::multiportgraph::{MultiPortGraph, SubportIndex};
+    /// # use portgraph::{NodeIndex, PortIndex, Direction};
+    /// let mut g = MultiPortGraph::new();
     /// let a = g.add_node(0, 2);
     /// let b = g.add_node(2, 0);
     ///
     /// g.link_nodes(a, 0, b, 0).unwrap();
     /// g.link_nodes(a, 1, b, 1).unwrap();
     ///
-    /// assert_eq!(g.get_connection(a, b), Some((g.output(a,0).unwrap(), g.input(b,0).unwrap())));
+    /// let out0 = g.output(a, 0).unwrap();
+    /// let in0 = g.input(b, 0).unwrap();
+    /// assert_eq!(g.get_connection(a, b), Some((SubportIndex::new_multi(out0,0), SubportIndex::new_multi(in0,0))));
     /// ```
     #[must_use]
     #[inline]
@@ -252,8 +262,9 @@ impl MultiPortGraph {
     ///
     /// # Example
     /// ```
-    /// # use portgraph::{PortGraph, NodeIndex, PortIndex, Direction};
-    /// let mut g = PortGraph::new();
+    /// # use hugr::hugr::multiportgraph::MultiPortGraph;
+    /// # use portgraph::{NodeIndex, PortIndex, Direction};
+    /// let mut g = MultiPortGraph::new();
     /// let a = g.add_node(0, 2);
     /// let b = g.add_node(2, 0);
     ///

--- a/src/hugr/multiportgraph/iter.rs
+++ b/src/hugr/multiportgraph/iter.rs
@@ -1,0 +1,431 @@
+//! Iterators used by the implementation of HugrView for Hugr.
+
+use std::iter::{Enumerate, FusedIterator};
+use std::ops::Range;
+
+use portgraph::portgraph::NodePorts;
+use portgraph::{NodeIndex, PortIndex};
+
+use super::{MultiPortGraph, SubportIndex};
+
+/// Iterator over the ports of a node.
+#[derive(Clone)]
+pub struct Nodes<'a> {
+    // We use portgraph's iterator, but filter out the copy nodes.
+    pub(super) multigraph: &'a MultiPortGraph,
+    pub(super) iter: portgraph::portgraph::Nodes<'a>,
+    pub(super) len: usize,
+}
+
+impl<'a> Iterator for Nodes<'a> {
+    type Item = NodeIndex;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = self
+            .iter
+            .find(|node| !self.multigraph.is_copy_node(*node))?;
+        self.len -= 1;
+        Some(next)
+    }
+
+    #[inline]
+    fn count(self) -> usize {
+        self.len
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len, Some(self.len))
+    }
+}
+
+impl<'a> ExactSizeIterator for Nodes<'a> {
+    fn len(&self) -> usize {
+        self.len
+    }
+}
+
+impl<'a> DoubleEndedIterator for Nodes<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        loop {
+            let node = self.iter.next_back()?;
+            if !self.multigraph.is_copy_node(node) {
+                self.len -= 1;
+                return Some(node);
+            }
+        }
+    }
+}
+
+impl<'a> FusedIterator for Nodes<'a> {}
+
+/// Iterator over the ports of a node.
+#[derive(Clone)]
+pub struct NodeSubports<'a> {
+    multigraph: &'a MultiPortGraph,
+    ports: portgraph::portgraph::NodePorts,
+    current_port: Option<PortIndex>,
+    current_subports: Range<usize>,
+}
+
+impl<'a> NodeSubports<'a> {
+    pub(super) fn new(
+        multigraph: &'a MultiPortGraph,
+        ports: portgraph::portgraph::NodePorts,
+    ) -> Self {
+        Self {
+            multigraph,
+            ports,
+            current_port: None,
+            current_subports: 0..0,
+        }
+    }
+}
+
+impl<'a> Iterator for NodeSubports<'a> {
+    type Item = SubportIndex;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(offset) = self.current_subports.next() {
+            // We are in the middle of iterating over the subports of a port.
+            let current_port = self
+                .current_port
+                .expect("NodeSubports set an invalid current_port value.");
+            return Some(SubportIndex::new_multi(current_port, offset));
+        }
+        // Proceed to the next port.
+        if let Some(port) = self.ports.next() {
+            self.current_port = Some(port);
+            if self.multigraph.is_multiport(port) {
+                let dir = self.multigraph.graph.port_direction(port).unwrap();
+                let copy_node = self
+                    .multigraph
+                    .get_copy_node(port)
+                    .expect("A port was marked as multiport, but no copy node was found.");
+                self.current_subports = self
+                    .multigraph
+                    .graph
+                    .port_offsets(copy_node, dir)
+                    .as_range(dir);
+            } else {
+                // The port is not a multiport, return the single subport.
+                return Some(SubportIndex::new_unique(port));
+            }
+        }
+        None
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.ports.len() + self.current_subports.len(), None)
+    }
+}
+
+impl<'a> FusedIterator for NodeSubports<'a> {}
+
+/// Iterator over the ports of a node.
+#[derive(Clone)]
+pub struct Neighbours<'a> {
+    multigraph: &'a MultiPortGraph,
+    subports: NodeSubports<'a>,
+    current_copy_node: Option<portgraph::NodeIndex>,
+}
+
+impl<'a> Neighbours<'a> {
+    pub(super) fn new(multigraph: &'a MultiPortGraph, subports: NodeSubports<'a>) -> Self {
+        Self {
+            multigraph,
+            subports,
+            current_copy_node: None,
+        }
+    }
+}
+
+impl<'a> Iterator for Neighbours<'a> {
+    type Item = NodeIndex;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let link = self.subports.find_map(|subport| {
+            let port_index = subport.port();
+            if !self.multigraph.is_multiport(port_index) {
+                self.multigraph.graph.port_link(port_index)
+            } else {
+                // There is a copy node
+                if subport.offset() == 0 {
+                    self.current_copy_node = self.multigraph.get_copy_node(port_index);
+                }
+                let copy_node = self
+                    .current_copy_node
+                    .expect("Copy node not connected to a multiport.");
+                let dir = self.multigraph.graph.port_direction(port_index).unwrap();
+                let offset = portgraph::PortOffset::new(dir, subport.offset());
+                let subport_index = self.multigraph.graph.port_index(copy_node, offset).unwrap();
+                self.multigraph.graph.port_link(subport_index)
+            }
+        })?;
+        self.multigraph.graph.port_node(link)
+    }
+}
+
+impl<'a> FusedIterator for Neighbours<'a> {}
+
+/// Iterator over the links from a node, created by
+/// [`MultiPortGraph::node_links`].
+///
+/// In contrast to [`portgraph::portgraph::NodeLinks`], this iterator
+/// only returns linked subports, and includes the source subport.
+#[derive(Clone)]
+#[allow(dead_code)]
+pub struct NodeLinks<'a> {
+    multigraph: &'a MultiPortGraph,
+    ports: NodePorts,
+    current_links: Option<PortLinks<'a>>,
+}
+
+impl<'a> NodeLinks<'a> {
+    pub(super) fn new(multigraph: &'a MultiPortGraph, ports: NodePorts) -> Self {
+        Self {
+            multigraph,
+            ports,
+            current_links: None,
+        }
+    }
+}
+
+impl<'a> Iterator for NodeLinks<'a> {
+    /// A link from one of the node's subports to another subport.
+    type Item = (SubportIndex, SubportIndex);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(links) = &mut self.current_links {
+                if let Some(elt) = links.next() {
+                    return Some(elt);
+                }
+                self.current_links = None;
+            }
+            let port = self.ports.next()?;
+            self.current_links = Some(PortLinks::new(self.multigraph, port));
+        }
+    }
+}
+
+impl<'a> FusedIterator for NodeLinks<'a> {}
+
+/// Iterator over the links between two nodes, created by
+/// [`MultiPortGraph::get_connections`].
+#[derive(Clone)]
+#[allow(dead_code)]
+pub struct NodeConnections<'a> {
+    multigraph: &'a MultiPortGraph,
+    target: NodeIndex,
+    links: NodeLinks<'a>,
+}
+
+impl<'a> NodeConnections<'a> {
+    pub(super) fn new(
+        multigraph: &'a MultiPortGraph,
+        target: NodeIndex,
+        links: NodeLinks<'a>,
+    ) -> Self {
+        Self {
+            multigraph,
+            target,
+            links,
+        }
+    }
+}
+
+impl<'a> Iterator for NodeConnections<'a> {
+    /// A link from one of the node's subports to another subport.
+    type Item = (SubportIndex, SubportIndex);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let (source, target) = self.links.next()?;
+            let target_node = self.multigraph.graph.port_node(target.port())?;
+            if target_node == self.target {
+                return Some((source, target));
+            }
+        }
+    }
+}
+
+impl<'a> FusedIterator for NodeConnections<'a> {}
+
+/// Iterator over the links of a port
+#[derive(Clone)]
+#[allow(missing_docs)]
+pub enum PortLinks<'a> {
+    /// The port is not a multiport. The iterator returns exactly one link.
+    SinglePort {
+        multigraph: &'a MultiPortGraph,
+        port: PortIndex,
+        empty: bool,
+    },
+    /// The port is a multiport. The iterator may return any number of links.
+    Multiport {
+        multigraph: &'a MultiPortGraph,
+        port: PortIndex,
+        subports: Enumerate<portgraph::portgraph::NodePorts>,
+    },
+}
+
+impl<'a> PortLinks<'a> {
+    pub(super) fn new(multigraph: &'a MultiPortGraph, port: PortIndex) -> Self {
+        if multigraph.is_multiport(port) {
+            let copy_node = multigraph.get_copy_node(port).unwrap();
+            let dir = multigraph.graph.port_direction(port).unwrap();
+            let subports = multigraph.graph.ports(copy_node, dir).enumerate();
+            Self::Multiport {
+                multigraph,
+                port,
+                subports,
+            }
+        } else {
+            Self::SinglePort {
+                multigraph,
+                port,
+                empty: false,
+            }
+        }
+    }
+}
+
+/// Returns the link of a single port for a `PortLinks` iterator.
+#[inline(always)]
+fn port_links_single(
+    multigraph: &MultiPortGraph,
+    port: PortIndex,
+) -> Option<(SubportIndex, SubportIndex)> {
+    let link = multigraph.graph.port_link(port)?;
+    let link = multigraph.get_subport_from_index(link)?;
+    Some((SubportIndex::new_unique(port), link))
+}
+
+/// Try to get the next link of a multiport for a `PortLinks` iterator.
+#[inline(always)]
+fn port_links_multiport(
+    multigraph: &MultiPortGraph,
+    port: PortIndex,
+    subport_offset: usize,
+    copy_port_index: PortIndex,
+) -> Option<(SubportIndex, SubportIndex)> {
+    let link = multigraph.graph.port_link(copy_port_index)?;
+    let link = multigraph.get_subport_from_index(link)?;
+    Some((SubportIndex::new_multi(port, subport_offset), link))
+}
+
+impl<'a> Iterator for PortLinks<'a> {
+    type Item = (SubportIndex, SubportIndex);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            PortLinks::SinglePort {
+                multigraph,
+                port,
+                empty,
+            } if !*empty => {
+                *empty = true;
+                port_links_single(multigraph, *port)
+            }
+            PortLinks::SinglePort { .. } => None,
+            PortLinks::Multiport {
+                multigraph,
+                port,
+                subports,
+                ..
+            } => subports
+                .find_map(|(offset, index)| port_links_multiport(multigraph, *port, offset, index)),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            PortLinks::SinglePort { empty, .. } => {
+                if *empty {
+                    (0, Some(0))
+                } else {
+                    (1, Some(1))
+                }
+            }
+            PortLinks::Multiport { subports, .. } => (0, Some(subports.len())),
+        }
+    }
+}
+
+impl<'a> DoubleEndedIterator for PortLinks<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        match self {
+            PortLinks::SinglePort {
+                multigraph,
+                port,
+                empty,
+            } if !*empty => {
+                *empty = true;
+                port_links_single(multigraph, *port)
+            }
+            PortLinks::SinglePort { .. } => None,
+            PortLinks::Multiport {
+                multigraph,
+                port,
+                subports,
+                ..
+            } => loop {
+                let (offset, index) = subports.next_back()?;
+                if let Some(res) = port_links_multiport(multigraph, *port, offset, index) {
+                    return Some(res);
+                }
+            },
+        }
+    }
+}
+
+impl<'a> FusedIterator for PortLinks<'a> {}
+
+/// Iterator over all the ports of the multiport graph.
+#[derive(Clone)]
+pub struct Ports<'a> {
+    /// The multiport graph.
+    multigraph: &'a MultiPortGraph,
+    /// The current port.
+    ports: portgraph::portgraph::Ports<'a>,
+}
+
+impl<'a> Ports<'a> {
+    pub(super) fn new(
+        multigraph: &'a MultiPortGraph,
+        ports: portgraph::portgraph::Ports<'a>,
+    ) -> Self {
+        Self { multigraph, ports }
+    }
+}
+
+impl<'a> Iterator for Ports<'a> {
+    type Item = PortIndex;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.ports.find(|&port| {
+            let node = self.multigraph.port_node(port).unwrap();
+            !self.multigraph.is_copy_node(node)
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, self.ports.size_hint().1)
+    }
+}
+
+impl<'a> DoubleEndedIterator for Ports<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        loop {
+            let port = self.ports.next_back()?;
+            let node = self.multigraph.port_node(port).unwrap();
+            if !self.multigraph.is_copy_node(node) {
+                return Some(port);
+            }
+        }
+    }
+}
+
+impl<'a> FusedIterator for Ports<'a> {}

--- a/src/hugr/multiportgraph/iter.rs
+++ b/src/hugr/multiportgraph/iter.rs
@@ -8,7 +8,7 @@ use portgraph::{NodeIndex, PortIndex};
 
 use super::{MultiPortGraph, SubportIndex};
 
-/// Iterator over the ports of a node.
+/// Iterator over the nodes of a graph.
 #[derive(Clone)]
 pub struct Nodes<'a> {
     // We use portgraph's iterator, but filter out the copy nodes.
@@ -201,8 +201,8 @@ impl<'a> Iterator for NodeLinks<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(links) = &mut self.current_links {
-                if let Some(elt) = links.next() {
-                    return Some(elt);
+                if let Some(link) = links.next() {
+                    return Some(link);
                 }
                 self.current_links = None;
             }
@@ -390,7 +390,9 @@ impl<'a> FusedIterator for PortLinks<'a> {}
 pub struct Ports<'a> {
     /// The multiport graph.
     multigraph: &'a MultiPortGraph,
-    /// The current port.
+    /// The wrapped ports iterator.
+    ///
+    /// We filter out the copy nodes from here.
     ports: portgraph::portgraph::Ports<'a>,
 }
 


### PR DESCRIPTION
This is a work in progress for implementing implicit copies as a thin layer an top of a portgraph.

Switching the graph in a hugr for this should be almost frictionless, except `LinkError::AlreadyConnected` should not be thrown when connecting already-connected ports.
There's just some slight API changes when compared to portgraph, and some new methods needed to manipulate the subports.

Ideally this should be upstreamed to portgraph in the future.

Implementation progress:
- [x] Basic wrapper with automatic creation of copy nodes.
- Iterators:
  - [x] `Nodes`, `NodeSubports`, `Neighbours`, `PortLinks`
  - [x] `NodeConnections`
  - [x] `NodeLinks`
  - [x] `Ports`
- [x] `port_count` method
- [x] Node and port compacting
- [x] Drop copy nodes when `set_num_ports` deletes some ports
- [x] Unit tests