### PR TITLE
Implement `SimpleReplace`

### DIFF
--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -1072,12 +1072,12 @@ There are the following primitive operations.
 This method is used for simple replacement of dataflow subgraphs consisting of
 leaf nodes.
 
-Given a set $S$ of nodes in a hugr $H$, let:
+Given a set $X$ of nodes in a hugr $G$, let:
 
-  - $\textrm{inp}_H(S)$ be the set of input ports of nodes in $S$ whose source
-    is in $H \setminus S$;
-  - $\textrm{out}_H(S)$ be the set of input ports of nodes in $H \setminus S$
-    whose source is in $S$.
+  - $\textrm{inp}_G(X)$ be the set of input ports of nodes in $X$ whose source
+    is in $G \setminus X$;
+  - $\textrm{out}_G(X)$ be the set of input ports of nodes in $G \setminus X$
+    whose source is in $X$.
 
 Notation: given an input port $p$, let $p^-$ be its unique predecessor port.
 

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -1079,6 +1079,8 @@ Given a set $S$ of nodes in a hugr $H$, let:
   - $\textrm{out}_H(S)$ be the set of input ports of nodes in $H \setminus S$
     whose source is in $S$.
 
+Notation: given an input port $p$, let $p^-$ be its unique predecessor port.
+
 The method takes as input:
 
   - the ID of a DFG node $P$ in $\Gamma$;
@@ -1090,16 +1092,20 @@ The method takes as input:
   - a map $\nu\_\textrm{inp}: \textrm{inp}\_H(T \setminus \\{\texttt{Input}\\}) \to \textrm{inp}\_{\Gamma}(S)$;
   - a map $\nu_\textrm{out}: \textrm{out}_{\Gamma}(S) \to \textrm{out}_H(T \setminus \\{\texttt{Output}\\})$.
   
-The new hugr is then derived by:
+The new hugr is then derived as follows:
   
-  - adding copies of all children of $R$, except for Input and Output nodes, to
-    $\Gamma$, and make them all children of $P$;
-  - adding edges between all newly added nodes matching those in $R$;
-  - for each $p \in \textrm{inp}\_H(T)$, adding an edge from the predecessor of
-    $\nu\_\textrm{inp}(p)$ to the new copy of $p$;
-  - for each $p \in \textrm{out}\_{\Gamma}(S)$, adding an edge from the new copy
-    of the predecessor of $\nu\_\textrm{out}(p)$ to $p$.
-  - removing all nodes in $S$ and edges between them.
+  1. Make a copy in $\Gamma$ of all children of $R$, excluding Input and Output,
+     and all edges between them. Make all the newly added nodes children of $P$.
+     Notation: if $p$ is a port of a node in $R$, write $p^*$ for the copy of
+     the port in $\Gamma$.
+  2. For each $(q, p = \nu_\textrm{inp}(q))$ such that $q \notin \texttt{Output}$,
+     add an edge from $p^-$ to $q^*$.
+  3. For each $(p, q = \nu_\textrm{out}(p))$ such that $q^- \notin \texttt{Input}$,
+     add an edge from $(q^-)^*$ to $p$.
+  4. For each $p_1, q, p_0$ such that
+     $q = \nu_\textrm{out}(p_1), p_0 = \nu_\textrm{inp}(q)$, add an edge from
+     $p_0^-$ to $p_1$. (Sanity check: $q^-$ must be an Input node in this case.)
+  5. Remove all nodes in $S$ and edges between them.
 
 ###### `Replace`
 

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -1063,7 +1063,45 @@ in {a}\* (i.e. there is no hierarchy relation between them).
 
 There are the following primitive operations.
 
-##### Replacement method
+##### Replacement methods
+
+###### `SimpleReplace`
+
+This method is used for simple replacement of dataflow subgraphs consisting of
+leaf nodes.
+
+Given a DFG-convex set $S$ of IDs of leaf nodes in a DSG, let:
+
+  - $\textrm{inp}(S)$ be the set of input ports of nodes in $S$ whose source is
+    in $\Gamma \setminus S$;
+  - $\textrm{out}(S)$ be the set of input ports of nodes in $\Gamma \setminus S$
+    whose source is in $S$.
+
+Given a DFG node $P$, let:
+
+  - $\textrm{inp}(P)$ be the set of successor ports of edges from output ports
+    of the Input node of $P$;
+  - $\textrm{out}(P)$ be the set of input ports of the Output node of $P$.
+
+The method takes as input:
+
+  - the ID of a DFG node $P$ in $\Gamma$;
+  - a DFG-convex set $S$ of IDs of leaf nodes that are children of $P$;
+  - a "modular hugr" with DFG root $R$ and only leaf nodes as children;
+  - a map $\nu_\textrm{inp}: \textrm{inp}(S) \to \textrm{inp}(R)$;
+  - a map $\nu_\textrm{out}: \textrm{out}(R) \to \textrm{out}(S)$.
+  
+The new hugr is then derived by:
+  
+  - adding all children of $R$, and all edges between them, to $\Gamma$;
+  - making $P$ the parent of all the newly added nodes except for the Input and
+    Output nodes;
+  - for each $p \in \textrm{inp}(S)$, adding an edge from the predecessor of $p$
+    to $\nu_\textrm{inp}(p)$;
+  - for each $p \in \textrm{out}(R)$, adding an edge from the predecessor of $p$
+    to $\nu_\textrm{out}(p)$
+  - removing all nodes in $S$ and edges between them;
+  - removing the Input and Output nodes of $R$ and all edges from them.
 
 ###### `Replace`
 

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -1086,7 +1086,8 @@ Given a DFG node $P$, let:
 The method takes as input:
 
   - the ID of a DFG node $P$ in $\Gamma$;
-  - a DFG-convex set $S$ of IDs of leaf nodes that are children of $P$;
+  - a DFG-convex set $S$ of IDs of leaf nodes that are children of $P$ (not
+    including the Input and Output nodes);
   - a "modular hugr" with DFG root $R$ and only leaf nodes as children;
   - a map $\nu_\textrm{inp}: \textrm{inp}(R) \to \textrm{inp}(S)$;
   - a map $\nu_\textrm{out}: \textrm{out}(S) \to \textrm{out}(R)$.

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -1088,7 +1088,7 @@ The method takes as input:
   - the ID of a DFG node $P$ in $\Gamma$;
   - a DFG-convex set $S$ of IDs of leaf nodes that are children of $P$ (not
     including the Input and Output nodes);
-  - a "modular hugr" with DFG root $R$ and only leaf nodes as children;
+  - a hugr whose root is a DFG node $R$ with only leaf nodes as children;
   - a map $\nu_\textrm{inp}: \textrm{inp}(R) \to \textrm{inp}(S)$;
   - a map $\nu_\textrm{out}: \textrm{out}(S) \to \textrm{out}(R)$.
   

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -1088,18 +1088,18 @@ The method takes as input:
   - the ID of a DFG node $P$ in $\Gamma$;
   - a DFG-convex set $S$ of IDs of leaf nodes that are children of $P$;
   - a "modular hugr" with DFG root $R$ and only leaf nodes as children;
-  - a map $\nu_\textrm{inp}: \textrm{inp}(S) \to \textrm{inp}(R)$;
-  - a map $\nu_\textrm{out}: \textrm{out}(R) \to \textrm{out}(S)$.
+  - a map $\nu_\textrm{inp}: \textrm{inp}(R) \to \textrm{inp}(S)$;
+  - a map $\nu_\textrm{out}: \textrm{out}(S) \to \textrm{out}(R)$.
   
 The new hugr is then derived by:
   
   - adding all children of $R$, and all edges between them, to $\Gamma$;
   - making $P$ the parent of all the newly added nodes except for the Input and
     Output nodes;
