### PR TITLE
Rewrite Extension section for type info

### DIFF
--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -601,8 +601,10 @@ at runtime. In many cases this is desirable.
 
 #### Extension Implementation
 
-To strike a balance then, every resource provides a YAML declaration of its operations,
-where each specifies its type by one of two methods:
+To strike a balance then, every resource provides YAML that declares its opaque
+types and a number of named **OpDef**s (operation-definitions), which may be
+polymorphic in type. Each OpDef specifies one of two methods for how the type
+of individual operations is computed:
 
 1. A type scheme is included in the YAML, to be processed by a "type scheme interpreter"
    that is built into tools that process the HUGR.
@@ -610,11 +612,10 @@ where each specifies its type by one of two methods:
 2. The extension self-registers binary code (e.g. a Rust trait) providing a function
    `compute_signature` that computes the type.
 
-Each *operation-definition* (aka **OpFactory** ?? Or just **OpDef**??) has a name, and
-may declare named type parameters---if so then the individual operation nodes in a HUGR
-will provide for each a static-constant "type argument": a value that in many cases
-will be a type. These type arguments are processed by the type scheme interpreter or
-the `compute_signature` implementation.
+Each OpDef may declare named type parameters---if so then the individual operation nodes
+in a HUGR will provide for each a static-constant "type argument": a value that in many
+cases will be a type. These type arguments are processed by the type scheme interpreter
+or the `compute_signature` implementation to compute the type of that operation node.
 
 When serializing the node, we also serialize the type arguments; we can also serialize
 the resulting (computed) type with the operation, and this will be useful when the type
@@ -639,9 +640,9 @@ resources to provide semantics portable across tools.
    when a higher-performance (e.g. native HW) implementation is not available.
    Such a HUGR may itself require other resources.
 
-Whether a particular operation-definition provides binary code for `try_lower` is
-independent of whether it provides a binary `compute_signature`, but it will not
-generally be possible to provide a HUGR for a function whose type cannot be expressed
+Whether a particular OpDef provides binary code for `try_lower` is independent
+of whether it provides a binary `compute_signature`, but it will not generally
+be possible to provide a HUGR for a function whose type cannot be expressed
 in YAML.
 
 <!-- Should we preserve some of this language about downcasting?

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -624,14 +624,19 @@ to be passed through tools that do not understand what the operations *do*
 (that is, allowing new operations to be defined independently of any tool -
 so long as we do not need the tooling to understand them).
 
-In all cases the serialized representation is the same: the name of the definition (**"Op Factory"**??), a list of type arguments (see below), and optionally the type of the operation node that results. The three kinds of definition are:
+In all cases the serialized representation is the same: the name of the definition
+(**"Op Factory"**??), a list of type arguments (see below), and optionally the type
+of the operation node that results. The three kinds of definition are:
 
 1.  `Opdef`: where the type of the operation is defined by a function
     (aka type scheme) given in the declarative YAML format. The function
     may take type arguments also specified in YAML. The code that turns the
     actual type arguments provided, into the operation type, given the YAML
     description, is referred to in this doc as the "YAML interpreter" and is
-    expected to be shared across tools and resources. (Note: here we generally do not serialize the computed type, as the YAML definition is passed along with the HUGR. However of course we *could* do so for tools that lack YAML interpreters...)
+    expected to be shared across tools and resources. (Note: here we generally
+    do not serialize the computed type, as the YAML definition is passed along
+    with the HUGR. However of course we *could* do so for tools that lack YAML
+    interpreters...)
 
 2.  `CustomOp`: here the declarative YAML specifies the type arguments
     (these may include statically-known values e.g. U64), but does not
@@ -645,16 +650,23 @@ In all cases the serialized representation is the same: the name of the definiti
 3.  `native`: a special case of the previous where the type argument is
     a single `Opaque` value, provided as a serialized blob.
 
