### PR TITLE
[refactor] Add resources to signatures

### DIFF
--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -437,9 +437,8 @@ pub trait Dataflow: Container {
         let hugr = self.hugr();
         let def_op = hugr.get_optype(function.node());
         let signature = match def_op {
-            OpType::Def(ops::Def { signature }) | OpType::Declare(ops::Declare { signature }) => {
-                signature.clone()
-            }
+            OpType::Def(ops::Def { signature, .. })
+            | OpType::Declare(ops::Declare { signature, .. }) => signature.clone(),
             _ => {
                 return Err(BuildError::UnexpectedType {
                     node: function.node(),

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -168,7 +168,7 @@ pub trait Dataflow: Container {
             input_wires,
         )?;
 
-        DFGBuilder::create_with_io(self.base(), dfg_n, input_types.into(), output_types)
+        DFGBuilder::create_with_io(self.base(), dfg_n, signature)
     }
 
     /// Return a builder for a [`crate::ops::controlflow::ControlFlowOp::CFG`] node,

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -156,16 +156,15 @@ pub trait Dataflow: Container {
     /// the DFG node.
     fn dfg_builder(
         &mut self,
-        inputs: impl IntoIterator<Item = (SimpleType, Wire)>,
-        output_types: TypeRow,
+        signature: Signature,
+        input_wires: impl IntoIterator<Item = Wire>,
     ) -> Result<DFGBuilder<&mut HugrMut>, BuildError> {
-        let (input_types, input_wires): (Vec<SimpleType>, Vec<Wire>) = inputs.into_iter().unzip();
         let (dfg_n, _) = add_op_with_wires(
             self,
             OpType::Dataflow(DataflowOp::DFG {
-                signature: Signature::new_df(input_types.clone(), output_types.clone()),
+                signature: signature.clone(),
             }),
-            input_wires,
+            input_wires.into_iter().collect(),
         )?;
 
         DFGBuilder::create_with_io(self.base(), dfg_n, signature)

--- a/src/builder/cfg.rs
+++ b/src/builder/cfg.rs
@@ -9,6 +9,7 @@ use crate::{hugr::view::HugrView, ops::ControlFlowOp, type_row, types::SimpleTyp
 
 use crate::ops::handle::NodeHandle;
 use crate::ops::{BasicBlockOp, OpType};
+use crate::types::Signature;
 
 use crate::Node;
 use crate::{hugr::HugrMut, types::TypeRow, Hugr};
@@ -225,7 +226,8 @@ impl<B: HugrMutRef> BlockBuilder<B> {
         let predicate_type = SimpleType::new_predicate(predicate_variants);
         let mut node_outputs = vec![predicate_type];
         node_outputs.extend_from_slice(&other_outputs);
-        let db = DFGBuilder::create_with_io(base, block_n, inputs, node_outputs.into())?;
+        let signature = Signature::new_df(inputs, TypeRow::from(node_outputs));
+        let db = DFGBuilder::create_with_io(base, block_n, signature)?;
         Ok(BlockBuilder::from_dfg_builder(db))
     }
 }

--- a/src/builder/conditional.rs
+++ b/src/builder/conditional.rs
@@ -176,7 +176,7 @@ impl CaseBuilder<HugrMut> {
     pub fn new(input: impl Into<TypeRow>, output: impl Into<TypeRow>) -> Result<Self, BuildError> {
         let input = input.into();
         let output = output.into();
-        let signature = Signature::new_df(input.clone(), output.clone());
+        let signature = Signature::new_df(input, output);
         let op = CaseOp {
             signature: signature.clone(),
         };

--- a/src/builder/conditional.rs
+++ b/src/builder/conditional.rs
@@ -127,7 +127,7 @@ impl<B: HugrMutRef> ConditionalBuilder<B> {
 
         self.case_nodes[case] = Some(case_node);
 
-        let dfg_builder = DFGBuilder::create_with_io(self.base(), case_node, inputs, outputs)?;
+        let dfg_builder = DFGBuilder::create_with_io(self.base(), case_node, Signature::new_df(inputs, outputs))?;
 
         Ok(CaseBuilder::from_dfg_builder(dfg_builder))
     }
@@ -175,12 +175,11 @@ impl CaseBuilder<HugrMut> {
     pub fn new(input: impl Into<TypeRow>, output: impl Into<TypeRow>) -> Result<Self, BuildError> {
         let input = input.into();
         let output = output.into();
-        let op = CaseOp {
-            signature: Signature::new_df(input.clone(), output.clone()),
-        };
+        let signature = Signature::new_df(input.clone(), output.clone());
+        let op = CaseOp { signature: signature.clone() };
         let base = HugrMut::new(op);
         let root = base.hugr().root();
-        let dfg_builder = DFGBuilder::create_with_io(base, root, input, output)?;
+        let dfg_builder = DFGBuilder::create_with_io(base, root, signature)?;
 
         Ok(CaseBuilder::from_dfg_builder(dfg_builder))
     }

--- a/src/builder/conditional.rs
+++ b/src/builder/conditional.rs
@@ -127,7 +127,8 @@ impl<B: HugrMutRef> ConditionalBuilder<B> {
 
         self.case_nodes[case] = Some(case_node);
 
-        let dfg_builder = DFGBuilder::create_with_io(self.base(), case_node, Signature::new_df(inputs, outputs))?;
+        let dfg_builder =
+            DFGBuilder::create_with_io(self.base(), case_node, Signature::new_df(inputs, outputs))?;
 
         Ok(CaseBuilder::from_dfg_builder(dfg_builder))
     }
@@ -176,7 +177,9 @@ impl CaseBuilder<HugrMut> {
         let input = input.into();
         let output = output.into();
         let signature = Signature::new_df(input.clone(), output.clone());
-        let op = CaseOp { signature: signature.clone() };
+        let op = CaseOp {
+            signature: signature.clone(),
+        };
         let base = HugrMut::new(op);
         let root = base.hugr().root();
         let dfg_builder = DFGBuilder::create_with_io(base, root, signature)?;

--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -136,9 +136,10 @@ impl FunctionBuilder<HugrMut> {
     /// # Errors
     ///
     /// Error in adding DFG child nodes.
-    pub fn new(_name: impl Into<String>, signature: Signature) -> Result<Self, BuildError> {
+    pub fn new(name: impl Into<String>, signature: Signature) -> Result<Self, BuildError> {
         let op = ops::Def {
             signature: signature.clone(),
+            name: name.into(),
         };
 
         let base = HugrMut::new(op);

--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -65,7 +65,7 @@ impl DFGBuilder<HugrMut> {
     ) -> Result<DFGBuilder<HugrMut>, BuildError> {
         let input = input.into();
         let output = output.into();
-        let signature = Signature::new_df(input.clone(), output.clone());
+        let signature = Signature::new_df(input, output);
         let dfg_op = DataflowOp::DFG {
             signature: signature.clone(),
         };

--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -25,7 +25,7 @@ impl<T: HugrMutRef> DFGBuilder<T> {
     pub(super) fn create_with_io(
         mut base: T,
         parent: Node,
-        signature: Signature
+        signature: Signature,
     ) -> Result<Self, BuildError> {
         let num_in_wires = signature.input.len();
         let num_out_wires = signature.output.len();
@@ -66,7 +66,9 @@ impl DFGBuilder<HugrMut> {
         let input = input.into();
         let output = output.into();
         let signature = Signature::new_df(input.clone(), output.clone());
-        let dfg_op = DataflowOp::DFG { signature: signature.clone() };
+        let dfg_op = DataflowOp::DFG {
+            signature: signature.clone(),
+        };
         let base = HugrMut::new(dfg_op);
         let root = base.hugr().root();
         DFGBuilder::create_with_io(base, root, signature)
@@ -135,7 +137,9 @@ impl FunctionBuilder<HugrMut> {
     ///
     /// Error in adding DFG child nodes.
     pub fn new(_name: impl Into<String>, signature: Signature) -> Result<Self, BuildError> {
-        let op = ModuleOp::Def { signature: signature.clone() };
+        let op = ModuleOp::Def {
+            signature: signature.clone(),
+        };
 
         let base = HugrMut::new(op);
         let root = base.hugr().root();
@@ -225,7 +229,8 @@ mod test {
                     vec![qb],
                 )?;
 
-                let inner_builder = func_builder.dfg_builder(vec![(NAT, int)], type_row![NAT])?;
+                let inner_builder = func_builder
+                    .dfg_builder(Signature::new_df(type_row![NAT], type_row![NAT]), [int])?;
                 let inner_id = n_identity(inner_builder)?;
 
                 func_builder.finish_with_outputs(inner_id.outputs().chain(q_out.outputs()))?
@@ -318,7 +323,8 @@ mod test {
             let noop = f_build.add_dataflow_op(LeafOp::Noop(BIT), [i1])?;
             let i1 = noop.out_wire(0);
 
-            let mut nested = f_build.dfg_builder(vec![], type_row![BIT])?;
+            let mut nested =
+                f_build.dfg_builder(Signature::new_df(type_row![], type_row![BIT]), [])?;
 
             let id = nested.add_dataflow_op(LeafOp::Noop(BIT), [i1])?;
 

--- a/src/builder/module_builder.rs
+++ b/src/builder/module_builder.rs
@@ -74,14 +74,18 @@ impl<T: HugrMutRef> ModuleBuilder<T> {
         let f_node = f_id.node();
         let signature = match self.hugr().get_optype(f_node) {
             OpType::Module(ModuleOp::Declare { signature }) => signature.clone(),
-            _ => return Err(BuildError::UnexpectedType {
-                node: f_node,
-                op_desc: "ModuleOp::Declare",
-            }),
+            _ => {
+                return Err(BuildError::UnexpectedType {
+                    node: f_node,
+                    op_desc: "ModuleOp::Declare",
+                })
+            }
         };
         self.base().replace_op(
             f_node,
-            OpType::Module(ModuleOp::Def { signature: signature.clone() })
+            OpType::Module(ModuleOp::Def {
+                signature: signature.clone(),
+            }),
         );
 
         let db = DFGBuilder::create_with_io(self.base(), f_node, signature)?;

--- a/src/builder/tail_loop.rs
+++ b/src/builder/tail_loop.rs
@@ -22,10 +22,7 @@ impl<B: HugrMutRef> TailLoopBuilder<B> {
         loop_node: Node,
         tail_loop: &ops::TailLoop,
     ) -> Result<Self, BuildError> {
-        let signature = Signature::new_df(
-            tail_loop.body_input_row(),
-            tail_loop.body_output_row(),
-        );
+        let signature = Signature::new_df(tail_loop.body_input_row(), tail_loop.body_output_row());
         let dfg_build = DFGBuilder::create_with_io(base, loop_node, signature)?;
 
         Ok(TailLoopBuilder::from_dfg_builder(dfg_build))

--- a/src/builder/tail_loop.rs
+++ b/src/builder/tail_loop.rs
@@ -3,7 +3,7 @@ use crate::ops::controlflow::TailLoopSignature;
 use crate::ops::{controlflow::ControlFlowOp, DataflowOp, OpType};
 
 use crate::hugr::view::HugrView;
-use crate::types::TypeRow;
+use crate::types::{Signature,TypeRow};
 use crate::Node;
 
 use super::build_traits::SubContainer;
@@ -23,11 +23,11 @@ impl<B: HugrMutRef> TailLoopBuilder<B> {
         loop_node: Node,
         tail_loop_sig: &TailLoopSignature,
     ) -> Result<Self, BuildError> {
+        let signature = Signature::new_df(tail_loop_sig.body_input_row(), tail_loop_sig.body_output_row());
         let dfg_build = DFGBuilder::create_with_io(
             base,
             loop_node,
-            tail_loop_sig.body_input_row(),
-            tail_loop_sig.body_output_row(),
+            signature,
         )?;
 
         Ok(TailLoopBuilder::from_dfg_builder(dfg_build))

--- a/src/builder/tail_loop.rs
+++ b/src/builder/tail_loop.rs
@@ -3,7 +3,7 @@ use crate::ops::controlflow::TailLoopSignature;
 use crate::ops::{controlflow::ControlFlowOp, DataflowOp, OpType};
 
 use crate::hugr::view::HugrView;
-use crate::types::{Signature,TypeRow};
+use crate::types::{Signature, TypeRow};
 use crate::Node;
 
 use super::build_traits::SubContainer;
@@ -23,12 +23,11 @@ impl<B: HugrMutRef> TailLoopBuilder<B> {
         loop_node: Node,
         tail_loop_sig: &TailLoopSignature,
     ) -> Result<Self, BuildError> {
-        let signature = Signature::new_df(tail_loop_sig.body_input_row(), tail_loop_sig.body_output_row());
-        let dfg_build = DFGBuilder::create_with_io(
-            base,
-            loop_node,
-            signature,
-        )?;
+        let signature = Signature::new_df(
+            tail_loop_sig.body_input_row(),
+            tail_loop_sig.body_output_row(),
+        );
+        let dfg_build = DFGBuilder::create_with_io(base, loop_node, signature)?;
 
         Ok(TailLoopBuilder::from_dfg_builder(dfg_build))
     }

--- a/src/builder/tail_loop.rs
+++ b/src/builder/tail_loop.rs
@@ -20,11 +20,11 @@ impl<B: HugrMutRef> TailLoopBuilder<B> {
     pub(super) fn create_with_io(
         base: B,
         loop_node: Node,
-        tail_loop_sig: &ops::TailLoop,
+        tail_loop: &ops::TailLoop,
     ) -> Result<Self, BuildError> {
         let signature = Signature::new_df(
-            tail_loop_sig.body_input_row(),
-            tail_loop_sig.body_output_row(),
+            tail_loop.body_input_row(),
+            tail_loop.body_output_row(),
         );
         let dfg_build = DFGBuilder::create_with_io(base, loop_node, signature)?;
 

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use portgraph::SecondaryMap;
 
 use crate::hugr::{Direction, HugrError, Node, ValidationError};
-use crate::ops::{OpTrait, OpType};
+use crate::ops::{dataflow::IOTrait, OpTrait, OpType};
 use crate::{Hugr, Port};
 
 /// A low-level builder for a HUGR.
@@ -293,25 +293,13 @@ mod test {
 
         {
             let f_in = builder
-                .add_op_with_parent(
-                    f,
-                    ops::Input {
-                        types: type_row![NAT],
-                        resources: ResourceSet::new(),
-                    },
-                )
+                .add_op_with_parent(f, ops::Input::new(type_row![NAT]))
                 .unwrap();
             let noop = builder
                 .add_op_with_parent(f, LeafOp::Noop(ClassicType::i64().into()))
                 .unwrap();
             let f_out = builder
-                .add_op_with_parent(
-                    f,
-                    ops::Output {
-                        types: type_row![NAT, NAT],
-                        resources: ResourceSet::new(),
-                    },
-                )
+                .add_op_with_parent(f, ops::Output::new(type_row![NAT, NAT]))
                 .unwrap();
 
             assert!(builder.connect(f_in, 0, noop, 0).is_ok());

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -263,6 +263,7 @@ mod test {
         hugr::HugrView,
         macros::type_row,
         ops::{DataflowOp, LeafOp, ModuleOp},
+        resource::ResourceSet,
         types::{ClassicType, Signature, SimpleType},
     };
 
@@ -296,6 +297,7 @@ mod test {
                     f,
                     DataflowOp::Input {
                         types: type_row![NAT],
+                        resources: ResourceSet::new(),
                     },
                 )
                 .unwrap();
@@ -307,6 +309,7 @@ mod test {
                     f,
                     DataflowOp::Output {
                         types: type_row![NAT, NAT],
+                        resources: ResourceSet::new(),
                     },
                 )
                 .unwrap();

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -286,6 +286,7 @@ mod test {
             .add_op_with_parent(
                 module,
                 ops::Def {
+                    name: "main".into(),
                     signature: Signature::new_df(type_row![NAT], type_row![NAT, NAT]),
                 },
             )

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use portgraph::SecondaryMap;
 
 use crate::hugr::{Direction, HugrError, Node, ValidationError};
-use crate::ops::{dataflow::IOTrait, OpTrait, OpType};
+use crate::ops::{OpTrait, OpType};
 use crate::{Hugr, Port};
 
 /// A low-level builder for a HUGR.
@@ -262,8 +262,7 @@ mod test {
     use crate::{
         hugr::HugrView,
         macros::type_row,
-        ops::{self, LeafOp},
-        resource::ResourceSet,
+        ops::{self, dataflow::IOTrait, LeafOp},
         types::{ClassicType, Signature, SimpleType},
     };
 

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -763,8 +763,8 @@ mod test {
 
     use super::*;
     use crate::hugr::HugrMut;
-    use crate::ops::{self, ConstValue, LeafOp, OpType};
     use crate::ops::dataflow::IOTrait;
+    use crate::ops::{self, ConstValue, LeafOp, OpType};
     use crate::resource::ResourceSet;
     use crate::types::{ClassicType, LinearType, Signature};
     use crate::{type_row, Node};
@@ -777,6 +777,7 @@ mod test {
     /// Returns the hugr and the node index of the definition.
     fn make_simple_hugr(copies: usize) -> (HugrMut, Node) {
         let def_op: OpType = ops::Def {
+            name: "main".into(),
             signature: Signature::new_df(type_row![B], vec![B; copies]),
         }
         .into();
@@ -853,6 +854,7 @@ mod test {
     #[test]
     fn invalid_root() {
         let declare_op: OpType = ops::Declare {
+            name: "main".into(),
             signature: Default::default(),
         }
         .into();
@@ -925,7 +927,13 @@ mod test {
         // Add a definition without children
         let def_sig = Signature::new_df(type_row![B], type_row![B, B]);
         let new_def = b
-            .add_op_with_parent(root, ops::Def { signature: def_sig })
+            .add_op_with_parent(
+                root,
+                ops::Def {
+                    signature: def_sig,
+                    name: "main".into(),
+                },
+            )
             .unwrap();
         assert_matches!(
             b.hugr().validate(),

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -765,7 +765,6 @@ mod test {
     use crate::hugr::HugrMut;
     use crate::ops::dataflow::IOTrait;
     use crate::ops::{self, ConstValue, LeafOp, OpType};
-    use crate::resource::ResourceSet;
     use crate::types::{ClassicType, LinearType, Signature};
     use crate::{type_row, Node};
 

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -763,8 +763,8 @@ mod test {
 
     use super::*;
     use crate::hugr::HugrMut;
-    use crate::ops;
-    use crate::ops::{ConstValue, LeafOp, OpType};
+    use crate::ops::{self, ConstValue, LeafOp, OpType};
+    use crate::ops::dataflow::IOTrait;
     use crate::resource::ResourceSet;
     use crate::types::{ClassicType, LinearType, Signature};
     use crate::{type_row, Node};
@@ -795,25 +795,13 @@ mod test {
     /// Returns the node indices of each of the operations.
     fn add_df_children(b: &mut HugrMut, parent: Node, copies: usize) -> (Node, Node, Node) {
         let input = b
-            .add_op_with_parent(
-                parent,
-                ops::Input {
-                    types: type_row![B],
-                    resources: ResourceSet::new(),
-                },
-            )
+            .add_op_with_parent(parent, ops::Input::new(type_row![B]))
             .unwrap();
         let copy = b
             .add_op_with_parent(parent, LeafOp::Noop(ClassicType::bit().into()))
             .unwrap();
         let output = b
-            .add_op_with_parent(
-                parent,
-                ops::Output {
-                    types: vec![B; copies].into(),
-                    resources: ResourceSet::new(),
-                },
-            )
+            .add_op_with_parent(parent, ops::Output::new(vec![B; copies].into()))
             .unwrap();
 
         b.connect(input, 0, copy, 0).unwrap();
@@ -838,13 +826,7 @@ mod test {
         let tag_type = SimpleType::Classic(ClassicType::new_simple_predicate(predicate_size));
 
         let input = b
-            .add_op_with_parent(
-                parent,
-                ops::Input {
-                    types: type_row![B],
-                    resources: ResourceSet::new(),
-                },
-            )
+            .add_op_with_parent(parent, ops::Input::new(type_row![B]))
             .unwrap();
         let tag_def = b.add_op_with_parent(b.root(), const_op).unwrap();
         let tag = b
@@ -856,13 +838,7 @@ mod test {
             )
             .unwrap();
         let output = b
-            .add_op_with_parent(
-                parent,
-                ops::Output {
-                    types: vec![tag_type, B].into(),
-                    resources: ResourceSet::new(),
-                },
-            )
+            .add_op_with_parent(parent, ops::Output::new(vec![tag_type, B].into()))
             .unwrap();
 
         b.add_ports(tag_def, Direction::Outgoing, 1);
@@ -968,13 +944,7 @@ mod test {
         // After moving the previous definition to a valid place,
         // add an input node to the module subgraph
         let new_input = b
-            .add_op_with_parent(
-                root,
-                ops::Input {
-                    types: type_row![],
-                    resources: ResourceSet::new(),
-                },
-            )
+            .add_op_with_parent(root, ops::Input::new(type_row![]))
             .unwrap();
         assert_matches!(
             b.hugr().validate(),
@@ -1002,34 +972,16 @@ mod test {
         );
 
         // Revert it back to an output, but with the wrong number of ports
-        b.replace_op(
-            output,
-            ops::Output {
-                types: type_row![B],
-                resources: ResourceSet::new(),
-            },
-        );
+        b.replace_op(output, ops::Output::new(type_row![B]));
         assert_matches!(
             b.hugr().validate(),
             Err(ValidationError::InvalidChildren { parent, source: ChildrenValidationError::IOSignatureMismatch { child, .. }, .. })
                 => {assert_eq!(parent, def); assert_eq!(child, output.index)}
         );
-        b.replace_op(
-            output,
-            ops::Output {
-                types: type_row![B, B],
-                resources: ResourceSet::new(),
-            },
-        );
+        b.replace_op(output, ops::Output::new(type_row![B, B]));
 
         // After fixing the output back, replace the copy with an output op
-        b.replace_op(
-            copy,
-            ops::Output {
-                types: type_row![B, B],
-                resources: ResourceSet::new(),
-            },
-        );
+        b.replace_op(copy, ops::Output::new(type_row![B, B]));
         assert_matches!(
             b.hugr().validate(),
             Err(ValidationError::InvalidChildren { parent, source: ChildrenValidationError::InternalIOChildren { child, .. }, .. })
@@ -1139,19 +1091,10 @@ mod test {
         let mut block_children = b.hugr().hierarchy.children(block.index);
         let block_input = block_children.next().unwrap().into();
         let block_output = block_children.next_back().unwrap().into();
-        b.replace_op(
-            block_input,
-            ops::Input {
-                types: type_row![Q],
-                resources: ResourceSet::new(),
-            },
-        );
+        b.replace_op(block_input, ops::Input::new(type_row![Q]));
         b.replace_op(
             block_output,
-            ops::Output {
-                types: vec![SimpleType::new_simple_predicate(1), Q].into(),
-                resources: ResourceSet::new(),
-            },
+            ops::Output::new(vec![SimpleType::new_simple_predicate(1), Q].into()),
         );
         assert_matches!(
             b.hugr().validate(),

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -768,6 +768,7 @@ mod test {
     use super::*;
     use crate::hugr::HugrMut;
     use crate::ops::{BasicBlockOp, ConstValue, LeafOp, ModuleOp, OpType};
+    use crate::resource::ResourceSet;
     use crate::types::{ClassicType, LinearType, Signature};
     use crate::{type_row, Node};
 

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -801,6 +801,7 @@ mod test {
                 parent,
                 DataflowOp::Input {
                     types: type_row![B],
+                    resources: ResourceSet::new(),
                 },
             )
             .unwrap();
@@ -812,6 +813,7 @@ mod test {
                 parent,
                 DataflowOp::Output {
                     types: vec![B; copies].into(),
+                    resources: ResourceSet::new(),
                 },
             )
             .unwrap();
@@ -842,6 +844,7 @@ mod test {
                 parent,
                 DataflowOp::Input {
                     types: type_row![B],
+                    resources: ResourceSet::new(),
                 },
             )
             .unwrap();
@@ -859,6 +862,7 @@ mod test {
                 parent,
                 DataflowOp::Output {
                     types: vec![tag_type, B].into(),
+                    resources: ResourceSet::new(),
                 },
             )
             .unwrap();
@@ -966,7 +970,13 @@ mod test {
         // After moving the previous definition to a valid place,
         // add an input node to the module subgraph
         let new_input = b
-            .add_op_with_parent(root, DataflowOp::Input { types: type_row![] })
+            .add_op_with_parent(
+                root,
+                DataflowOp::Input {
+                    types: type_row![],
+                    resources: ResourceSet::new(),
+                },
+            )
             .unwrap();
         assert_matches!(
             b.hugr().validate(),
@@ -998,6 +1008,7 @@ mod test {
             output,
             DataflowOp::Output {
                 types: type_row![B],
+                resources: ResourceSet::new(),
             },
         );
         assert_matches!(
@@ -1009,6 +1020,7 @@ mod test {
             output,
             DataflowOp::Output {
                 types: type_row![B, B],
+                resources: ResourceSet::new(),
             },
         );
 
@@ -1017,6 +1029,7 @@ mod test {
             copy,
             DataflowOp::Output {
                 types: type_row![B, B],
+                resources: ResourceSet::new(),
             },
         );
         assert_matches!(
@@ -1132,12 +1145,14 @@ mod test {
             block_input,
             DataflowOp::Input {
                 types: type_row![Q],
+                resources: ResourceSet::new(),
             },
         );
         b.replace_op(
             block_output,
             DataflowOp::Output {
                 types: vec![SimpleType::new_simple_predicate(1), Q].into(),
+                resources: ResourceSet::new(),
             },
         );
         assert_matches!(

--- a/src/ops/dataflow.rs
+++ b/src/ops/dataflow.rs
@@ -27,7 +27,8 @@ pub(super) trait DataflowOpTrait {
     }
 }
 
-pub(crate) trait IOTrait {
+/// Helpers to construct input and output nodes
+pub trait IOTrait {
     /// Construct a new I/O node from a type row with no resource requirements
     fn new(types: TypeRow) -> Self;
     /// Helper method to add resource requirements to an I/O node

--- a/src/ops/dataflow.rs
+++ b/src/ops/dataflow.rs
@@ -27,6 +27,13 @@ pub(super) trait DataflowOpTrait {
     }
 }
 
+pub(crate) trait IOTrait {
+    /// Construct a new I/O node from a type row with no resource requirements
+    fn new(types: TypeRow) -> Self;
+    /// Helper method to add resource requirements to an I/O node
+    fn with_resources(self, rs: ResourceSet) -> Self;
+}
+
 /// An input node.
 /// The outputs of this node are the inputs to the function.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -39,6 +46,20 @@ pub struct Input {
 
 impl_op_name!(Input);
 
+impl IOTrait for Input {
+    fn new(types: TypeRow) -> Self {
+        Input {
+            types,
+            resources: ResourceSet::new(),
+        }
+    }
+
+    fn with_resources(mut self, resources: ResourceSet) -> Self {
+        self.resources = resources;
+        self
+    }
+}
+
 /// An output node. The inputs are the outputs of the function.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Output {
@@ -49,6 +70,20 @@ pub struct Output {
 }
 
 impl_op_name!(Output);
+
+impl IOTrait for Output {
+    fn new(types: TypeRow) -> Self {
+        Output {
+            types,
+            resources: ResourceSet::new(),
+        }
+    }
+
+    fn with_resources(mut self, resources: ResourceSet) -> Self {
+        self.resources = resources;
+        self
+    }
+}
 
 impl DataflowOpTrait for Input {
     fn description(&self) -> &str {

--- a/src/ops/module.rs
+++ b/src/ops/module.rs
@@ -27,6 +27,8 @@ impl OpTrait for Module {
 /// Children nodes are the body of the definition.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Def {
+    /// Name of function
+    pub name: String,
     /// Signature of the function
     pub signature: Signature,
 }
@@ -51,6 +53,8 @@ impl OpTrait for Def {
 /// External function declaration, linked at runtime.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Declare {
+    /// Name of function
+    pub name: String,
     /// Signature of the function
     pub signature: Signature,
 }

--- a/src/ops/validate.rs
+++ b/src/ops/validate.rs
@@ -13,7 +13,6 @@ use thiserror::Error;
 use crate::types::{SimpleType, TypeRow};
 
 use super::{impl_validate_op, tag::OpTag, BasicBlock, OpTrait, OpType, ValidateOp};
-use crate::ops::dataflow::IOTrait;
 
 /// A set of property flags required for an operation.
 #[non_exhaustive]
@@ -452,8 +451,8 @@ fn validate_cfg_edge(edge: ChildrenEdgeData) -> Result<(), EdgeValidationError> 
 mod test {
     use crate::ops;
     use crate::{
+        ops::dataflow::IOTrait,
         ops::LeafOp,
-        resource::ResourceSet,
         type_row,
         types::{ClassicType, SimpleType},
     };

--- a/src/ops/validate.rs
+++ b/src/ops/validate.rs
@@ -12,6 +12,7 @@ use thiserror::Error;
 
 use crate::types::{SimpleType, TypeRow};
 
+use crate::ops::dataflow::IOTrait;
 use super::{impl_validate_op, tag::OpTag, BasicBlock, OpTrait, OpType, ValidateOp};
 
 /// A set of property flags required for an operation.
@@ -467,16 +468,8 @@ mod test {
         let in_types = type_row![B];
         let out_types = type_row![B, B];
 
-        let input_node: OpType = ops::Input {
-            types: in_types.clone(),
-            resources: ResourceSet::new(),
-        }
-        .into();
-        let output_node = ops::Output {
-            types: out_types.clone(),
-            resources: ResourceSet::new(),
-        }
-        .into();
+        let input_node: OpType = ops::Input::new(in_types.clone()).into();
+        let output_node = ops::Output::new(out_types.clone()).into();
         let leaf_node = LeafOp::Noop(ClassicType::bit().into()).into();
 
         // Well-formed dataflow sibling nodes. Check the input and output node signatures.

--- a/src/ops/validate.rs
+++ b/src/ops/validate.rs
@@ -498,6 +498,7 @@ mod test {
 
     use crate::{
         ops::LeafOp,
+        resource::ResourceSet,
         type_row,
         types::{ClassicType, SimpleType},
     };
@@ -513,9 +514,11 @@ mod test {
 
         let input_node = OpType::Dataflow(DataflowOp::Input {
             types: in_types.clone(),
+            resources: ResourceSet::new(),
         });
         let output_node = OpType::Dataflow(DataflowOp::Output {
             types: out_types.clone(),
+            resources: ResourceSet::new(),
         });
         let leaf_node = OpType::Dataflow(DataflowOp::Leaf {
             op: LeafOp::Noop(ClassicType::bit().into()),

--- a/src/ops/validate.rs
+++ b/src/ops/validate.rs
@@ -12,8 +12,8 @@ use thiserror::Error;
 
 use crate::types::{SimpleType, TypeRow};
 
-use crate::ops::dataflow::IOTrait;
 use super::{impl_validate_op, tag::OpTag, BasicBlock, OpTrait, OpType, ValidateOp};
+use crate::ops::dataflow::IOTrait;
 
 /// A set of property flags required for an operation.
 #[non_exhaustive]

--- a/src/replacement/simple_replace.rs
+++ b/src/replacement/simple_replace.rs
@@ -101,8 +101,10 @@ mod test {
                 vec![qb2],
             )?;
 
-            let mut inner_builder =
-                func_builder.dfg_builder(vec![(QB, qb0), (QB, qb1)], type_row![QB, QB])?;
+            let mut inner_builder = func_builder.dfg_builder(
+                Signature::new_df(type_row![QB, QB], type_row![QB, QB]),
+                [qb0, qb1],
+            )?;
             let inner_graph = {
                 let [wire0, wire1] = inner_builder.input_wires_arr();
                 let wire2 = inner_builder.add_dataflow_op(

--- a/src/types.rs
+++ b/src/types.rs
@@ -58,6 +58,10 @@ pub struct Signature {
     pub output: TypeRow,
     /// Possible constE input (for call / load-constant).
     pub const_input: TypeRow,
+    /// The resource requirements of all the inputs
+    pub input_resources: ResourceSet,
+    /// The resource requirements of all the outputs
+    pub output_resources: ResourceSet,
 }
 
 #[cfg_attr(feature = "pyo3", pymethods)]
@@ -142,6 +146,8 @@ impl Signature {
             input: input.into(),
             output: output.into(),
             const_input: const_input.into(),
+            input_resources: ResourceSet::new(),
+            output_resources: ResourceSet::new(),
         }
     }
 


### PR DESCRIPTION
Resource requirements for a dataflow node can be represented by a pair of the resources requirements of the inputs and the resource requirements of the outputs (see the very bottom of the diff).

Inside of a dataflow node, the input requirements are uniformly associated with the wires coming out of the source (Input) node, and the output requirements are associated with the sinks in the Output node

In this PR:
* Add input & output resources to signatures
* Change function interfaces to deal with signatures when possible, so that resources aren't forgotten about
* Include resource requirements in Input/Output nodes, so that their signatures can be computed