### PR TITLE
Make HugrMut a trait

### DIFF
--- a/src/algorithm/nest_cfgs.rs
+++ b/src/algorithm/nest_cfgs.rs
@@ -399,7 +399,7 @@ impl<T: Copy + Clone + PartialEq + Eq + Hash> EdgeClassifier<T> {
 pub(crate) mod test {
     use super::*;
     use crate::builder::{
-        BuildError, CFGBuilder, Container, Dataflow, DataflowSubContainer, HugrBuilder, HugrMutRef,
+        BuildError, CFGBuilder, Container, Dataflow, DataflowSubContainer, HugrBuilder,
         ModuleBuilder, SubContainer,
     };
     use crate::ops::{
@@ -611,7 +611,7 @@ pub(crate) mod test {
         dataflow_builder.finish_with_outputs([u].into_iter().chain(w))
     }
 
-    fn build_if_then_else_merge<T: HugrMutRef>(
+    fn build_if_then_else_merge<T: AsMut<Hugr> + AsRef<Hugr>>(
         cfg: &mut CFGBuilder<T>,
         const_pred: &ConstID,
         unit_const: &ConstID,
@@ -624,7 +624,7 @@ pub(crate) mod test {
         Ok((split, merge))
     }
 
-    fn build_then_else_merge_from_if<T: HugrMutRef>(
+    fn build_then_else_merge_from_if<T: AsMut<Hugr> + AsRef<Hugr>>(
         cfg: &mut CFGBuilder<T>,
         unit_const: &ConstID,
         split: BasicBlockID,
@@ -649,7 +649,7 @@ pub(crate) mod test {
     }
 
     // Returns loop tail - caller must link header to tail, and provide 0th successor of tail
-    fn build_loop_from_header<T: HugrMutRef>(
+    fn build_loop_from_header<T: AsMut<Hugr> + AsRef<Hugr>>(
         cfg: &mut CFGBuilder<T>,
         const_pred: &ConstID,
         header: BasicBlockID,
@@ -663,7 +663,7 @@ pub(crate) mod test {
     }
 
     // Result is header and tail. Caller must provide 0th successor of header (linking to tail), and 0th successor of tail.
-    fn build_loop<T: HugrMutRef>(
+    fn build_loop<T: AsMut<Hugr> + AsRef<Hugr>>(
         cfg: &mut CFGBuilder<T>,
         const_pred: &ConstID,
         unit_const: &ConstID,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2,7 +2,7 @@
 //!
 use thiserror::Error;
 
-use crate::hugr::{HugrError, HugrMut, Node, ValidationError, Wire};
+use crate::hugr::{Hugr, HugrError, HugrMut, Node, ValidationError, Wire};
 use crate::ops::handle::{BasicBlockID, CfgID, ConditionalID, DfgID, FuncID, TailLoopID};
 
 use crate::types::LinearType;
@@ -70,26 +70,13 @@ pub enum BuildError {
     CircuitError(#[from] circuit_builder::CircuitBuildError),
 }
 
-impl AsMut<HugrMut> for HugrMut {
-    fn as_mut(&mut self) -> &mut HugrMut {
-        self
-    }
-}
-impl AsRef<HugrMut> for HugrMut {
-    fn as_ref(&self) -> &HugrMut {
-        self
-    }
-}
-
 /// Trait allowing treating type as (im)mutable reference to [`HugrMut`]
-pub trait HugrMutRef: AsMut<HugrMut> + AsRef<HugrMut> {}
-impl HugrMutRef for HugrMut {}
-impl HugrMutRef for &mut HugrMut {}
+pub trait HugrMutRef: AsMut<Hugr> + AsRef<Hugr> {}
+impl<H: HugrMut> HugrMutRef for H {}
+impl HugrMutRef for &mut Hugr {}
 
 #[cfg(test)]
 mod test {
-
-    use crate::hugr::HugrMut;
     use crate::types::{ClassicType, LinearType, Signature, SimpleType};
     use crate::Hugr;
 
@@ -112,7 +99,7 @@ mod test {
 
     pub(super) fn build_main(
         signature: Signature,
-        f: impl FnOnce(FunctionBuilder<&mut HugrMut>) -> Result<BuildHandle<FuncID<true>>, BuildError>,
+        f: impl FnOnce(FunctionBuilder<&mut Hugr>) -> Result<BuildHandle<FuncID<true>>, BuildError>,
     ) -> Result<Hugr, BuildError> {
         let mut module_builder = ModuleBuilder::new();
         let f_builder = module_builder.declare_and_def("main", signature)?;

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2,7 +2,7 @@
 //!
 use thiserror::Error;
 
-use crate::hugr::{Hugr, HugrError, HugrMut, Node, ValidationError, Wire};
+use crate::hugr::{HugrError, Node, ValidationError, Wire};
 use crate::ops::handle::{BasicBlockID, CfgID, ConditionalID, DfgID, FuncID, TailLoopID};
 
 use crate::types::LinearType;
@@ -69,11 +69,6 @@ pub enum BuildError {
     #[error("Error in CircuitBuilder: {0}.")]
     CircuitError(#[from] circuit_builder::CircuitBuildError),
 }
-
-/// Trait allowing treating type as (im)mutable reference to [`Hugr`]
-pub trait HugrMutRef: AsMut<Hugr> + AsRef<Hugr> {}
-impl<H: HugrMut> HugrMutRef for H {}
-impl HugrMutRef for &mut Hugr {}
 
 #[cfg(test)]
 mod test {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -70,7 +70,7 @@ pub enum BuildError {
     CircuitError(#[from] circuit_builder::CircuitBuildError),
 }
 
-/// Trait allowing treating type as (im)mutable reference to [`HugrMut`]
+/// Trait allowing treating type as (im)mutable reference to [`Hugr`]
 pub trait HugrMutRef: AsMut<Hugr> + AsRef<Hugr> {}
 impl<H: HugrMut> HugrMutRef for H {}
 impl HugrMutRef for &mut Hugr {}

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -37,9 +37,9 @@ use crate::hugr::HugrMut;
 pub trait Container {
     /// The container node.
     fn container_node(&self) -> Node;
-    /// The underlying [`Hugr`] being built...TODO: should we just require AsMut<Hugr>?
+    /// The underlying [`Hugr`] being built...TODO: should we just require `AsMut<Hugr>`?
     fn base(&mut self) -> &mut Hugr;
-    /// Immutable reference to HUGR being built...TODO: should we just require AsRef<Hugr>? Or combine with previous?
+    /// Immutable reference to HUGR being built...TODO: should we just require `AsRef<Hugr>`? Or combine with previous?
     fn hugr(&self) -> &Hugr;
     /// Add an [`OpType`] as the final child of the container.
     fn add_child_op(&mut self, op: impl Into<OpType>) -> Result<Node, BuildError> {

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -35,9 +35,9 @@ use crate::hugr::HugrMut;
 pub trait Container {
     /// The container node.
     fn container_node(&self) -> Node;
-    /// The underlying [`Hugr`] being built...TODO: should we just require `AsMut<Hugr>`?
+    /// The underlying [`Hugr`] being built
     fn hugr_mut(&mut self) -> &mut Hugr;
-    /// Immutable reference to HUGR being built...TODO: should we just require `AsRef<Hugr>`? Or combine with previous?
+    /// Immutable reference to HUGR being built
     fn hugr(&self) -> &Hugr;
     /// Add an [`OpType`] as the final child of the container.
     fn add_child_op(&mut self, op: impl Into<OpType>) -> Result<Node, BuildError> {

--- a/src/builder/cfg.rs
+++ b/src/builder/cfg.rs
@@ -30,7 +30,7 @@ impl<B: HugrMutRef> Container for CFGBuilder<B> {
     }
 
     #[inline]
-    fn base(&mut self) -> &mut Hugr {
+    fn hugr_mut(&mut self) -> &mut Hugr {
         self.base.as_mut()
     }
 
@@ -113,12 +113,12 @@ impl<B: HugrMutRef> CFGBuilder<B> {
             predicate_variants: predicate_variants.clone(),
         });
         let exit = self.exit_node;
-        let block_n = self.base().add_op_before(exit, op)?;
+        let block_n = self.hugr_mut().add_op_before(exit, op)?;
 
-        self.base().set_num_ports(block_n, 0, n_cases);
+        self.hugr_mut().set_num_ports(block_n, 0, n_cases);
 
         BlockBuilder::create(
-            self.base(),
+            self.hugr_mut(),
             block_n,
             predicate_variants,
             other_outputs,
@@ -192,7 +192,7 @@ impl<B: HugrMutRef> CFGBuilder<B> {
     ) -> Result<(), BuildError> {
         let from = predecessor.node();
         let to = successor.node();
-        let hugr = self.base();
+        let hugr = self.hugr_mut();
         let tin = hugr.num_inputs(to);
         let tout = hugr.num_outputs(to);
 

--- a/src/builder/cfg.rs
+++ b/src/builder/cfg.rs
@@ -2,7 +2,7 @@ use super::{
     build_traits::SubContainer,
     dataflow::{DFGBuilder, DFGWrapper},
     handle::BuildHandle,
-    BasicBlockID, BuildError, CfgID, Container, Dataflow, HugrBuilder, HugrMutRef, Wire,
+    BasicBlockID, BuildError, CfgID, Container, Dataflow, HugrBuilder, Wire,
 };
 
 use crate::{hugr::view::HugrView, type_row, types::SimpleType};
@@ -23,7 +23,7 @@ pub struct CFGBuilder<T> {
     pub(super) n_out_wires: usize,
 }
 
-impl<B: HugrMutRef> Container for CFGBuilder<B> {
+impl<B: AsMut<Hugr> + AsRef<Hugr>> Container for CFGBuilder<B> {
     #[inline]
     fn container_node(&self) -> Node {
         self.cfg_node
@@ -40,7 +40,7 @@ impl<B: HugrMutRef> Container for CFGBuilder<B> {
     }
 }
 
-impl<H: HugrMutRef> SubContainer for CFGBuilder<H> {
+impl<H: AsMut<Hugr> + AsRef<Hugr>> SubContainer for CFGBuilder<H> {
     type ContainerHandle = BuildHandle<CfgID>;
     #[inline]
     fn finish_sub_container(self) -> Result<Self::ContainerHandle, BuildError> {
@@ -71,7 +71,7 @@ impl HugrBuilder for CFGBuilder<Hugr> {
     }
 }
 
-impl<B: HugrMutRef> CFGBuilder<B> {
+impl<B: AsMut<Hugr> + AsRef<Hugr>> CFGBuilder<B> {
     pub(super) fn create(
         mut base: B,
         cfg_node: Node,
@@ -204,7 +204,7 @@ impl<B: HugrMutRef> CFGBuilder<B> {
 /// Builder for a [`BasicBlock::Block`] child graph.
 pub type BlockBuilder<B> = DFGWrapper<B, BasicBlockID>;
 
-impl<B: HugrMutRef> BlockBuilder<B> {
+impl<B: AsMut<Hugr> + AsRef<Hugr>> BlockBuilder<B> {
     /// Set the outputs of the block, with `branch_wire` being the value of the
     /// predicate.  `outputs` are the remaining outputs.
     pub fn set_outputs(
@@ -229,7 +229,7 @@ impl<B: HugrMutRef> BlockBuilder<B> {
         Ok(BlockBuilder::from_dfg_builder(db))
     }
 }
-impl<B: HugrMutRef> BlockBuilder<B> {
+impl<B: AsMut<Hugr> + AsRef<Hugr>> BlockBuilder<B> {
     /// [Set outputs](BlockBuilder::set_outputs) and [finish](`BlockBuilder::finish_sub_container`).
     pub fn finish_with_outputs(
         mut self,
@@ -310,7 +310,9 @@ mod test {
 
         Ok(())
     }
-    fn build_basic_cfg<T: HugrMutRef>(cfg_builder: &mut CFGBuilder<T>) -> Result<(), BuildError> {
+    fn build_basic_cfg<T: AsMut<Hugr> + AsRef<Hugr>>(
+        cfg_builder: &mut CFGBuilder<T>,
+    ) -> Result<(), BuildError> {
         let sum2_variants = vec![type_row![NAT], type_row![NAT]];
         let mut entry_b = cfg_builder.entry_builder(sum2_variants.clone(), type_row![])?;
         let entry = {

--- a/src/builder/cfg.rs
+++ b/src/builder/cfg.rs
@@ -64,9 +64,10 @@ impl CFGBuilder<Hugr> {
     }
 }
 
-impl<H: HugrMut> HugrBuilder for CFGBuilder<H> {
+impl HugrBuilder for CFGBuilder<Hugr> {
     fn finish_hugr(self) -> Result<Hugr, crate::hugr::ValidationError> {
-        self.base.finish()
+        self.base.validate()?;
+        Ok(self.base)
     }
 }
 

--- a/src/builder/conditional.rs
+++ b/src/builder/conditional.rs
@@ -6,12 +6,12 @@ use crate::ops::handle::CaseID;
 
 use super::build_traits::SubContainer;
 use super::handle::BuildHandle;
+use super::HugrBuilder;
 use super::{
     build_traits::Container,
     dataflow::{DFGBuilder, DFGWrapper},
     BuildError, ConditionalID,
 };
-use super::{HugrBuilder, HugrMutRef};
 
 use crate::Node;
 use crate::{hugr::HugrMut, Hugr};
@@ -47,7 +47,7 @@ pub struct ConditionalBuilder<T> {
     pub(super) case_nodes: Vec<Option<Node>>,
 }
 
-impl<T: HugrMutRef> Container for ConditionalBuilder<T> {
+impl<T: AsMut<Hugr> + AsRef<Hugr>> Container for ConditionalBuilder<T> {
     #[inline]
     fn container_node(&self) -> Node {
         self.conditional_node
@@ -64,7 +64,7 @@ impl<T: HugrMutRef> Container for ConditionalBuilder<T> {
     }
 }
 
-impl<H: HugrMutRef> SubContainer for ConditionalBuilder<H> {
+impl<H: AsMut<Hugr> + AsRef<Hugr>> SubContainer for ConditionalBuilder<H> {
     type ContainerHandle = BuildHandle<ConditionalID>;
 
     fn finish_sub_container(self) -> Result<Self::ContainerHandle, BuildError> {
@@ -84,7 +84,7 @@ impl<H: HugrMutRef> SubContainer for ConditionalBuilder<H> {
         Ok((self.conditional_node, self.n_out_wires).into())
     }
 }
-impl<B: HugrMutRef> ConditionalBuilder<B> {
+impl<B: AsMut<Hugr> + AsRef<Hugr>> ConditionalBuilder<B> {
     /// Return a builder the Case node with index `case`.
     ///
     /// # Panics

--- a/src/builder/conditional.rs
+++ b/src/builder/conditional.rs
@@ -54,7 +54,7 @@ impl<T: HugrMutRef> Container for ConditionalBuilder<T> {
     }
 
     #[inline]
-    fn base(&mut self) -> &mut Hugr {
+    fn hugr_mut(&mut self) -> &mut Hugr {
         self.base.as_mut()
     }
 
@@ -118,14 +118,14 @@ impl<B: HugrMutRef> ConditionalBuilder<B> {
         let case_node =
             // add case before any existing subsequent cases
             if let Some(&sibling_node) = self.case_nodes[case + 1..].iter().flatten().next() {
-                self.base().add_op_before(sibling_node, case_op)?
+                self.hugr_mut().add_op_before(sibling_node, case_op)?
             } else {
                 self.add_child_op(case_op)?
             };
 
         self.case_nodes[case] = Some(case_node);
 
-        let dfg_builder = DFGBuilder::create_with_io(self.base(), case_node, inputs, outputs)?;
+        let dfg_builder = DFGBuilder::create_with_io(self.hugr_mut(), case_node, inputs, outputs)?;
 
         Ok(CaseBuilder::from_dfg_builder(dfg_builder))
     }

--- a/src/builder/conditional.rs
+++ b/src/builder/conditional.rs
@@ -131,9 +131,10 @@ impl<B: HugrMutRef> ConditionalBuilder<B> {
     }
 }
 
-impl<H: HugrMut> HugrBuilder for ConditionalBuilder<H> {
+impl HugrBuilder for ConditionalBuilder<Hugr> {
     fn finish_hugr(self) -> Result<Hugr, crate::hugr::ValidationError> {
-        self.base.finish()
+        self.base.validate()?;
+        Ok(self.base)
     }
 }
 

--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -68,9 +68,10 @@ impl DFGBuilder<Hugr> {
     }
 }
 
-impl<T: HugrMut> HugrBuilder for DFGBuilder<T> {
+impl HugrBuilder for DFGBuilder<Hugr> {
     fn finish_hugr(self) -> Result<Hugr, ValidationError> {
-        self.base.finish()
+        self.base.validate()?;
+        Ok(self.base)
     }
 }
 
@@ -183,7 +184,7 @@ impl<B: HugrMutRef, T: From<BuildHandle<DfgID>>> SubContainer for DFGWrapper<B, 
     }
 }
 
-impl<B: HugrMut, T> HugrBuilder for DFGWrapper<B, T> {
+impl<T> HugrBuilder for DFGWrapper<Hugr, T> {
     fn finish_hugr(self) -> Result<Hugr, ValidationError> {
         self.0.finish_hugr()
     }

--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -82,7 +82,7 @@ impl<T: HugrMutRef> Container for DFGBuilder<T> {
     }
 
     #[inline]
-    fn base(&mut self) -> &mut Hugr {
+    fn hugr_mut(&mut self) -> &mut Hugr {
         self.base.as_mut()
     }
 
@@ -153,8 +153,8 @@ impl<B: HugrMutRef, T> Container for DFGWrapper<B, T> {
     }
 
     #[inline]
-    fn base(&mut self) -> &mut Hugr {
-        self.0.base()
+    fn hugr_mut(&mut self) -> &mut Hugr {
+        self.0.hugr_mut()
     }
 
     #[inline]

--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -1,6 +1,6 @@
 use super::build_traits::{HugrBuilder, SubContainer};
 use super::handle::BuildHandle;
-use super::{BuildError, Container, Dataflow, DfgID, FuncID, HugrMutRef};
+use super::{BuildError, Container, Dataflow, DfgID, FuncID};
 
 use std::marker::PhantomData;
 
@@ -21,7 +21,7 @@ pub struct DFGBuilder<T> {
     pub(crate) io: [Node; 2],
 }
 
-impl<T: HugrMutRef> DFGBuilder<T> {
+impl<T: AsMut<Hugr> + AsRef<Hugr>> DFGBuilder<T> {
     pub(super) fn create_with_io(
         mut base: T,
         parent: Node,
@@ -75,7 +75,7 @@ impl HugrBuilder for DFGBuilder<Hugr> {
     }
 }
 
-impl<T: HugrMutRef> Container for DFGBuilder<T> {
+impl<T: AsMut<Hugr> + AsRef<Hugr>> Container for DFGBuilder<T> {
     #[inline]
     fn container_node(&self) -> Node {
         self.dfg_node
@@ -92,7 +92,7 @@ impl<T: HugrMutRef> Container for DFGBuilder<T> {
     }
 }
 
-impl<T: HugrMutRef> SubContainer for DFGBuilder<T> {
+impl<T: AsMut<Hugr> + AsRef<Hugr>> SubContainer for DFGBuilder<T> {
     type ContainerHandle = BuildHandle<DfgID>;
     #[inline]
     fn finish_sub_container(self) -> Result<Self::ContainerHandle, BuildError> {
@@ -100,7 +100,7 @@ impl<T: HugrMutRef> SubContainer for DFGBuilder<T> {
     }
 }
 
-impl<T: HugrMutRef> Dataflow for DFGBuilder<T> {
+impl<T: AsMut<Hugr> + AsRef<Hugr>> Dataflow for DFGBuilder<T> {
     #[inline]
     fn io(&self) -> [Node; 2] {
         self.io
@@ -146,7 +146,7 @@ impl FunctionBuilder<Hugr> {
     }
 }
 
-impl<B: HugrMutRef, T> Container for DFGWrapper<B, T> {
+impl<B: AsMut<Hugr> + AsRef<Hugr>, T> Container for DFGWrapper<B, T> {
     #[inline]
     fn container_node(&self) -> Node {
         self.0.container_node()
@@ -163,7 +163,7 @@ impl<B: HugrMutRef, T> Container for DFGWrapper<B, T> {
     }
 }
 
-impl<B: HugrMutRef, T> Dataflow for DFGWrapper<B, T> {
+impl<B: AsMut<Hugr> + AsRef<Hugr>, T> Dataflow for DFGWrapper<B, T> {
     #[inline]
     fn io(&self) -> [Node; 2] {
         self.0.io
@@ -175,7 +175,7 @@ impl<B: HugrMutRef, T> Dataflow for DFGWrapper<B, T> {
     }
 }
 
-impl<B: HugrMutRef, T: From<BuildHandle<DfgID>>> SubContainer for DFGWrapper<B, T> {
+impl<B: AsMut<Hugr> + AsRef<Hugr>, T: From<BuildHandle<DfgID>>> SubContainer for DFGWrapper<B, T> {
     type ContainerHandle = T;
 
     #[inline]

--- a/src/builder/module_builder.rs
+++ b/src/builder/module_builder.rs
@@ -1,7 +1,7 @@
 use super::{
     build_traits::HugrBuilder,
     dataflow::{DFGBuilder, FunctionBuilder},
-    BuildError, Container, HugrMutRef,
+    BuildError, Container,
 };
 
 use crate::{
@@ -23,7 +23,7 @@ use crate::{hugr::HugrMut, Hugr};
 /// Builder for a HUGR module.
 pub struct ModuleBuilder<T>(pub(super) T);
 
-impl<T: HugrMutRef> Container for ModuleBuilder<T> {
+impl<T: AsMut<Hugr> + AsRef<Hugr>> Container for ModuleBuilder<T> {
     #[inline]
     fn container_node(&self) -> Node {
         self.0.as_ref().root()
@@ -60,7 +60,7 @@ impl HugrBuilder for ModuleBuilder<Hugr> {
     }
 }
 
-impl<T: HugrMutRef> ModuleBuilder<T> {
+impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
     /// Generate a builder for defining a function body graph.
     ///
     /// Replaces a [`OpType::Declare`] node as specified by `f_id`

--- a/src/builder/module_builder.rs
+++ b/src/builder/module_builder.rs
@@ -29,30 +29,30 @@ impl<T: HugrMutRef> Container for ModuleBuilder<T> {
     }
 
     #[inline]
-    fn base(&mut self) -> &mut HugrMut {
+    fn base(&mut self) -> &mut Hugr {
         self.0.as_mut()
     }
 
     fn hugr(&self) -> &Hugr {
-        self.0.as_ref().hugr()
+        self.0.as_ref()
     }
 }
 
-impl ModuleBuilder<HugrMut> {
+impl ModuleBuilder<Hugr> {
     /// Begin building a new module.
     #[must_use]
     pub fn new() -> Self {
-        Self(HugrMut::new_module())
+        Self(Default::default())
     }
 }
 
-impl Default for ModuleBuilder<HugrMut> {
+impl Default for ModuleBuilder<Hugr> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl HugrBuilder for ModuleBuilder<HugrMut> {
+impl<H: HugrMut> HugrBuilder for ModuleBuilder<H> {
     fn finish_hugr(self) -> Result<Hugr, ValidationError> {
         self.0.finish()
     }
@@ -70,7 +70,7 @@ impl<T: HugrMutRef> ModuleBuilder<T> {
     pub fn define_function(
         &mut self,
         f_id: &FuncID<false>,
-    ) -> Result<FunctionBuilder<&mut HugrMut>, BuildError> {
+    ) -> Result<FunctionBuilder<&mut Hugr>, BuildError> {
         let f_node = f_id.node();
         let (inputs, outputs) = if let OpType::Module(ModuleOp::Declare { signature }) =
             self.hugr().get_optype(f_node)
@@ -104,7 +104,7 @@ impl<T: HugrMutRef> ModuleBuilder<T> {
         &mut self,
         name: impl Into<String>,
         signature: Signature,
-    ) -> Result<FunctionBuilder<&mut HugrMut>, BuildError> {
+    ) -> Result<FunctionBuilder<&mut Hugr>, BuildError> {
         let fid = self.declare(name, signature)?;
         self.define_function(&fid)
     }

--- a/src/builder/module_builder.rs
+++ b/src/builder/module_builder.rs
@@ -30,7 +30,7 @@ impl<T: HugrMutRef> Container for ModuleBuilder<T> {
     }
 
     #[inline]
-    fn base(&mut self) -> &mut Hugr {
+    fn hugr_mut(&mut self) -> &mut Hugr {
         self.0.as_mut()
     }
 
@@ -88,7 +88,7 @@ impl<T: HugrMutRef> ModuleBuilder<T> {
                 op_desc: "OpType::Declare",
             });
         };
-        self.base().replace_op(
+        self.hugr_mut().replace_op(
             f_node,
             ops::Def {
                 name,
@@ -96,7 +96,7 @@ impl<T: HugrMutRef> ModuleBuilder<T> {
             },
         );
 
-        let db = DFGBuilder::create_with_io(self.base(), f_node, inputs, outputs)?;
+        let db = DFGBuilder::create_with_io(self.hugr_mut(), f_node, inputs, outputs)?;
         Ok(FunctionBuilder::from_dfg_builder(db))
     }
 

--- a/src/builder/module_builder.rs
+++ b/src/builder/module_builder.rs
@@ -53,9 +53,10 @@ impl Default for ModuleBuilder<Hugr> {
     }
 }
 
-impl<H: HugrMut> HugrBuilder for ModuleBuilder<H> {
+impl HugrBuilder for ModuleBuilder<Hugr> {
     fn finish_hugr(self) -> Result<Hugr, ValidationError> {
-        self.0.finish()
+        self.0.validate()?;
+        Ok(self.0)
     }
 }
 

--- a/src/builder/tail_loop.rs
+++ b/src/builder/tail_loop.rs
@@ -6,7 +6,6 @@ use crate::{Hugr, Node};
 
 use super::build_traits::SubContainer;
 use super::handle::BuildHandle;
-use super::HugrMutRef;
 use super::{
     dataflow::{DFGBuilder, DFGWrapper},
     BuildError, Container, Dataflow, TailLoopID, Wire,
@@ -15,7 +14,7 @@ use super::{
 /// Builder for a [`ops::TailLoop`] node.
 pub type TailLoopBuilder<B> = DFGWrapper<B, BuildHandle<TailLoopID>>;
 
-impl<B: HugrMutRef> TailLoopBuilder<B> {
+impl<B: AsMut<Hugr> + AsRef<Hugr>> TailLoopBuilder<B> {
     pub(super) fn create_with_io(
         base: B,
         loop_node: Node,
@@ -59,7 +58,7 @@ impl<B: HugrMutRef> TailLoopBuilder<B> {
     }
 }
 
-impl<H: HugrMutRef> TailLoopBuilder<H> {
+impl<H: AsMut<Hugr> + AsRef<Hugr>> TailLoopBuilder<H> {
     /// Set outputs and finish, see [`TailLoopBuilder::set_outputs`]
     pub fn finish_with_outputs(
         mut self,

--- a/src/builder/tail_loop.rs
+++ b/src/builder/tail_loop.rs
@@ -1,10 +1,9 @@
-use crate::hugr::HugrMut;
 use crate::ops::controlflow::TailLoopSignature;
 use crate::ops::{controlflow::ControlFlowOp, DataflowOp, OpType};
 
 use crate::hugr::view::HugrView;
 use crate::types::TypeRow;
-use crate::Node;
+use crate::{Hugr, Node};
 
 use super::build_traits::SubContainer;
 use super::handle::BuildHandle;
@@ -65,7 +64,7 @@ impl<B: HugrMutRef> TailLoopBuilder<B> {
     }
 }
 
-impl TailLoopBuilder<&mut HugrMut> {
+impl<H: HugrMutRef> TailLoopBuilder<H> {
     /// Set outputs and finish, see [`TailLoopBuilder::set_outputs`]
     pub fn finish_with_outputs(
         mut self,
@@ -80,7 +79,7 @@ impl TailLoopBuilder<&mut HugrMut> {
     }
 }
 
-impl TailLoopBuilder<HugrMut> {
+impl TailLoopBuilder<Hugr> {
     /// Initialize new builder for a [`ControlFlowOp::TailLoop`] rooted HUGR
     pub fn new(
         just_inputs: impl Into<TypeRow>,
@@ -93,8 +92,8 @@ impl TailLoopBuilder<HugrMut> {
             rest: inputs_outputs.into(),
         };
         let op = ControlFlowOp::TailLoop(tail_loop_sig.clone());
-        let base = HugrMut::new(op);
-        let root = base.hugr().root();
+        let base = Hugr::new(op);
+        let root = base.root();
         Self::create_with_io(base, root, &tail_loop_sig)
     }
 }

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -50,6 +50,18 @@ impl Default for Hugr {
     }
 }
 
+impl AsRef<Hugr> for Hugr {
+    fn as_ref(&self) -> &Hugr {
+        self
+    }
+}
+
+impl AsMut<Hugr> for Hugr {
+    fn as_mut(&mut self) -> &mut Hugr {
+        self
+    }
+}
+
 /// A handle to a node in the HUGR.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, From)]
 pub struct Node {

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -7,7 +7,7 @@ pub mod serialize;
 pub mod validate;
 pub mod view;
 
-pub use self::hugrmut::HugrMut;
+pub(crate) use self::hugrmut::HugrMut;
 use self::multiportgraph::MultiPortGraph;
 pub use self::validate::ValidationError;
 

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -127,18 +127,6 @@ pub(crate) trait HugrMut: AsRef<Hugr> + AsMut<Hugr> {
     fn replace_op(&mut self, node: Node, op: impl Into<OpType>) -> OpType;
 }
 
-impl AsRef<Hugr> for Hugr {
-    fn as_ref(&self) -> &Hugr {
-        self
-    }
-}
-
-impl AsMut<Hugr> for Hugr {
-    fn as_mut(&mut self) -> &mut Hugr {
-        self
-    }
-}
-
 impl HugrMut for Hugr {
     fn add_op(&mut self, op: impl Into<OpType>) -> Node {
         let op: OpType = op.into();

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -10,7 +10,7 @@ use crate::ops::OpType;
 use crate::{Hugr, Port};
 
 /// Functions for low-level building of a HUGR. (Or, in the future, a subregion thereof)
-pub trait HugrMut: AsRef<Hugr> + AsMut<Hugr> {
+pub(crate) trait HugrMut: AsRef<Hugr> + AsMut<Hugr> {
     /// Add a node to the graph.
     fn add_op(&mut self, op: impl Into<OpType>) -> Node;
 

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -52,7 +52,12 @@ pub trait HugrMut: AsRef<Hugr> + AsMut<Hugr> {
     ///
     /// [`OpType::other_inputs`]: crate::ops::OpType::other_inputs
     /// [`OpType::other_outputs`]: crate::ops::OpType::other_outputs.
-    fn add_other_edge(&mut self, src: Node, dst: Node) -> Result<(usize, usize), HugrError>;
+    fn add_other_edge(&mut self, src: Node, dst: Node) -> Result<(usize, usize), HugrError> {
+        let src_port: usize = self.add_ports(src, Direction::Outgoing, 1).collect_vec()[0];
+        let dst_port: usize = self.add_ports(dst, Direction::Incoming, 1).collect_vec()[0];
+        self.connect(src, src_port, dst, dst_port)?;
+        Ok((src_port, dst_port))
+    }
 
     /// Set the number of ports on a node. This may invalidate the node's `PortIndex`.
     fn set_num_ports(&mut self, node: Node, incoming: usize, outgoing: usize);
@@ -183,14 +188,6 @@ impl HugrMut for Hugr {
         )?;
         self.graph.unlink_port(port);
         Ok(())
-    }
-
-    // ALAN can this move into the trait?
-    fn add_other_edge(&mut self, src: Node, dst: Node) -> Result<(usize, usize), HugrError> {
-        let src_port: usize = self.add_ports(src, Direction::Outgoing, 1).collect_vec()[0];
-        let dst_port: usize = self.add_ports(dst, Direction::Incoming, 1).collect_vec()[0];
-        self.connect(src, src_port, dst, dst_port)?;
-        Ok((src_port, dst_port))
     }
 
     #[inline]

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -2,7 +2,6 @@
 
 use std::ops::Range;
 
-use derive_more::{Deref, DerefMut};
 use itertools::Itertools;
 use portgraph::SecondaryMap;
 
@@ -10,58 +9,20 @@ use crate::hugr::{Direction, HugrError, Node, ValidationError};
 use crate::ops::OpType;
 use crate::{Hugr, Port};
 
-/// A low-level builder for a HUGR.
-#[derive(Clone, Debug, Default, Deref, DerefMut)]
-pub struct HugrMut {
-    /// The partial HUGR being built.
-    hugr: Hugr,
-}
-
-impl HugrMut {
-    /// Initialize a new module HUGR builder.
-    pub fn new_module() -> Self {
-        Default::default()
-    }
-
-    /// Initialize a new HUGR builder with `root_op` as the root node.
-    pub fn new(root_op: impl Into<OpType>) -> Self {
-        Self {
-            hugr: Hugr::new(root_op),
-        }
-    }
-
+/// Functions for low-level building of a HUGR. (Or, in the future, a subregion thereof)
+pub trait HugrMut: AsRef<Hugr> + AsMut<Hugr> {
     /// Add a node to the graph.
-    pub fn add_op(&mut self, op: impl Into<OpType>) -> Node {
-        let op: OpType = op.into();
-        let sig = op.signature();
-        let node = self.hugr.graph.add_node(
-            sig.input.len() + sig.const_input.iter().count(),
-            sig.output.len(),
-        );
-        self.hugr.op_types[node] = op;
-        node.into()
-    }
+    fn add_op(&mut self, op: impl Into<OpType>) -> Node;
 
     /// Remove a node from the graph.
     ///
     /// # Panics
     ///
     /// Panics if the node is the root node.
-    pub fn remove_op(&mut self, node: Node) -> Result<(), HugrError> {
-        if node.index == self.hugr.root {
-            // TODO: Add a HugrMutError ?
-            panic!("cannot remove root node");
-        }
-        self.remove_node(node)
-    }
+    fn remove_op(&mut self, node: Node) -> Result<(), HugrError>;
 
     /// Remove a node from the graph
-    fn remove_node(&mut self, node: Node) -> Result<(), HugrError> {
-        self.hugr.hierarchy.remove(node.index);
-        self.hugr.graph.remove_node(node.index);
-        self.hugr.op_types.remove(node.index);
-        Ok(())
-    }
+    fn remove_node(&mut self, node: Node) -> Result<(), HugrError>;
 
     /// Connect two nodes at the given ports.
     ///
@@ -69,33 +30,18 @@ impl HugrMut {
     ///
     /// [`add_ports`]: #method.add_ports
     /// [`set_num_ports`]: #method.set_num_ports.
-    pub fn connect(
+    fn connect(
         &mut self,
         src: Node,
         src_port: usize,
         dst: Node,
         dst_port: usize,
-    ) -> Result<(), HugrError> {
-        self.hugr
-            .graph
-            .link_nodes(src.index, src_port, dst.index, dst_port)?;
-        Ok(())
-    }
+    ) -> Result<(), HugrError>;
 
     /// Disconnects all edges from the given port.
     ///
     /// The port is left in place.
-    pub fn disconnect(&mut self, node: Node, port: Port) -> Result<(), HugrError> {
-        let offset = port.offset;
-        let port = self.hugr.graph.port_index(node.index, offset).ok_or(
-            portgraph::LinkError::UnknownOffset {
-                node: node.index,
-                offset,
-            },
-        )?;
-        self.hugr.graph.unlink_port(port);
-        Ok(())
-    }
+    fn disconnect(&mut self, node: Node, port: Port) -> Result<(), HugrError>;
 
     /// Adds a non-dataflow edge between two nodes, allocating new ports for the
     /// connection. The kind is given by the operation's
@@ -106,30 +52,157 @@ impl HugrMut {
     ///
     /// [`OpType::other_inputs`]: crate::ops::OpType::other_inputs
     /// [`OpType::other_outputs`]: crate::ops::OpType::other_outputs.
-    pub fn add_other_edge(&mut self, src: Node, dst: Node) -> Result<(usize, usize), HugrError> {
-        let src_port: usize = self.add_ports(src, Direction::Outgoing, 1).collect_vec()[0];
-        let dst_port: usize = self.add_ports(dst, Direction::Incoming, 1).collect_vec()[0];
-        self.connect(src, src_port, dst, dst_port)?;
-        Ok((src_port, dst_port))
-    }
+    fn add_other_edge(&mut self, src: Node, dst: Node) -> Result<(usize, usize), HugrError>;
 
     /// Set the number of ports on a node. This may invalidate the node's `PortIndex`.
-    #[inline]
-    pub fn set_num_ports(&mut self, node: Node, incoming: usize, outgoing: usize) {
-        self.hugr
-            .graph
-            .set_num_ports(node.index, incoming, outgoing, |_, _| {})
-    }
+    fn set_num_ports(&mut self, node: Node, incoming: usize, outgoing: usize);
 
     /// Alter the number of ports on a node and returns a range with the new
     /// port offsets, if any. This may invalidate the node's `PortIndex`.
     ///
     /// The `direction` parameter specifies whether to add ports to the incoming
     /// or outgoing list.
+    fn add_ports(&mut self, node: Node, direction: Direction, amount: isize) -> Range<usize>;
+
+    /// Sets the parent of a node.
+    ///
+    /// The node becomes the parent's last child.
+    fn set_parent(&mut self, node: Node, parent: Node) -> Result<(), HugrError>;
+
+    /// Move a node in the hierarchy to be the subsequent sibling of another
+    /// node.
+    ///
+    /// The sibling node's parent becomes the new node's parent.
+    ///
+    /// The node becomes the parent's last child.
+    fn move_after_sibling(&mut self, node: Node, after: Node) -> Result<(), HugrError>;
+
+    /// Move a node in the hierarchy to be the prior sibling of another node.
+    ///
+    /// The sibling node's parent becomes the new node's parent.
+    ///
+    /// The node becomes the parent's last child.
+    fn move_before_sibling(&mut self, node: Node, before: Node) -> Result<(), HugrError>;
+
+    /// Add a node to the graph with a parent in the hierarchy.
+    ///
+    /// The node becomes the parent's last child.
+    fn add_op_with_parent(
+        &mut self,
+        parent: Node,
+        op: impl Into<OpType>,
+    ) -> Result<Node, HugrError>;
+
+    /// Add a node to the graph as the previous sibling of another node.
+    ///
+    /// The sibling node's parent becomes the new node's parent.
+    ///
+    /// # Errors
+    ///
+    ///  - If the sibling node does not have a parent.
+    ///  - If the attachment would introduce a cycle.
+    fn add_op_before(&mut self, sibling: Node, op: impl Into<OpType>) -> Result<Node, HugrError>;
+
+    /// Add a node to the graph as the next sibling of another node.
+    ///
+    /// The sibling node's parent becomes the new node's parent.
+    ///
+    /// # Errors
+    ///
+    ///  - If the sibling node does not have a parent.
+    ///  - If the attachment would introduce a cycle.
+    fn add_op_after(&mut self, sibling: Node, op: impl Into<OpType>) -> Result<Node, HugrError>;
+
+    /// Build the HUGR, returning an error if the graph is not valid.
+    fn finish(self) -> Result<Hugr, ValidationError>;
+
+    /// Replace the OpType at node and return the old OpType.
+    /// In general this invalidates the ports, which may need to be resized to
+    /// match the OpType signature.
+    fn replace_op(&mut self, node: Node, op: impl Into<OpType>) -> OpType;
+}
+
+impl AsRef<Hugr> for Hugr {
+    fn as_ref(&self) -> &Hugr {
+        self
+    }
+}
+
+impl AsMut<Hugr> for Hugr {
+    fn as_mut(&mut self) -> &mut Hugr {
+        self
+    }
+}
+
+impl HugrMut for Hugr {
+    fn add_op(&mut self, op: impl Into<OpType>) -> Node {
+        let op: OpType = op.into();
+        let sig = op.signature();
+        let node = self.graph.add_node(
+            sig.input.len() + sig.const_input.iter().count(),
+            sig.output.len(),
+        );
+        self.op_types[node] = op;
+        node.into()
+    }
+
+    fn remove_op(&mut self, node: Node) -> Result<(), HugrError> {
+        if node.index == self.root {
+            // TODO: Add a HugrMutError ?
+            panic!("cannot remove root node");
+        }
+        self.remove_node(node)
+    }
+
+    fn remove_node(&mut self, node: Node) -> Result<(), HugrError> {
+        self.hierarchy.remove(node.index);
+        self.graph.remove_node(node.index);
+        self.op_types.remove(node.index);
+        Ok(())
+    }
+
+    fn connect(
+        &mut self,
+        src: Node,
+        src_port: usize,
+        dst: Node,
+        dst_port: usize,
+    ) -> Result<(), HugrError> {
+        self.graph
+            .link_nodes(src.index, src_port, dst.index, dst_port)?;
+        Ok(())
+    }
+
+    fn disconnect(&mut self, node: Node, port: Port) -> Result<(), HugrError> {
+        let offset = port.offset;
+        let port = self.graph.port_index(node.index, offset).ok_or(
+            portgraph::LinkError::UnknownOffset {
+                node: node.index,
+                offset,
+            },
+        )?;
+        self.graph.unlink_port(port);
+        Ok(())
+    }
+
+    // ALAN can this move into the trait?
+    fn add_other_edge(&mut self, src: Node, dst: Node) -> Result<(usize, usize), HugrError> {
+        let src_port: usize = self.add_ports(src, Direction::Outgoing, 1).collect_vec()[0];
+        let dst_port: usize = self.add_ports(dst, Direction::Incoming, 1).collect_vec()[0];
+        self.connect(src, src_port, dst, dst_port)?;
+        Ok((src_port, dst_port))
+    }
+
     #[inline]
-    pub fn add_ports(&mut self, node: Node, direction: Direction, amount: isize) -> Range<usize> {
-        let mut incoming = self.hugr.graph.num_inputs(node.index);
-        let mut outgoing = self.hugr.graph.num_outputs(node.index);
+    fn set_num_ports(&mut self, node: Node, incoming: usize, outgoing: usize) {
+        self.graph
+            .set_num_ports(node.index, incoming, outgoing, |_, _| {})
+    }
+
+    #[inline]
+    fn add_ports(&mut self, node: Node, direction: Direction, amount: isize) -> Range<usize> {
+        let mut incoming = self.graph.num_inputs(node.index);
+        let mut outgoing = self.graph.num_outputs(node.index);
         let increment = |num: &mut usize| {
             let new = num.saturating_add_signed(amount);
             let range = *num..new;
@@ -140,119 +213,60 @@ impl HugrMut {
             Direction::Incoming => increment(&mut incoming),
             Direction::Outgoing => increment(&mut outgoing),
         };
-        self.hugr
-            .graph
+        self.graph
             .set_num_ports(node.index, incoming, outgoing, |_, _| {});
         range
     }
 
-    /// Sets the parent of a node.
-    ///
-    /// The node becomes the parent's last child.
-    pub fn set_parent(&mut self, node: Node, parent: Node) -> Result<(), HugrError> {
-        self.hugr.hierarchy.detach(node.index);
-        self.hugr.hierarchy.push_child(node.index, parent.index)?;
+    fn set_parent(&mut self, node: Node, parent: Node) -> Result<(), HugrError> {
+        self.hierarchy.detach(node.index);
+        self.hierarchy.push_child(node.index, parent.index)?;
         Ok(())
     }
 
-    /// Move a node in the hierarchy to be the subsequent sibling of another
-    /// node.
-    ///
-    /// The sibling node's parent becomes the new node's parent.
-    ///
-    /// The node becomes the parent's last child.
-    pub fn move_after_sibling(&mut self, node: Node, after: Node) -> Result<(), HugrError> {
-        self.hugr.hierarchy.detach(node.index);
-        self.hugr.hierarchy.insert_after(node.index, after.index)?;
+    fn move_after_sibling(&mut self, node: Node, after: Node) -> Result<(), HugrError> {
+        self.hierarchy.detach(node.index);
+        self.hierarchy.insert_after(node.index, after.index)?;
         Ok(())
     }
 
-    /// Move a node in the hierarchy to be the prior sibling of another node.
-    ///
-    /// The sibling node's parent becomes the new node's parent.
-    ///
-    /// The node becomes the parent's last child.
-    pub fn move_before_sibling(&mut self, node: Node, before: Node) -> Result<(), HugrError> {
-        self.hugr.hierarchy.detach(node.index);
-        self.hugr
-            .hierarchy
-            .insert_before(node.index, before.index)?;
+    fn move_before_sibling(&mut self, node: Node, before: Node) -> Result<(), HugrError> {
+        self.hierarchy.detach(node.index);
+        self.hierarchy.insert_before(node.index, before.index)?;
         Ok(())
     }
 
-    /// Add a node to the graph with a parent in the hierarchy.
-    ///
-    /// The node becomes the parent's last child.
-    pub fn add_op_with_parent(
+    fn add_op_with_parent(
         &mut self,
         parent: Node,
         op: impl Into<OpType>,
     ) -> Result<Node, HugrError> {
         let node = self.add_op(op.into());
-        self.hugr.hierarchy.push_child(node.index, parent.index)?;
+        self.hierarchy.push_child(node.index, parent.index)?;
         Ok(node)
     }
 
-    /// Add a node to the graph as the previous sibling of another node.
-    ///
-    /// The sibling node's parent becomes the new node's parent.
-    ///
-    /// # Errors
-    ///
-    ///  - If the sibling node does not have a parent.
-    ///  - If the attachment would introduce a cycle.
-    pub fn add_op_before(
-        &mut self,
-        sibling: Node,
-        op: impl Into<OpType>,
-    ) -> Result<Node, HugrError> {
+    fn add_op_before(&mut self, sibling: Node, op: impl Into<OpType>) -> Result<Node, HugrError> {
         let node = self.add_op(op.into());
-        self.hugr
-            .hierarchy
-            .insert_before(node.index, sibling.index)?;
+        self.hierarchy.insert_before(node.index, sibling.index)?;
         Ok(node)
     }
 
-    /// Add a node to the graph as the next sibling of another node.
-    ///
-    /// The sibling node's parent becomes the new node's parent.
-    ///
-    /// # Errors
-    ///
-    ///  - If the sibling node does not have a parent.
-    ///  - If the attachment would introduce a cycle.
-    pub fn add_op_after(
-        &mut self,
-        sibling: Node,
-        op: impl Into<OpType>,
-    ) -> Result<Node, HugrError> {
+    fn add_op_after(&mut self, sibling: Node, op: impl Into<OpType>) -> Result<Node, HugrError> {
         let node = self.add_op(op.into());
-        self.hugr
-            .hierarchy
-            .insert_after(node.index, sibling.index)?;
+        self.hierarchy.insert_after(node.index, sibling.index)?;
         Ok(node)
     }
 
     /// Build the HUGR, returning an error if the graph is not valid.
-    pub fn finish(self) -> Result<Hugr, ValidationError> {
-        let hugr = self.hugr;
+    fn finish(self) -> Result<Hugr, ValidationError> {
+        self.validate()?;
 
-        hugr.validate()?;
-
-        Ok(hugr)
+        Ok(self)
     }
 
-    /// Immutable reference to HUGR being built.
-    #[inline]
-    pub fn hugr(&self) -> &Hugr {
-        &self.hugr
-    }
-
-    /// Replace the OpType at node and return the old OpType.
-    /// In general this invalidates the ports, which may need to be resized to
-    /// match the OpType signature.
-    pub fn replace_op(&mut self, node: Node, op: impl Into<OpType>) -> OpType {
-        let cur = self.hugr.op_types.get_mut(node.index);
+    fn replace_op(&mut self, node: Node, op: impl Into<OpType>) -> OpType {
+        let cur = self.op_types.get_mut(node.index);
         std::mem::replace(cur, op.into())
     }
 }
@@ -273,10 +287,10 @@ mod test {
     #[test]
     fn simple_function() {
         // Starts an empty builder
-        let mut builder = HugrMut::new_module();
+        let mut builder = Hugr::default();
 
         // Create the root module definition
-        let module: Node = builder.hugr().root();
+        let module: Node = builder.root();
 
         // Start a main function with two nat inputs.
         //

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 use itertools::Itertools;
 use portgraph::SecondaryMap;
 
-use crate::hugr::{Direction, HugrError, Node, ValidationError};
+use crate::hugr::{Direction, HugrError, Node};
 use crate::ops::{OpTrait, OpType};
 use crate::{Hugr, Port};
 
@@ -117,9 +117,6 @@ pub(crate) trait HugrMut: AsRef<Hugr> + AsMut<Hugr> {
     ///  - If the sibling node does not have a parent.
     ///  - If the attachment would introduce a cycle.
     fn add_op_after(&mut self, sibling: Node, op: impl Into<OpType>) -> Result<Node, HugrError>;
-
-    /// Build the HUGR, returning an error if the graph is not valid.
-    fn finish(self) -> Result<Hugr, ValidationError>;
 
     /// Replace the OpType at node and return the old OpType.
     /// In general this invalidates the ports, which may need to be resized to
@@ -243,13 +240,6 @@ impl HugrMut for Hugr {
         Ok(node)
     }
 
-    /// Build the HUGR, returning an error if the graph is not valid.
-    fn finish(self) -> Result<Hugr, ValidationError> {
-        self.validate()?;
-
-        Ok(self)
-    }
-
     fn replace_op(&mut self, node: Node, op: impl Into<OpType>) -> OpType {
         let cur = self.op_types.get_mut(node.index);
         std::mem::replace(cur, op.into())
@@ -317,7 +307,6 @@ mod test {
         }
 
         // Finish the construction and create the HUGR
-        let hugr: Result<Hugr, ValidationError> = builder.finish();
-        assert_eq!(hugr.err(), None);
+        builder.validate().unwrap();
     }
 }


### PR DESCRIPTION
This turned out significantly harder than I'd expected, I'd not realized how much parameterization over hugr/ref/hugrmut there was in the builder. But I think I got there....
* Anything returning a (new) HugrMut has to return an actual Hugr, it's the only concrete implementation of HugrMut we have.
* `Container` having both `base()` and `hugr()` methods now seems a bit strange. But one is mutable and one is not....so left as is for now (TODO's can be removed if we are happy)?
* Other things are variously parameterized over HugrMut and HugrMutRef...this was quite hard to satisfy `rustc` and I'm not sure I've got all these as consistent as I could have. The acid test will be when we have mutable views onto subregions and want to use HugrMut methods on those, but that's not in this PR!
* Using `Hugr::default()` for a new module-rooted hugr is perhaps slightly tricky, could expose something there. (This was what the old HugrMut was using.)
* Also made HugrMut be only `pub(crate)`, but that's a separate commit (1bb79d2df4c398aa4cb7778338d7c1e7878cab3c)