### PR TITLE
[fix] Display each port's type, rather than whole signature in dot

### DIFF
--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -132,9 +132,9 @@ impl Hugr {
                 let optype = self.op_types.get(src);
                 let mut label = String::new();
                 let offset = self.graph.port_offset(p).unwrap();
-                let type_string = match optype.port_kind(offset).unwrap() {
-                    EdgeKind::Const(ty) => format!("{}", ty),
-                    EdgeKind::Value(ty) => format!("{}", ty),
+                let type_string = match optype.port_kind(offset) {
+                    Some(EdgeKind::Const(ty)) => format!("{}", ty),
+                    Some(EdgeKind::Value(ty)) => format!("{}", ty),
                     _ => String::new(),
                 };
                 encode_text_to_string(type_string, &mut label);

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -131,7 +131,13 @@ impl Hugr {
 
                 let optype = self.op_types.get(src);
                 let mut label = String::new();
-                encode_text_to_string(&format!("{}", optype.signature()), &mut label);
+                let offset = self.graph.port_offset(p).unwrap();
+                let type_string = match optype.port_kind(offset).unwrap() {
+                    EdgeKind::Const(ty) => format!("{}", ty),
+                    EdgeKind::Value(ty) => format!("{}", ty),
+                    _ => String::new(),
+                };
+                encode_text_to_string(type_string, &mut label);
 
                 (label, style)
             },


### PR DESCRIPTION
I reproduced @cqc-alec 's circuit (minus a Hadamard gate) and here's what it looks like now:

![graphviz](https://github.com/CQCL-DEV/hugr/assets/5727256/80939e52-d997-4b30-ac03-ea39592893f5)