-Type arguments are given by a type language that is a distinct, simplified form of the [Type System](#type-system):
+Type arguments are given by a type language that is a distinct, simplified
+form of the [Type System](#type-system):
 ```
 TypeArgs ::= TypeArg (,TypeArgs)?
 TypeArg ::= Type | ClassicType | F64 | U64 | I64 | Opaque(name, ...) | List(TypeArg)
 ```
 <!--(`Type` and `ClassicType` here means the YAML declaration is literally "Type" or "ClassicType" but the argument will be one of those.)-->
 
-**Semantics** The *semantics* of any operation are necessarily specific to both operation *and* tool (e.g. compiler or runtime). However for each operation-definition resources (extension providers) *may* implement a different Rust Trait[^1] providing a function `try_lower` that takes the type arguments and a set of target resources and may return a subgraph/function-body-HUGR using only those target resources.
+**Semantics** The *semantics* of any operation are necessarily specific
+to both operation *and* tool (e.g. compiler or runtime). However for each
+operation-definition resources (extension providers) *may* implement a
+different Rust Trait[^1] providing a function `try_lower` that takes the
+type arguments and a set of target resources and may return a subgraph /
+function-body-HUGR using only those target resources.
 
-[^1]: Whether a particular operation-definition provides Rust code for `try_lower` is independent of whether it provides Rust code for `compute_type`.
+[^1]: Whether a particular operation-definition provides Rust code for
+`try_lower` is independent of whether it provides Rust code for `compute_type`.
 
 <!-- Should we preserve some of this language about downcasting?
 

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -604,43 +604,39 @@ at runtime. In many cases this is desirable.
 **Typing** To strike a balance then, we implement three kinds of operation/type
 definition in tooling that processes the HUGR. Note these mechanisms only
 deal with specifying the *type* of the operation, allowing such operations
-to be passed through tools that do not understand what the operations *do*
-(that is, allowing new operations to be defined independently of any tool -
-so long as we do not need the tooling to understand them).
+to be passed through tools that do not understand what the operations *do* -
+that is, these allow new operations to be defined independently of any tool,
+but do not provide any way for the tooling to treat them as anything other than a black box.
 
-In all cases the serialized representation is the same: the name of the definition
-(**"Op Factory"**??), a list of type arguments (see below), and optionally the type
-of the operation node that results. The three kinds of definition are:
+In all cases the operation type may depend upon type arguments that are also
+*declared* in the YAML - that is, the YAML declares the *parameters*, and
+individual nodes in a HUGR provide *arguments* i.e. statically-constant values
+for these parameters. (For many parameters, the corresponding argument is a type!)
+The serialized representation of a node is thus the name of the operation-definition
+(aka **"Op Factory"**??), the type arguments (a list, see below), and optionally
+the type of the operation node that results.
+
+The three kinds of operation-definition are:
 
 1.  `Opdef`: where the type of the operation is defined by a function
-    (aka type scheme) given in the declarative YAML format. The function
-    may take type arguments also specified in YAML. The code that turns the
-    actual type arguments provided, into the operation type, given the YAML
+    (aka type scheme) given in the declarative YAML format. The function that turns
+    the actual type arguments provided, into the operation type, given the YAML
     description, is referred to in this doc as the "YAML interpreter" and is
-    expected to be shared across tools and resources. (Note: here we generally
-    do not serialize the computed type, as the YAML definition is passed along
-    with the HUGR. However of course we *could* do so for tools that lack YAML
-    interpreters...)
+    expected to be shared across tools and resources. (Note there is generally
+    no need to serialize the computed type, as the YAML definition is passed along
+    with the HUGR.)
 
-2.  `CustomOp`: here the declarative YAML specifies the type arguments
-    (these may include statically-known values e.g. U64), but does not
-    specify how the operation type is computed from those. Instead the
-    resource/extension provider implements a Rust Trait providing a
-    function `compute_type` that takes the type arguments (for a particular
-    instance i.e. operation node) and returns the type. Here it is useful
-    to serialize the resulting (computed) type so the operation can be treated
-    opaquely by tools that do not have the extension's Rust code available.
+2.  `CustomOp`: here the declarative YAML specifies the type parameters
+    (for example, a Type and a U64), but does not specify how the operation type
+    is computed from those. Instead the resource/extension provider self-registers
+    binary code (e.g. a Rust Trait) providing a function `compute_signature` that
+    takes the type arguments from the operation node and returns the operation type.
+    Here it is useful to serialize the resulting (computed) type so the operation
+    can be treated opaquely by tools that have only the YAML definition of the extension.
 
 3.  `native`: a special case of the previous where the type argument is
-    a single `Opaque` value, provided as a serialized blob.
-
-Type arguments are given by a type language that is a distinct, simplified
-form of the [Type System](#type-system):
-```
-TypeArgs ::= TypeArg (,TypeArgs)?
-TypeArg ::= Type | ClassicType | F64 | U64 | I64 | Opaque(name, ...) | List(TypeArg)
-```
-<!--(`Type` and `ClassicType` here means the YAML declaration is literally "Type" or "ClassicType" but the argument will be one of those.)-->
+    a single `Opaque` value, provided as a serialized blob, given which the
+    `compute_signature` function returns a type.
 
 **Semantics** The *semantics* of any operation are necessarily specific
 to both operation *and* tool (e.g. compiler or runtime). However for each
@@ -650,7 +646,7 @@ type arguments and a set of target resources and may return a subgraph /
 function-body-HUGR using only those target resources.
 
 [^1]: Whether a particular operation-definition provides Rust code for
-`try_lower` is independent of whether it provides Rust code for `compute_type`.
+`try_lower` is independent of whether it provides Rust code for `compute_signature`.
 
 <!-- Should we preserve some of this language about downcasting?
 
@@ -698,23 +694,27 @@ resources:
   operations:
   - name: measure
     description: "measure a qubit"
-    inputs: [[null, Q]]  # Q is defined in Quantum resource
-    # the first element of each pair is an optional parameter name
-    outputs: [[null, Q], ["measured", B]]
+    type_scheme:
+      inputs: [[null, Q]]  # Q is defined in Quantum resource
+      # the first element of each pair is an optional parameter name
+      outputs: [[null, Q], ["measured", B]]
   - name: ZZPhase
     description: "Apply a parametric ZZPhase gate"
-    inputs: [[null, Q], [null, Q], ["angle", Angle]]
-    outputs: [[null, Q], [null, Q]]
+    type_scheme:
+      inputs: [[null, Q], [null, Q], ["angle", Angle]]
+      outputs: [[null, Q], [null, Q]]
     misc:
-      # extra data that may be used by some compiler passes and is passed to try_lower
+      # extra data that may be used by some compiler passes
+      # and is passed to try_lower and compute_signature
       equivalent: [0, 1]
       basis: [Z, Z]
   - name: SU2
     description: "One qubit unitary matrix"
-    inputs: [[null, Q]]
-    outputs: [[null, Q]]
-    args:
-      - matrix: Opaque(matrix3,F64) # Or do we specify sizes here? That requires dependent types?
+    type_scheme:
+      inputs: [[null, Q]]
+      outputs: [[null, Q]]
+    args: # These will be passed to the type-scheme interpreter, but ignored
+      - matrix: Opaque(complex_matrix,2,2)
   - name: MatMul
     description: "Multiply matrices of statically-known size"
     args:
@@ -724,20 +724,27 @@ resources:
     inputs: [["a", Array<i>(Array<j>(F64))], ["b", Array<j>(Array<k>(F64))]]
     outputs: [[null, Array<i>(Array<k>(F64))]]
   - name: ArrayConcat
-    description: "Must provide Rust code to compute signature from argument values"
-    args:
+    description: "Concatenate two arrays. Must provide a compute_signature implementation."
+    args: # These will be passed to compute_signature
       - t: Type  # Classic or Quantum
       - i: U64
       - j: U64
-    # inputs could be: Array<i>(U64), Array<j>(U64)
-    # outputs would be, in principle: Array<i+j>(U64)
+    # inputs could be: Array<i>(t), Array<j>(t)
+    # outputs would be, in principle: Array<i+j>(t)
     # However the YAML type-scheme interpreter does not support such addition,
-    # hence (the lack of inputs+outputs means) we must provide
-    # a Rust compute_type function instead
+    # hence (the lack of a type_scheme means) we must provide
+    # a Rust compute_signature function instead
   - name: EvenMoreAwkwardOp
     description: "Inputs and outputs computed from the parameter blob"
     args:
       - matrix: Opaque(MyType) # Passed in as a blob?
+```
+
+The declaration of the `args` uses a language that is a distinct, simplified
+form of the [Type System](#type-system) - writing terminals that appear in the YAML in quotes:
+```
+args ::= TypeParam (,TypeParam)*
+TypeParam ::= "Type" | "ClassicType" | "F64" | "U64" | "I64" | "Opaque"(name, ...) | "List"(TypeParam)
 ```
 
 Reading this format into Rust is made easy by `serde` and
@@ -746,18 +753,15 @@ Serialization section). It is also trivial to serialize these
 definitions in to the overall HUGR serialization format.
 
 Note the only required fields are `name` and `description`.
-`inputs` and `outputs` must either be both specified or both absent;
-if absent, Rust code for `compute_type` must be instead. The optional
-`misc` field is used for arbitrary YAML, which is read in as-is (into
-the `serde_yaml Value`
-struct). The data held here can be used by compiler passes which expect
-to deal with this operation (e.g. a pass can use the `basis` information
-to perform commutation). The optional `args` field can be used to
-specify the types of parameters to the operation - for example the
+`type_scheme` may be present (containing both `inputs` and `outputs`) but
+if absent, the extension must register code for `compute_signature` instead.
+The optional `misc` field is used for arbitrary YAML, which is read in as-is
+(into the `serde_yaml Value` struct). The data held here can be used by compiler
+passes which expect to deal with this operation (e.g. a pass can use the `basis`
+information to perform commutation). The optional `args` field can be used to
+specify the types of static+const arguments to the operation - for example the
 matrix needed to define an SU2 operation. If `args` are not specified
-then it is assumed empty. (An operation with neither `args` nor
-`inputs` nor `outputs` must provide a `compute_type` which is essentially
-constant as it will receive no parameters.)
+then it is assumed empty.
 
 ### Extensible metadata
 

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -606,11 +606,11 @@ and may provide (binary) code that computes signatures of operations, or use a d
 "type scheme interpreter" that processes a type scheme included in the YAML - this is
 expected to be built into most tools that process the HUGR and used across many resources.
 
-Each *operation-definition* (aka **OpFactory** ?? Or just **OpDef**??) has a name, and may declare named type
-parameters - if so then the individual operation nodes in a HUGR will provide static-constant
-"type arguments" (values) for these---in many cases these values will be types. It also
-identifies the function that will be used (for each operation/node of that definition) to
-compute the type - this may be built-in or self-registered, see below.
+Each *operation-definition* (aka **OpFactory** ?? Or just **OpDef**??) has a name, and
+may declare named type parameters---if so then the individual operation nodes in a HUGR
+will provide for each a static-constant "type argument": a value that in many cases
+ will be a type. The operation-definition also identifies the function that will be used
+compute the type of each operation; this may be built-in or self-registered, see below.
 
 When serializing the node, we also serialize the type arguments; we can also serialize
 the resulting (computed) type with the operation, and this will be useful when the OpDef
@@ -619,20 +619,22 @@ opaquely by tools that do not have the binary code available. (The YAML definiti
 be sent with the HUGR).
 
 This mechanism allows new operations to be passed through tools that do not understand
-what the operations *do* - that is, new operations may be be defined independently of
+what the operations *do*---that is, new operations may be be defined independently of
 any tool, but without providing any way for the tooling to treat them as anything other
 than a black box. The *semantics* of any operation are necessarily specific to both
 operation *and* tool (e.g. compiler or runtime). However we also provide two ways for
 resources to provide semantics portable across tools.
 
 1. They *may* provide binary code (e.g. a Rust trait) implementing a function `try_lower`
-   that takes the type arguments and a set of target resources and may return a subgraph /
-   function-body-HUGR using only those target resources.
+   that takes the type arguments and a set of target resources and may fallibly return
+   a subgraph or function-body-HUGR using only those target resources.
 
-2. They may provide a HUGR, that declares functions implementing those operations.
-   Note this will only be possible for operations with sufficiently simple type (schemes),
-   and is considered a "fallback" for use when a higher-performance (e.g. native HW)
-   implementation is not available. Such a HUGR may itself require other resources.
+2. They may provide a HUGR, that declares functions implementing those operations. This
+   is a simple case of the above (where the binary code is a constant function) but
+   easy to pass between tools. However note this will only be possible for operations
+   with sufficiently simple type (schemes), and is considered a "fallback" for use
+   when a higher-performance (e.g. native HW) implementation is not available.
+   Such a HUGR may itself require other resources.
 
 Whether a particular operation-definition provides Rust code for `try_lower` is
 independent of how its type is computed, but it will not generally be possible to


### PR DESCRIPTION
This is intended to enact what we've discussed a couple of times about extensions, unifying some concepts. It may need more work on phrasing and some details, e.g. I haven't learnt about `serde` yet, and there's that bit about downcasting...

Also there is some uncertainty about terminology. I've been using "operation-definition" for what we at one point called "OpFactory", but I've also removed the previous term "OpDef" (along with CustomOp - I think these terms just live in the code) so it is tempting to use that. Thoughts?

I've deleted a fair bit of the old text that seemed to be talking about implementation, I'm happy to negotiate which bits of that to bring back and how.

* I removed operations outside resources, as we think these should be done by writing them as `call`s to functions in other HUGRs
* Also removed the `resource_reqs` as they seemed to be superceded by the existing/previous description of "a fallible interface for returning an equivalent program made of operations from some provided set of `Resources`."
* I'm not sure about type arguments to Opaque types
* WordWrap...is there a policy here?