-  - for each $p \in \textrm{inp}(S)$, adding an edge from the predecessor of $p$
-    to $\nu_\textrm{inp}(p)$;
-  - for each $p \in \textrm{out}(R)$, adding an edge from the predecessor of $p$
-    to $\nu_\textrm{out}(p)$
+  - for each $p \in \textrm{inp}(R)$, adding an edge from the predecessor of
+    $\nu_\textrm{inp}(p)$ to $p$;
+  - for each $p \in \textrm{out}(S)$, adding an edge from the predecessor of
+    $\nu_\textrm{out}(p)$ to $p$.
   - removing all nodes in $S$ and edges between them;
   - removing the Input and Output nodes of $R$ and all edges from them.
 

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -113,8 +113,7 @@ impl Hugr {
         let self_input_node_index: NodeIndex = self.hierarchy.first(r.p.index).unwrap();
         let n_output_node_index: NodeIndex = n_indices[n_sz - 1];
         for n_index in n_non_io_indices {
-            let n_node = Node { index: *n_index };
-            let op: &OpType = r.n.get_optype(n_node);
+            let op: &OpType = r.n.get_optype((*n_index).into());
             let sig = op.signature();
             if !sig.const_input.is_empty() {
                 return Err(SimpleReplacementError::InvalidReplacementNode());

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -83,7 +83,7 @@ impl Hugr {
         r: SimpleReplacement,
     ) -> Result<(), SimpleReplacementError> {
         // 1. Check the parent node exists.
-        if self.nodes().all(|node| node != r.p) || self.get_optype(r.p).tag() != OpTag::Dfg {
+        if !self.graph.contains_node(r.p.index) || self.get_optype(r.p).tag() != OpTag::Dfg {
             return Err(SimpleReplacementError::InvalidParentNode());
         }
         // 2. Check that all the to-be-removed nodes are children of it and are leaves.

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -180,7 +180,7 @@ impl Hugr {
                     .port_index(rem_inp_node.index, rem_inp_port.offset)
                     .unwrap();
                 let rem_inp_predecessor_port_index =
-                    self.graph.port_link(rem_inp_port_index).unwrap();
+                    self.graph.port_link(rem_inp_port_index).unwrap().port();
                 let new_inp_port_index = self
                     .graph
                     .port_index(*new_inp_node_index, rep_inp_port.offset)
@@ -242,7 +242,7 @@ impl Hugr {
                     .port_index(rem_inp_node.index, rem_inp_port.offset)
                     .unwrap();
                 let rem_inp_predecessor_port_index =
-                    self.graph.port_link(rem_inp_port_index).unwrap();
+                    self.graph.port_link(rem_inp_port_index).unwrap().port();
                 let rem_out_port_index = self
                     .graph
                     .port_index(rem_out_node.index, rem_out_port.offset)

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -99,7 +99,7 @@ impl Hugr {
         }
         // 3. Do the replacement.
         // 3.1. Add copies of all replacement nodes to self. Exclude Input/Output nodes.
-        // Create map from old NodeIndex (in r.n) to new NodeIndex (in self).
+        // Create map from old NodeIndex (in r.replacement) to new NodeIndex (in self).
         let mut index_map: HashMap<NodeIndex, NodeIndex> = HashMap::new();
         let replacement_nodes = r
             .replacement
@@ -192,7 +192,7 @@ impl Hugr {
                 .link_ports(rem_inp_predecessor_port_index, new_inp_port_index)
                 .ok();
         }
-        // 3.4. For each p in out(r.s), add an edge from (new copy of) the predecessor of
+        // 3.4. For each p in out(r.removal), add an edge from (new copy of) the predecessor of
         // r.nu_out[p] to p.
         for ((rem_out_node, rem_out_port), rep_out_port) in r.nu_out {
             let rem_out_port_index = self
@@ -226,7 +226,7 @@ impl Hugr {
                 .link_ports(new_out_port_index, rem_out_port_index)
                 .ok();
         }
-        // 3.5. Remove all nodes in r.s and edges between them.
+        // 3.5. Remove all nodes in r.removal and edges between them.
         for node in &r.removal {
             self.graph.remove_node(node.index);
             self.hierarchy.remove(node.index);

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -109,8 +109,10 @@ impl Hugr {
             .children(r.replacement.root().index)
             .map_into::<Node>()
             .collect::<Vec<Node>>();
-        let replacement_sz = replacement_nodes.len(); // number of replacement nodes including Input and Output
-        let replacement_inner_nodes = &replacement_nodes[1..replacement_sz - 1]; // omit Input and Output
+        // number of replacement nodes including Input and Output:
+        let replacement_sz = replacement_nodes.len();
+        // slice of nodes omitting Input and Output:
+        let replacement_inner_nodes = &replacement_nodes[1..replacement_sz - 1];
         for &node in replacement_inner_nodes {
             // 3.1.1. Check there are no const inputs.
             if !r
@@ -173,7 +175,8 @@ impl Hugr {
                 }
             }
         }
-        // 3.3. For each p in inp(replacement), add an edge from the predecessor of r.nu_inp[p] to (new copy of) p.
+        // 3.3. For each p in inp(replacement), add an edge from the predecessor of r.nu_inp[p] to
+        // (new copy of) p.
         for ((rep_inp_node, rep_inp_port), (rem_inp_node, rem_inp_port)) in r.nu_inp {
             let new_inp_node_index = index_map.get(&rep_inp_node.index).unwrap();
             // add edge from predecessor of (s_inp_node, s_inp_port) to (new_inp_node, n_inp_port)
@@ -191,7 +194,8 @@ impl Hugr {
                 .link_ports(rem_inp_predecessor_port_index, new_inp_port_index)
                 .ok();
         }
-        // 3.4. For each p in out(r.s), add an edge from (new copy of) the predecessor of r.nu_out[p] to p.
+        // 3.4. For each p in out(r.s), add an edge from (new copy of) the predecessor of
+        // r.nu_out[p] to p.
         for ((rem_out_node, rem_out_port), rep_out_port) in r.nu_out {
             let rem_out_port_index = self
                 .graph

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -84,10 +84,8 @@ impl Hugr {
         &mut self,
         r: SimpleReplacement,
     ) -> Result<(), SimpleReplacementError> {
-        // 1. Check the parent node exists.
-        if !self.graph.contains_node(r.region.index)
-            || self.get_optype(r.region).tag() != OpTag::Dfg
-        {
+        // 1. Check the parent node exists and is a DFG node.
+        if self.get_optype(r.region).tag() != OpTag::Dfg {
             return Err(SimpleReplacementError::InvalidParentNode());
         }
         // 2. Check that all the to-be-removed nodes are children of it and are leaves.

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -86,8 +86,7 @@ impl Hugr {
         }
         // 2. Check that all the to-be-removed nodes are children of it and are leaves.
         for node in &r.removal {
-            if self.hierarchy.is_root(node.index)
-                || self.hierarchy.parent(node.index).unwrap() != r.parent.index
+            if self.hierarchy.parent(node.index) != Some(r.parent.index)
                 || self.hierarchy.has_children(node.index)
             {
                 return Err(SimpleReplacementError::InvalidRemovedNode());

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -110,14 +110,24 @@ impl Hugr {
                 .collect::<Vec<NodeIndex>>();
         let n_sz = n_indices.len(); // number of replacement nodes including Input and Output
         let n_non_io_indices = &n_indices[1..n_sz - 1]; // omit Input and Output
+        for n_index in n_non_io_indices {
+            // 3.1.1. Check there are no const inputs.
+            if !r
+                .n
+                .get_optype((*n_index).into())
+                .signature()
+                .const_input
+                .is_empty()
+            {
+                return Err(SimpleReplacementError::InvalidReplacementNode());
+            }
+        }
         let self_input_node_index: NodeIndex = self.hierarchy.first(r.p.index).unwrap();
         let n_output_node_index: NodeIndex = n_indices[n_sz - 1];
         for n_index in n_non_io_indices {
+            // 3.1.2. Add the nodes.
             let op: &OpType = r.n.get_optype((*n_index).into());
             let sig = op.signature();
-            if !sig.const_input.is_empty() {
-                return Err(SimpleReplacementError::InvalidReplacementNode());
-            }
             let new_node_index = self.graph.add_node(sig.input.len(), sig.output.len());
             self.op_types[new_node_index] = op.clone();
             // Make r.p the parent

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -131,7 +131,7 @@ impl Hugr {
             let sig = op.signature();
             let new_node_index = self.graph.add_node(sig.input.len(), sig.output.len());
             self.op_types[new_node_index] = op.clone();
-            // Make r.p the parent
+            // Make r.region the parent
             self.hierarchy
                 .insert_after(new_node_index, self_input_node_index)
                 .ok();

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -6,16 +6,20 @@ pub mod view;
 pub mod serialize;
 pub mod validate;
 
+use std::collections::HashMap;
+
 use derive_more::From;
 pub use hugrmut::HugrMut;
 pub use validate::ValidationError;
 
 use portgraph::dot::{hier_graph_dot_string_with, DotEdgeStyle};
-use portgraph::{Hierarchy, PortGraph, UnmanagedDenseMap};
+use portgraph::{Hierarchy, NodeIndex, PortGraph, UnmanagedDenseMap};
 use thiserror::Error;
 
 pub use self::view::HugrView;
+use crate::ops::tag::OpTag;
 use crate::ops::{ModuleOp, OpType};
+use crate::replacement::{SimpleReplacement, SimpleReplacementError};
 use crate::rewrite::{Rewrite, RewriteError};
 use crate::types::EdgeKind;
 
@@ -71,6 +75,127 @@ impl Hugr {
     /// Returns an immutable view over the graph.
     pub fn view(&self) {
         unimplemented!()
+    }
+
+    /// Apply a simple replacement operation to the HUGR.
+    pub fn apply_simple_replacement(
+        &mut self,
+        r: SimpleReplacement,
+    ) -> Result<(), SimpleReplacementError> {
+        // 1. Check the parent node exists.
+        if self.nodes().all(|node| node != r.p) || self.get_optype(r.p).tag() != OpTag::Dfg {
+            return Err(SimpleReplacementError::InvalidParentNode());
+        }
+        // 2. Check that all the to-be-removed nodes are children of it and are leaves.
+        for node in &r.s {
+            if self.hierarchy.is_root(node.index)
+                || self.hierarchy.parent(node.index).unwrap() != r.p.index
+                || self.hierarchy.has_children(node.index)
+            {
+                return Err(SimpleReplacementError::InvalidRemovedNode());
+            }
+        }
+        // 3. Do the replacement.
+        // First locate the DFG in r.n. TODO this won't be necessary when we have DFG-rooted HUGRs.
+        let n_dfg_node =
+            r.n.nodes()
+                .find(|node: &Node| r.n.get_optype(*node).tag() == OpTag::Dfg)
+                .unwrap();
+        // 3.1. Add copies of all children of n_dfg_node to self. Exclude Input/Output nodes.
+        // Create map from old NodeIndex (in r.n) to new NodeIndex (in self).
+        let mut index_map: HashMap<NodeIndex, NodeIndex> = HashMap::new();
+        let n_indices =
+            r.n.hierarchy
+                .children(n_dfg_node.index)
+                .collect::<Vec<NodeIndex>>();
+        let n_sz = n_indices.len(); // number of replacement nodes including Input and Output
+        let n_non_io_indices = &n_indices[1..n_sz - 1]; // omit Input and Output
+        let self_input_node_index: NodeIndex = self.hierarchy.first(r.p.index).unwrap();
+        let n_output_node_index: NodeIndex = n_indices[n_sz - 1];
+        for n_index in n_non_io_indices {
+            let n_node = Node { index: *n_index };
+            let op: &OpType = r.n.get_optype(n_node);
+            let sig = op.signature();
+            if !sig.const_input.is_empty() {
+                return Err(SimpleReplacementError::InvalidReplacementNode());
+            }
+            let new_node_index = self.graph.add_node(sig.input.len(), sig.output.len());
+            self.op_types[new_node_index] = op.clone();
+            // Make r.p the parent
+            self.hierarchy
+                .insert_after(new_node_index, self_input_node_index)
+                .ok();
+            index_map.insert(*n_index, new_node_index);
+        }
+        // 3.2. Add edges between all newly added nodes matching those in n_dfg_node.
+        for n_index in n_non_io_indices {
+            let n_node = Node { index: *n_index };
+            let new_node_index = index_map.get(n_index).unwrap();
+            for n_node_succ in r.n.output_neighbours(n_node) {
+                if r.n.get_optype(n_node_succ).tag() != OpTag::Output {
+                    let new_node_succ_index = index_map.get(&n_node_succ.index).unwrap();
+                    for connection in r.n.graph.get_connections(*n_index, n_node_succ.index) {
+                        let src_offset = r.n.graph.port_offset(connection.0).unwrap().index();
+                        let tgt_offset = r.n.graph.port_offset(connection.1).unwrap().index();
+                        self.graph
+                            .link_nodes(
+                                *new_node_index,
+                                src_offset,
+                                *new_node_succ_index,
+                                tgt_offset,
+                            )
+                            .ok();
+                    }
+                }
+            }
+        }
+        // 3.3. For each p in inp(n_dfg_node), add an edge from the predecessor of r.nu_inp[p] to (new copy of) p.
+        for ((n_inp_node, n_inp_port), (s_inp_node, s_inp_port)) in r.nu_inp {
+            let new_inp_node_index = index_map.get(&n_inp_node.index).unwrap();
+            // add edge from predecessor of (s_inp_node, s_inp_port) to (new_inp_node, n_inp_port)
+            let s_inp_portindex = self
+                .graph
+                .port_index(s_inp_node.index, s_inp_port.offset)
+                .unwrap();
+            let s_preinp_portindex = self.graph.port_link(s_inp_portindex).unwrap();
+            let new_inp_portindex = self
+                .graph
+                .port_index(*new_inp_node_index, n_inp_port.offset)
+                .unwrap();
+            self.graph.unlink_port(s_preinp_portindex);
+            self.graph
+                .link_ports(s_preinp_portindex, new_inp_portindex)
+                .ok();
+        }
+        // 3.4. For each p in out(r.s), add an edge from (new copy of) the predecessor of r.nu_out[p] to p.
+        for ((s_exit_node, s_exit_port), n_out_port) in r.nu_out {
+            let s_exit_portindex = self
+                .graph
+                .port_index(s_exit_node.index, s_exit_port.offset)
+                .unwrap();
+            let n_out_portindex =
+                r.n.graph
+                    .port_index(n_output_node_index, n_out_port.offset)
+                    .unwrap();
+            let n_preexit_portindex = r.n.graph.port_link(n_out_portindex).unwrap();
+            let n_preexit_nodeindex = r.n.graph.port_node(n_preexit_portindex).unwrap();
+            let n_preexit_portoffset = r.n.graph.port_offset(n_preexit_portindex).unwrap();
+            let new_out_nodeindex = index_map.get(&n_preexit_nodeindex).unwrap();
+            let new_out_portindex = self
+                .graph
+                .port_index(*new_out_nodeindex, n_preexit_portoffset)
+                .unwrap();
+            self.graph.unlink_port(s_exit_portindex);
+            self.graph
+                .link_ports(new_out_portindex, s_exit_portindex)
+                .ok();
+        }
+        // 3.5. Remove all nodes in r.s and edges between them.
+        for node in &r.s {
+            self.graph.remove_node(node.index);
+            self.hierarchy.remove(node.index);
+        }
+        Ok(())
     }
 
     /// Applies a rewrite to the graph.

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -98,7 +98,7 @@ impl Hugr {
             }
         }
         // 3. Do the replacement.
-        // 3.1. Add copies of all replacement nodes to self. Exclude Input/Output nodes.
+        // 3.1. Add copies of all replacement nodes and edges to self. Exclude Input/Output nodes.
         // Create map from old NodeIndex (in r.replacement) to new NodeIndex (in self).
         let mut index_map: HashMap<NodeIndex, NodeIndex> = HashMap::new();
         let replacement_nodes = r
@@ -112,7 +112,7 @@ impl Hugr {
         // slice of nodes omitting Input and Output:
         let replacement_inner_nodes = &replacement_nodes[1..replacement_sz - 1];
         for &node in replacement_inner_nodes {
-            // 3.1.1. Check there are no const inputs.
+            // Check there are no const inputs.
             if !r
                 .replacement
                 .get_optype(node)
@@ -126,7 +126,7 @@ impl Hugr {
         let self_input_node_index = self.hierarchy.first(r.region.index).unwrap();
         let replacement_output_node = replacement_nodes[replacement_sz - 1];
         for &node in replacement_inner_nodes {
-            // 3.1.2. Add the nodes.
+            // Add the nodes.
             let op: &OpType = r.replacement.get_optype(node);
             let sig = op.signature();
             let new_node_index = self.graph.add_node(sig.input.len(), sig.output.len());
@@ -137,7 +137,7 @@ impl Hugr {
                 .ok();
             index_map.insert(node.index, new_node_index);
         }
-        // 3.2. Add edges between all newly added nodes matching those in replacement.
+        // Add edges between all newly added nodes matching those in replacement.
         // TODO This will probably change when implicit copies are implemented.
         for &node in replacement_inner_nodes {
             let new_node_index = index_map.get(&node.index).unwrap();
@@ -173,28 +173,31 @@ impl Hugr {
                 }
             }
         }
-        // 3.3. For each p in inp(replacement), add an edge from the predecessor of r.nu_inp[p] to
-        // (new copy of) p.
-        for ((rep_inp_node, rep_inp_port), (rem_inp_node, rem_inp_port)) in r.nu_inp {
-            let new_inp_node_index = index_map.get(&rep_inp_node.index).unwrap();
-            // add edge from predecessor of (s_inp_node, s_inp_port) to (new_inp_node, n_inp_port)
-            let rem_inp_port_index = self
-                .graph
-                .port_index(rem_inp_node.index, rem_inp_port.offset)
-                .unwrap();
-            let rem_inp_predecessor_port_index = self.graph.port_link(rem_inp_port_index).unwrap();
-            let new_inp_port_index = self
-                .graph
-                .port_index(*new_inp_node_index, rep_inp_port.offset)
-                .unwrap();
-            self.graph.unlink_port(rem_inp_predecessor_port_index);
-            self.graph
-                .link_ports(rem_inp_predecessor_port_index, new_inp_port_index)
-                .ok();
+        // 3.2. For each p = r.nu_inp[q] such that q is not an Output port, add an edge from the
+        // predecessor of p to (the new copy of) q.
+        for ((rep_inp_node, rep_inp_port), (rem_inp_node, rem_inp_port)) in &r.nu_inp {
+            if r.replacement.get_optype(*rep_inp_node).tag() != OpTag::Output {
+                let new_inp_node_index = index_map.get(&rep_inp_node.index).unwrap();
+                // add edge from predecessor of (s_inp_node, s_inp_port) to (new_inp_node, n_inp_port)
+                let rem_inp_port_index = self
+                    .graph
+                    .port_index(rem_inp_node.index, rem_inp_port.offset)
+                    .unwrap();
+                let rem_inp_predecessor_port_index =
+                    self.graph.port_link(rem_inp_port_index).unwrap();
+                let new_inp_port_index = self
+                    .graph
+                    .port_index(*new_inp_node_index, rep_inp_port.offset)
+                    .unwrap();
+                self.graph.unlink_port(rem_inp_predecessor_port_index);
+                self.graph
+                    .link_ports(rem_inp_predecessor_port_index, new_inp_port_index)
+                    .ok();
+            }
         }
-        // 3.4. For each p in out(r.removal), add an edge from (new copy of) the predecessor of
-        // r.nu_out[p] to p.
-        for ((rem_out_node, rem_out_port), rep_out_port) in r.nu_out {
+        // 3.3. For each q = r.nu_out[p] such that the predecessor of q is not an Input port, add an
+        // edge from (the new copy of) the predecessor of q to p.
+        for ((rem_out_node, rem_out_port), rep_out_port) in &r.nu_out {
             let rem_out_port_index = self
                 .graph
                 .port_index(rem_out_node.index, rem_out_port.offset)
@@ -211,20 +214,49 @@ impl Hugr {
                 .graph
                 .port_node(rep_out_predecessor_port_index)
                 .unwrap();
-            let rep_out_predecessor_port_offset = r
-                .replacement
-                .graph
-                .port_offset(rep_out_predecessor_port_index)
-                .unwrap();
-            let new_out_node_index = index_map.get(&rep_out_predecessor_node_index).unwrap();
-            let new_out_port_index = self
-                .graph
-                .port_index(*new_out_node_index, rep_out_predecessor_port_offset)
-                .unwrap();
-            self.graph.unlink_port(rem_out_port_index);
-            self.graph
-                .link_ports(new_out_port_index, rem_out_port_index)
-                .ok();
+            if r.replacement
+                .get_optype(rep_out_predecessor_node_index.into())
+                .tag()
+                != OpTag::Input
+            {
+                let rep_out_predecessor_port_offset = r
+                    .replacement
+                    .graph
+                    .port_offset(rep_out_predecessor_port_index)
+                    .unwrap();
+                let new_out_node_index = index_map.get(&rep_out_predecessor_node_index).unwrap();
+                let new_out_port_index = self
+                    .graph
+                    .port_index(*new_out_node_index, rep_out_predecessor_port_offset)
+                    .unwrap();
+                self.graph.unlink_port(rem_out_port_index);
+                self.graph
+                    .link_ports(new_out_port_index, rem_out_port_index)
+                    .ok();
+            }
+        }
+        // 3.4. For each q = r.nu_out[p1], p0 = r.nu_inp[q], add an edge from the predecessor of p0
+        // to p1.
+        for ((rem_out_node, rem_out_port), &rep_out_port) in &r.nu_out {
+            let rem_inp_nodeport = r.nu_inp.get(&(replacement_output_node, rep_out_port));
+            if let Some((rem_inp_node, rem_inp_port)) = rem_inp_nodeport {
+                // add edge from predecessor of (rem_inp_node, rem_inp_port) to (rem_out_node, rem_out_port):
+                let rem_inp_port_index = self
+                    .graph
+                    .port_index(rem_inp_node.index, rem_inp_port.offset)
+                    .unwrap();
+                let rem_inp_predecessor_port_index =
+                    self.graph.port_link(rem_inp_port_index).unwrap();
+                let rem_out_port_index = self
+                    .graph
+                    .port_index(rem_out_node.index, rem_out_port.offset)
+                    .unwrap();
+                self.graph.unlink_port(rem_inp_port_index);
+                self.graph.unlink_port(rem_out_port_index);
+                self.graph
+                    .link_ports(rem_inp_predecessor_port_index, rem_out_port_index)
+                    .ok();
+            }
         }
         // 3.5. Remove all nodes in r.removal and edges between them.
         for node in &r.removal {

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -81,13 +81,13 @@ impl Hugr {
         r: SimpleReplacement,
     ) -> Result<(), SimpleReplacementError> {
         // 1. Check the parent node exists and is a DFG node.
-        if self.get_optype(r.region).tag() != OpTag::Dfg {
+        if self.get_optype(r.parent).tag() != OpTag::Dfg {
             return Err(SimpleReplacementError::InvalidParentNode());
         }
         // 2. Check that all the to-be-removed nodes are children of it and are leaves.
         for node in &r.removal {
             if self.hierarchy.is_root(node.index)
-                || self.hierarchy.parent(node.index).unwrap() != r.region.index
+                || self.hierarchy.parent(node.index).unwrap() != r.parent.index
                 || self.hierarchy.has_children(node.index)
             {
                 return Err(SimpleReplacementError::InvalidRemovedNode());
@@ -119,7 +119,7 @@ impl Hugr {
                 return Err(SimpleReplacementError::InvalidReplacementNode());
             }
         }
-        let self_input_node_index = self.hierarchy.first(r.region.index).unwrap();
+        let self_input_node_index = self.hierarchy.first(r.parent.index).unwrap();
         let replacement_output_node = replacement_nodes[replacement_sz - 1];
         for &node in replacement_inner_nodes {
             // Add the nodes.
@@ -127,7 +127,7 @@ impl Hugr {
             let sig = op.signature();
             let new_node_index = self.graph.add_node(sig.input.len(), sig.output.len());
             self.op_types[new_node_index] = op.clone();
-            // Make r.region the parent
+            // Make r.parent the parent
             self.hierarchy
                 .insert_after(new_node_index, self_input_node_index)
                 .ok();

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -110,11 +110,11 @@ impl Hugr {
                 .collect::<Vec<NodeIndex>>();
         let n_sz = n_indices.len(); // number of replacement nodes including Input and Output
         let n_non_io_indices = &n_indices[1..n_sz - 1]; // omit Input and Output
-        for n_index in n_non_io_indices {
+        for &n_index in n_non_io_indices {
             // 3.1.1. Check there are no const inputs.
             if !r
                 .n
-                .get_optype((*n_index).into())
+                .get_optype((n_index).into())
                 .signature()
                 .const_input
                 .is_empty()
@@ -124,9 +124,9 @@ impl Hugr {
         }
         let self_input_node_index: NodeIndex = self.hierarchy.first(r.p.index).unwrap();
         let n_output_node_index: NodeIndex = n_indices[n_sz - 1];
-        for n_index in n_non_io_indices {
+        for &n_index in n_non_io_indices {
             // 3.1.2. Add the nodes.
-            let op: &OpType = r.n.get_optype((*n_index).into());
+            let op: &OpType = r.n.get_optype((n_index).into());
             let sig = op.signature();
             let new_node_index = self.graph.add_node(sig.input.len(), sig.output.len());
             self.op_types[new_node_index] = op.clone();
@@ -134,16 +134,16 @@ impl Hugr {
             self.hierarchy
                 .insert_after(new_node_index, self_input_node_index)
                 .ok();
-            index_map.insert(*n_index, new_node_index);
+            index_map.insert(n_index, new_node_index);
         }
         // 3.2. Add edges between all newly added nodes matching those in n_dfg_node.
-        for n_index in n_non_io_indices {
-            let n_node = Node { index: *n_index };
-            let new_node_index = index_map.get(n_index).unwrap();
+        for &n_index in n_non_io_indices {
+            let n_node = Node { index: n_index };
+            let new_node_index = index_map.get(&n_index).unwrap();
             for n_node_succ in r.n.output_neighbours(n_node) {
                 if r.n.get_optype(n_node_succ).tag() != OpTag::Output {
                     let new_node_succ_index = index_map.get(&n_node_succ.index).unwrap();
-                    for connection in r.n.graph.get_connections(*n_index, n_node_succ.index) {
+                    for connection in r.n.graph.get_connections(n_index, n_node_succ.index) {
                         let src_offset = r.n.graph.port_offset(connection.0).unwrap().index();
                         let tgt_offset = r.n.graph.port_offset(connection.1).unwrap().index();
                         self.graph

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -116,7 +116,7 @@ impl Hugr {
             }
         }
         let self_input_node_index = self.hierarchy.first(r.parent.index).unwrap();
-        let replacement_output_node = replacement_nodes[replacement_sz - 1];
+        let replacement_output_node = *replacement_nodes.last().unwrap();
         for &node in replacement_inner_nodes {
             // Add the nodes.
             let op: &OpType = r.replacement.get_optype(node);

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -14,7 +14,6 @@ use self::multiportgraph::MultiPortGraph;
 pub use self::validate::ValidationError;
 
 use derive_more::From;
-use itertools::Itertools;
 use portgraph::dot::{hier_graph_dot_string_with, DotEdgeStyle};
 use portgraph::{Hierarchy, NodeIndex, UnmanagedDenseMap};
 use thiserror::Error;
@@ -98,9 +97,7 @@ impl Hugr {
         let mut index_map: HashMap<NodeIndex, NodeIndex> = HashMap::new();
         let replacement_nodes = r
             .replacement
-            .hierarchy
-            .children(r.replacement.root().index)
-            .map_into::<Node>()
+            .children(r.replacement.root())
             .collect::<Vec<Node>>();
         // number of replacement nodes including Input and Output:
         let replacement_sz = replacement_nodes.len();

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -133,6 +133,7 @@ impl Hugr {
             index_map.insert(n_node.index, new_node_index);
         }
         // 3.2. Add edges between all newly added nodes matching those in n_dfg_node.
+        // TODO This will probably change when implicit copies are implemented.
         for &n_node in n_non_io_nodes {
             let new_node_index = index_map.get(&n_node.index).unwrap();
             for n_node_succ in r.n.output_neighbours(n_node) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,11 +15,13 @@ pub mod extensions;
 pub mod hugr;
 pub mod macros;
 pub mod ops;
+pub mod replacement;
 pub mod resource;
 pub mod rewrite;
 pub mod types;
 mod utils;
 
 pub use crate::hugr::{Direction, Hugr, Node, Port, Wire};
+pub use crate::replacement::SimpleReplacement;
 pub use crate::resource::Resource;
 pub use crate::rewrite::{Rewrite, RewriteError};

--- a/src/replacement.rs
+++ b/src/replacement.rs
@@ -1,0 +1,6 @@
+//! Subgraph replacement operations on the HUGR.
+
+/// Module implementing the replacement API.
+pub mod simple_replace;
+
+pub use simple_replace::{SimpleReplacement, SimpleReplacementError};

--- a/src/replacement.rs
+++ b/src/replacement.rs
@@ -1,6 +1,5 @@
 //! Subgraph replacement operations on the HUGR.
 
-/// Module implementing the replacement API.
 pub mod simple_replace;
 
 pub use simple_replace::{SimpleReplacement, SimpleReplacementError};

--- a/src/replacement/simple_replace.rs
+++ b/src/replacement/simple_replace.rs
@@ -170,7 +170,7 @@ mod test {
             OpType::Dataflow(DataflowOp::Leaf { op: LeafOp::H }),
             vec![wire1],
         )?;
-        let wire2out = wire2.outputs().exactly_one().ok().unwrap();
+        let wire2out = wire2.outputs().exactly_one().unwrap();
         let wireoutvec = vec![wire0, wire2out];
         dfg_builder.finish_hugr_with_outputs(wireoutvec)
     }
@@ -195,7 +195,7 @@ mod test {
     /// ┤ H ├┤ X ├
     /// └───┘└───┘
     fn test_simple_replacement() {
-        let mut h: Hugr = make_hugr().ok().unwrap();
+        let mut h: Hugr = make_hugr().unwrap();
         // crate::utils::test::viz_dotstr(&h.dot_string());
         // 1. Find the DFG node for the inner circuit
         let p: Node = h
@@ -212,7 +212,7 @@ mod test {
         let (h_node_h0, h_node_h1) = h.output_neighbours(h_node_cx).collect_tuple().unwrap();
         let s: HashSet<Node> = vec![h_node_cx, h_node_h0, h_node_h1].into_iter().collect();
         // 3. Construct a new DFG-rooted hugr for the replacement
-        let n: Hugr = make_dfg_hugr().ok().unwrap();
+        let n: Hugr = make_dfg_hugr().unwrap();
         // crate::utils::test::viz_dotstr(&n.dot_string());
         // 4. Construct the input and output matchings
         // 4.1. Locate the CX and its predecessor H's in n
@@ -302,7 +302,7 @@ mod test {
     /// ┤ H ├
     /// └───┘
     fn test_simple_replacement_with_empty_wires() {
-        let mut h: Hugr = make_hugr().ok().unwrap();
+        let mut h: Hugr = make_hugr().unwrap();
         // 1. Find the DFG node for the inner circuit
         let p: Node = h
             .nodes()
@@ -317,7 +317,7 @@ mod test {
             .unwrap();
         let s: HashSet<Node> = vec![h_node_cx].into_iter().collect();
         // 3. Construct a new DFG-rooted hugr for the replacement
-        let n: Hugr = make_dfg_hugr2().ok().unwrap();
+        let n: Hugr = make_dfg_hugr2().unwrap();
         // crate::utils::test::viz_dotstr(&n.dot_string());
         // 4. Construct the input and output matchings
         // 4.1. Locate the Output and its predecessor H in n

--- a/src/replacement/simple_replace.rs
+++ b/src/replacement/simple_replace.rs
@@ -60,7 +60,7 @@ mod test {
     use itertools::Itertools;
     use portgraph::Direction;
 
-    use crate::builder::{BuildError, Container, Dataflow, ModuleBuilder};
+    use crate::builder::{BuildError, Dataflow, DataflowSubContainer, HugrBuilder, ModuleBuilder};
     use crate::hugr::view::HugrView;
     use crate::hugr::{Hugr, Node};
     use crate::ops::tag::OpTag;
@@ -118,7 +118,7 @@ mod test {
 
             func_builder.finish_with_outputs(inner_graph.outputs().chain(q_out.outputs()))?
         };
-        module_builder.finish()
+        Ok(module_builder.finish_hugr()?)
     }
 
     /// Creates a hugr with a DFG with which to replace a subgraph.
@@ -155,7 +155,7 @@ mod test {
 
             func_builder.finish_with_outputs(inner_graph.outputs())?
         };
-        module_builder.finish()
+        Ok(module_builder.finish_hugr()?)
     }
 
     #[test]

--- a/src/replacement/simple_replace.rs
+++ b/src/replacement/simple_replace.rs
@@ -7,11 +7,11 @@ use thiserror::Error;
 #[derive(Debug, Clone)]
 pub struct SimpleReplacement {
     /// The common DFG parent of all nodes to be replaced.
-    pub p: Node,
+    pub region: Node,
     /// The set of nodes to remove (a convex set of leaf children of `p`).
-    pub s: HashSet<Node>,
+    pub removal: HashSet<Node>,
     /// A hugr with DFG root (consisting of replacement nodes).
-    pub n: Hugr,
+    pub replacement: Hugr,
     /// A map from (target ports of edges from the Input node of n) to (target ports of edges from
     /// non-s nodes to s nodes).
     pub nu_inp: HashMap<(Node, Port), (Node, Port)>,
@@ -23,16 +23,16 @@ pub struct SimpleReplacement {
 impl SimpleReplacement {
     /// Create a new [`SimpleReplacement`] specification.
     pub fn new(
-        p: Node,
-        s: HashSet<Node>,
-        n: Hugr,
+        region: Node,
+        removal: HashSet<Node>,
+        replacement: Hugr,
         nu_inp: HashMap<(Node, Port), (Node, Port)>,
         nu_out: HashMap<(Node, Port), Port>,
     ) -> Self {
         Self {
-            p,
-            s,
-            n,
+            region,
+            removal,
+            replacement,
             nu_inp,
             nu_out,
         }
@@ -215,9 +215,9 @@ mod test {
         nu_out.insert((h_outp_node, h_port_3), n_port_3);
         // 5. Define the replacement
         let r = SimpleReplacement {
-            p,
-            s,
-            n,
+            region: p,
+            removal: s,
+            replacement: n,
             nu_inp,
             nu_out,
         };

--- a/src/replacement/simple_replace.rs
+++ b/src/replacement/simple_replace.rs
@@ -8,15 +8,15 @@ use thiserror::Error;
 pub struct SimpleReplacement {
     /// The common DFG parent of all nodes to be replaced.
     pub region: Node,
-    /// The set of nodes to remove (a convex set of leaf children of `p`).
+    /// The set of nodes to remove (a convex set of leaf children of `region`).
     pub removal: HashSet<Node>,
     /// A hugr with DFG root (consisting of replacement nodes).
     pub replacement: Hugr,
-    /// A map from (target ports of edges from the Input node of n) to (target ports of edges from
-    /// non-s nodes to s nodes).
+    /// A map from (target ports of edges from the Input node of `replacement`) to (target ports of
+    /// edges from nodes not in `removal` to nodes in `removal`).
     pub nu_inp: HashMap<(Node, Port), (Node, Port)>,
-    /// A map from (target ports of edges from s nodes to non-s nodes) to (input ports of the Output
-    /// node of n).
+    /// A map from (target ports of edges from nodes in `removal` to nodes not in `removal`) to
+    /// (input ports of the Output node of `replacement`).
     pub nu_out: HashMap<(Node, Port), Port>,
 }
 

--- a/src/replacement/simple_replace.rs
+++ b/src/replacement/simple_replace.rs
@@ -9,8 +9,8 @@ use thiserror::Error;
 #[derive(Debug, Clone)]
 pub struct SimpleReplacement {
     /// The common DFG parent of all nodes to be replaced.
-    pub region: Node,
-    /// The set of nodes to remove (a convex set of leaf children of `region`).
+    pub parent: Node,
+    /// The set of nodes to remove (a convex set of leaf children of `parent`).
     pub removal: HashSet<Node>,
     /// A hugr with DFG root (consisting of replacement nodes).
     pub replacement: Hugr,
@@ -25,14 +25,14 @@ pub struct SimpleReplacement {
 impl SimpleReplacement {
     /// Create a new [`SimpleReplacement`] specification.
     pub fn new(
-        region: Node,
+        parent: Node,
         removal: HashSet<Node>,
         replacement: Hugr,
         nu_inp: HashMap<(Node, Port), (Node, Port)>,
         nu_out: HashMap<(Node, Port), Port>,
     ) -> Self {
         Self {
-            region,
+            parent,
             removal,
             replacement,
             nu_inp,
@@ -266,7 +266,7 @@ mod test {
         nu_out.insert((h_outp_node, h_port_3), n_port_3);
         // 5. Define the replacement
         let r = SimpleReplacement {
-            region: p,
+            parent: p,
             removal: s,
             replacement: n,
             nu_inp,
@@ -361,7 +361,7 @@ mod test {
         nu_out.insert((h_node_h1, h_port_3), n_port_1);
         // 5. Define the replacement
         let r = SimpleReplacement {
-            region: p,
+            parent: p,
             removal: s,
             replacement: n,
             nu_inp,

--- a/src/replacement/simple_replace.rs
+++ b/src/replacement/simple_replace.rs
@@ -75,7 +75,15 @@ mod test {
 
     const QB: SimpleType = SimpleType::Linear(LinearType::Qubit);
 
-    /// Creates a hugr with a DFG.
+    /// Creates a hugr like the following:
+    /// --   H   --
+    /// -- [DFG] --
+    /// where [DFG] is:
+    /// ┌───┐     ┌───┐
+    /// ┤ H ├──■──┤ H ├
+    /// ├───┤┌─┴─┐├───┤
+    /// ┤ H ├┤ X ├┤ H ├
+    /// └───┘└───┘└───┘
     fn make_hugr() -> Result<Hugr, BuildError> {
         let mut module_builder = ModuleBuilder::new();
         let _f_id = {
@@ -124,7 +132,12 @@ mod test {
         Ok(module_builder.finish_hugr()?)
     }
 
-    /// Creates a hugr with a DFG root with which to replace a subgraph.
+    /// Creates a hugr with a DFG root like the following:
+    /// ┌───┐
+    /// ┤ H ├──■──
+    /// ├───┤┌─┴─┐
+    /// ┤ H ├┤ X ├
+    /// └───┘└───┘
     fn make_dfg_hugr() -> Result<Hugr, BuildError> {
         let mut dfg_builder = DFGBuilder::new(type_row![QB, QB], type_row![QB, QB])?;
         let [wire0, wire1] = dfg_builder.input_wires_arr();
@@ -144,6 +157,24 @@ mod test {
     }
 
     #[test]
+    /// Replace the
+    ///      ┌───┐
+    /// ──■──┤ H ├
+    /// ┌─┴─┐├───┤
+    /// ┤ X ├┤ H ├
+    /// └───┘└───┘
+    /// part of
+    /// ┌───┐     ┌───┐
+    /// ┤ H ├──■──┤ H ├
+    /// ├───┤┌─┴─┐├───┤
+    /// ┤ H ├┤ X ├┤ H ├
+    /// └───┘└───┘└───┘
+    /// with
+    /// ┌───┐
+    /// ┤ H ├──■──
+    /// ├───┤┌─┴─┐
+    /// ┤ H ├┤ X ├
+    /// └───┘└───┘
     fn test_simple_replacement() {
         let mut h: Hugr = make_hugr().ok().unwrap();
         // crate::utils::test::viz_dotstr(&h.dot_string());
@@ -207,6 +238,12 @@ mod test {
             nu_out,
         };
         h.apply_simple_replacement(r).ok();
+        // Expect [DFG] to be replaced with:
+        // ┌───┐┌───┐
+        // ┤ H ├┤ H ├──■──
+        // ├───┤├───┤┌─┴─┐
+        // ┤ H ├┤ H ├┤ X ├
+        // └───┘└───┘└───┘
         // crate::utils::test::viz_dotstr(&h.dot_string());
         assert_eq!(h.validate(), Ok(()));
     }

--- a/src/replacement/simple_replace.rs
+++ b/src/replacement/simple_replace.rs
@@ -205,8 +205,16 @@ mod test {
             .unwrap();
         let (n_node_h0, n_node_h1) = n.input_neighbours(n_node_cx).collect_tuple().unwrap();
         // 4.2. Locate the ports we need to specify as "glue" in n
-        let n_port_0 = n.node_ports(n_node_h0, Direction::Incoming).next().unwrap();
-        let n_port_1 = n.node_ports(n_node_h1, Direction::Incoming).next().unwrap();
+        let n_port_0 = n
+            .node_ports(n_node_h0, Direction::Incoming)
+            .exactly_one()
+            .ok()
+            .unwrap();
+        let n_port_1 = n
+            .node_ports(n_node_h1, Direction::Incoming)
+            .exactly_one()
+            .ok()
+            .unwrap();
         let (n_cx_out_0, n_cx_out_1) = n
             .node_ports(n_node_cx, Direction::Outgoing)
             .collect_tuple()
@@ -218,8 +226,16 @@ mod test {
             .node_ports(h_node_cx, Direction::Incoming)
             .collect_tuple()
             .unwrap();
-        let h_h0_out = h.node_ports(h_node_h0, Direction::Outgoing).next().unwrap();
-        let h_h1_out = h.node_ports(h_node_h1, Direction::Outgoing).next().unwrap();
+        let h_h0_out = h
+            .node_ports(h_node_h0, Direction::Outgoing)
+            .exactly_one()
+            .ok()
+            .unwrap();
+        let h_h1_out = h
+            .node_ports(h_node_h1, Direction::Outgoing)
+            .exactly_one()
+            .ok()
+            .unwrap();
         let (h_outp_node, h_port_2) = h.linked_port(h_node_h0, h_h0_out).unwrap();
         let h_port_3 = h.linked_port(h_node_h1, h_h1_out).unwrap().1;
         // 4.4. Construct the maps

--- a/src/replacement/simple_replace.rs
+++ b/src/replacement/simple_replace.rs
@@ -1,3 +1,5 @@
+//! Implementation of the `SimpleReplace` operation.
+
 use std::collections::{HashMap, HashSet};
 
 use crate::{hugr::Node, Hugr, Port};

--- a/src/replacement/simple_replace.rs
+++ b/src/replacement/simple_replace.rs
@@ -1,0 +1,228 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::{hugr::Node, Hugr, Port};
+use thiserror::Error;
+
+/// Specification of a simple replacement operation.
+#[derive(Debug, Clone)]
+pub struct SimpleReplacement {
+    /// The common DFG parent of all nodes to be replaced.
+    pub p: Node,
+    /// The set of nodes to remove (a convex set of leaf children of `p`).
+    pub s: HashSet<Node>,
+    /// A hugr with DFG root (consisting of replacement nodes).
+    pub n: Hugr,
+    /// A map from (target ports of edges from the Input node of n) to (target ports of edges from
+    /// non-s nodes to s nodes).
+    pub nu_inp: HashMap<(Node, Port), (Node, Port)>,
+    /// A map from (target ports of edges from s nodes to non-s nodes) to (input ports of the Output
+    /// node of n).
+    pub nu_out: HashMap<(Node, Port), Port>,
+}
+
+impl SimpleReplacement {
+    /// Create a new [`SimpleReplacement`] specification.
+    pub fn new(
+        p: Node,
+        s: HashSet<Node>,
+        n: Hugr,
+        nu_inp: HashMap<(Node, Port), (Node, Port)>,
+        nu_out: HashMap<(Node, Port), Port>,
+    ) -> Self {
+        Self {
+            p,
+            s,
+            n,
+            nu_inp,
+            nu_out,
+        }
+    }
+}
+
+/// Error from a [`SimpleReplacement`] operation.
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum SimpleReplacementError {
+    /// Invalid parent node.
+    #[error("Parent node is invalid.")]
+    InvalidParentNode(),
+    /// Node requested for removal is invalid.
+    #[error("A node requested for removal is invalid.")]
+    InvalidRemovedNode(),
+    /// Node in replacement graph is invalid.
+    #[error("A node in the replacement graph is invalid.")]
+    InvalidReplacementNode(),
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::{HashMap, HashSet};
+
+    use itertools::Itertools;
+    use portgraph::Direction;
+
+    use crate::builder::{BuildError, Container, Dataflow, ModuleBuilder};
+    use crate::hugr::view::HugrView;
+    use crate::hugr::{Hugr, Node};
+    use crate::ops::tag::OpTag;
+    use crate::ops::{DataflowOp, LeafOp, OpType};
+    use crate::types::{LinearType, Signature, SimpleType};
+    use crate::{type_row, Port};
+
+    use super::SimpleReplacement;
+
+    const QB: SimpleType = SimpleType::Linear(LinearType::Qubit);
+
+    /// Creates a hugr with a DFG.
+    fn make_hugr() -> Result<Hugr, BuildError> {
+        let mut module_builder = ModuleBuilder::new();
+        let _f_id = {
+            let mut func_builder = module_builder.declare_and_def(
+                "main",
+                Signature::new_df(type_row![QB, QB, QB], type_row![QB, QB, QB]),
+            )?;
+
+            let [qb0, qb1, qb2] = func_builder.input_wires_arr();
+
+            let q_out = func_builder.add_dataflow_op(
+                OpType::Dataflow(DataflowOp::Leaf { op: LeafOp::H }),
+                vec![qb2],
+            )?;
+
+            let mut inner_builder =
+                func_builder.dfg_builder(vec![(QB, qb0), (QB, qb1)], type_row![QB, QB])?;
+            let inner_graph = {
+                let [wire0, wire1] = inner_builder.input_wires_arr();
+                let wire2 = inner_builder.add_dataflow_op(
+                    OpType::Dataflow(DataflowOp::Leaf { op: LeafOp::H }),
+                    vec![wire0],
+                )?;
+                let wire3 = inner_builder.add_dataflow_op(
+                    OpType::Dataflow(DataflowOp::Leaf { op: LeafOp::H }),
+                    vec![wire1],
+                )?;
+                let wire45 = inner_builder.add_dataflow_op(
+                    OpType::Dataflow(DataflowOp::Leaf { op: LeafOp::CX }),
+                    wire2.outputs().chain(wire3.outputs()),
+                )?;
+                let [wire4, wire5] = wire45.outputs_arr();
+                let wire6 = inner_builder.add_dataflow_op(
+                    OpType::Dataflow(DataflowOp::Leaf { op: LeafOp::H }),
+                    vec![wire4],
+                )?;
+                let wire7 = inner_builder.add_dataflow_op(
+                    OpType::Dataflow(DataflowOp::Leaf { op: LeafOp::H }),
+                    vec![wire5],
+                )?;
+                inner_builder.finish_with_outputs(wire6.outputs().chain(wire7.outputs()))
+            }?;
+
+            func_builder.finish_with_outputs(inner_graph.outputs().chain(q_out.outputs()))?
+        };
+        module_builder.finish()
+    }
+
+    /// Creates a hugr with a DFG with which to replace a subgraph.
+    fn make_dfg_hugr() -> Result<Hugr, BuildError> {
+        // TODO This will change when we have DFG-rooted HUGRs implemented. For now, this is a
+        // module HUGR with one DFG node inside it.
+        let mut module_builder = ModuleBuilder::new();
+        let _f_id = {
+            let mut func_builder = module_builder.declare_and_def(
+                "main",
+                Signature::new_df(type_row![QB, QB], type_row![QB, QB]),
+            )?;
+
+            let [qb0, qb1] = func_builder.input_wires_arr();
+
+            let mut inner_builder =
+                func_builder.dfg_builder(vec![(QB, qb0), (QB, qb1)], type_row![QB, QB])?;
+            let inner_graph = {
+                let [wire0, wire1] = inner_builder.input_wires_arr();
+                let wire2 = inner_builder.add_dataflow_op(
+                    OpType::Dataflow(DataflowOp::Leaf { op: LeafOp::H }),
+                    vec![wire0],
+                )?;
+                let wire3 = inner_builder.add_dataflow_op(
+                    OpType::Dataflow(DataflowOp::Leaf { op: LeafOp::H }),
+                    vec![wire1],
+                )?;
+                let wire45 = inner_builder.add_dataflow_op(
+                    OpType::Dataflow(DataflowOp::Leaf { op: LeafOp::CX }),
+                    wire2.outputs().chain(wire3.outputs()),
+                )?;
+                inner_builder.finish_with_outputs(wire45.outputs())
+            }?;
+
+            func_builder.finish_with_outputs(inner_graph.outputs())?
+        };
+        module_builder.finish()
+    }
+
+    #[test]
+    fn test_simple_replacement() {
+        let mut h: Hugr = make_hugr().ok().unwrap();
+        // crate::utils::test::viz_dotstr(&h.dot_string());
+        // 1. Find the DFG node for the inner circuit
+        let p: Node = h
+            .nodes()
+            .find(|node: &Node| h.get_optype(*node).tag() == OpTag::Dfg)
+            .unwrap();
+        // 2. Locate the CX and its successor H's in h
+        let h_node_cx: Node = h
+            .nodes()
+            .find(|node: &Node| {
+                *h.get_optype(*node) == OpType::Dataflow(DataflowOp::Leaf { op: LeafOp::CX })
+            })
+            .unwrap();
+        let (h_node_h0, h_node_h1) = h.output_neighbours(h_node_cx).collect_tuple().unwrap();
+        let s: HashSet<Node> = vec![h_node_cx, h_node_h0, h_node_h1].into_iter().collect();
+        // 3. Construct a new DFG-rooted hugr for the replacement
+        let n: Hugr = make_dfg_hugr().ok().unwrap();
+        // crate::utils::test::viz_dotstr(&n.dot_string());
+        // 4. Construct the input and output matchings
+        // 4.1. Locate the CX and its predecessor H's in n
+        let n_node_cx = n
+            .nodes()
+            .find(|node: &Node| {
+                *n.get_optype(*node) == OpType::Dataflow(DataflowOp::Leaf { op: LeafOp::CX })
+            })
+            .unwrap();
+        let (n_node_h0, n_node_h1) = n.input_neighbours(n_node_cx).collect_tuple().unwrap();
+        // 4.2. Locate the ports we need to specify as "glue" in n
+        let n_port_0 = n.node_ports(n_node_h0, Direction::Incoming).next().unwrap();
+        let n_port_1 = n.node_ports(n_node_h1, Direction::Incoming).next().unwrap();
+        let (n_cx_out_0, n_cx_out_1) = n
+            .node_ports(n_node_cx, Direction::Outgoing)
+            .collect_tuple()
+            .unwrap();
+        let n_port_2 = n.linked_port(n_node_cx, n_cx_out_0).unwrap().1;
+        let n_port_3 = n.linked_port(n_node_cx, n_cx_out_1).unwrap().1;
+        // 4.3. Locate the ports we need to specify as "glue" in h
+        let (h_port_0, h_port_1) = h
+            .node_ports(h_node_cx, Direction::Incoming)
+            .collect_tuple()
+            .unwrap();
+        let h_h0_out = h.node_ports(h_node_h0, Direction::Outgoing).next().unwrap();
+        let h_h1_out = h.node_ports(h_node_h1, Direction::Outgoing).next().unwrap();
+        let (h_outp_node, h_port_2) = h.linked_port(h_node_h0, h_h0_out).unwrap();
+        let h_port_3 = h.linked_port(h_node_h1, h_h1_out).unwrap().1;
+        // 4.4. Construct the maps
+        let mut nu_inp: HashMap<(Node, Port), (Node, Port)> = HashMap::new();
+        let mut nu_out: HashMap<(Node, Port), Port> = HashMap::new();
+        nu_inp.insert((n_node_h0, n_port_0), (h_node_cx, h_port_0));
+        nu_inp.insert((n_node_h1, n_port_1), (h_node_cx, h_port_1));
+        nu_out.insert((h_outp_node, h_port_2), n_port_2);
+        nu_out.insert((h_outp_node, h_port_3), n_port_3);
+        // 5. Define the replacement
+        let r = SimpleReplacement {
+            p,
+            s,
+            n,
+            nu_inp,
+            nu_out,
+        };
+        h.apply_simple_replacement(r).ok();
+        // crate::utils::test::viz_dotstr(&h.dot_string());
+        assert_eq!(h.validate(), Ok(()));
+    }
+}

--- a/src/replacement/simple_replace.rs
+++ b/src/replacement/simple_replace.rs
@@ -155,7 +155,7 @@ mod test {
             OpType::Dataflow(DataflowOp::Leaf { op: LeafOp::CX }),
             wire2.outputs().chain(wire3.outputs()),
         )?;
-        Ok(dfg_builder.finish_hugr_with_outputs(wire45.outputs())?)
+        dfg_builder.finish_hugr_with_outputs(wire45.outputs())
     }
 
     #[test]


### PR DESCRIPTION
This PR includes and implements #85 .

Since we don't yet have DFG-rooted HUGRs we use a workaround where the replacement graph is specified as a HUGR with a unique DFG node. Once #112 is merged we can remove this workaround.