### PR TITLE
Allow Def in any Dataflow container

### DIFF
--- a/src/algorithm/nest_cfgs.rs
+++ b/src/algorithm/nest_cfgs.rs
@@ -434,7 +434,7 @@ pub(crate) mod test {
         let pred_const = module_builder.add_constant(ConstValue::simple_predicate(0, 2))?; // Nothing here cares which
         let const_unit = module_builder.add_constant(ConstValue::simple_unary_predicate())?;
 
-        let mut func_builder = module_builder.define_function(&main)?;
+        let mut func_builder = module_builder.define_declaration(&main)?;
         let [int] = func_builder.input_wires_arr();
 
         let mut cfg_builder = func_builder.cfg_builder(vec![(NAT, int)], type_row![NAT])?;
@@ -486,7 +486,7 @@ pub(crate) mod test {
         let pred_const = module_builder.add_constant(ConstValue::simple_predicate(0, 2))?; // Nothing here cares which
         let const_unit = module_builder.add_constant(ConstValue::simple_unary_predicate())?;
 
-        let mut func_builder = module_builder.define_function(&main)?;
+        let mut func_builder = module_builder.define_declaration(&main)?;
         let [int] = func_builder.input_wires_arr();
 
         let mut cfg_builder = func_builder.cfg_builder(vec![(NAT, int)], type_row![NAT])?;
@@ -687,7 +687,7 @@ pub(crate) mod test {
         let pred_const = module_builder.add_constant(ConstValue::simple_predicate(0, 2))?; // Nothing here cares which
         let const_unit = module_builder.add_constant(ConstValue::simple_unary_predicate())?;
 
-        let mut func_builder = module_builder.define_function(&main)?;
+        let mut func_builder = module_builder.define_declaration(&main)?;
         let [int] = func_builder.input_wires_arr();
 
         let mut cfg_builder = func_builder.cfg_builder(vec![(NAT, int)], type_row![NAT])?;

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -76,7 +76,7 @@ mod test {
     use crate::Hugr;
 
     use super::handle::BuildHandle;
-    use super::{BuildError, FuncID, FunctionBuilder, ModuleBuilder};
+    use super::{BuildError, FuncID, FunctionBuilder, ModuleBuilder, Container};
     use super::{DataflowSubContainer, HugrBuilder};
 
     pub(super) const NAT: SimpleType = SimpleType::Classic(ClassicType::i64());
@@ -97,7 +97,7 @@ mod test {
         f: impl FnOnce(FunctionBuilder<&mut Hugr>) -> Result<BuildHandle<FuncID<true>>, BuildError>,
     ) -> Result<Hugr, BuildError> {
         let mut module_builder = ModuleBuilder::new();
-        let f_builder = module_builder.declare_and_def("main", signature)?;
+        let f_builder = module_builder.define_function("main", signature)?;
 
         f(f_builder)?;
         Ok(module_builder.finish_hugr()?)

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -76,7 +76,7 @@ mod test {
     use crate::Hugr;
 
     use super::handle::BuildHandle;
-    use super::{BuildError, FuncID, FunctionBuilder, ModuleBuilder, Container};
+    use super::{BuildError, Container, FuncID, FunctionBuilder, ModuleBuilder};
     use super::{DataflowSubContainer, HugrBuilder};
 
     pub(super) const NAT: SimpleType = SimpleType::Classic(ClassicType::i64());

--- a/src/builder/cfg.rs
+++ b/src/builder/cfg.rs
@@ -288,10 +288,9 @@ mod test {
     fn basic_module_cfg() -> Result<(), BuildError> {
         let build_result = {
             let mut module_builder = ModuleBuilder::new();
-            let main =
-                module_builder.declare("main", Signature::new_df(vec![NAT], type_row![NAT]))?;
+            let mut func_builder = module_builder
+                .define_function("main", Signature::new_df(vec![NAT], type_row![NAT]))?;
             let _f_id = {
-                let mut func_builder = module_builder.define_function(&main)?;
                 let [int] = func_builder.input_wires_arr();
 
                 let cfg_id = {

--- a/src/builder/conditional.rs
+++ b/src/builder/conditional.rs
@@ -221,12 +221,10 @@ mod test {
     fn basic_conditional_module() -> Result<(), BuildError> {
         let build_result: Result<Hugr, BuildError> = {
             let mut module_builder = ModuleBuilder::new();
-            let main = module_builder
-                .declare("main", Signature::new_df(type_row![NAT], type_row![NAT]))?;
-            let tru_const = module_builder.add_constant(ConstValue::true_val())?;
+            let mut fbuild = module_builder
+                .define_function("main", Signature::new_df(type_row![NAT], type_row![NAT]))?;
+            let tru_const = fbuild.add_constant(ConstValue::true_val())?;
             let _fdef = {
-                let mut fbuild = module_builder.define_function(&main)?;
-
                 let const_wire = fbuild.load_const(&tru_const)?;
                 let [int] = fbuild.input_wires_arr();
                 let conditional_id = {

--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -209,7 +209,7 @@ mod test {
             let mut module_builder = ModuleBuilder::new();
 
             let _f_id = {
-                let mut func_builder = module_builder.declare_and_def(
+                let mut func_builder = module_builder.define_function(
                     "main",
                     Signature::new_df(type_row![NAT, QB], type_row![NAT, QB]),
                 )?;
@@ -240,7 +240,7 @@ mod test {
         let build_result = {
             let mut module_builder = ModuleBuilder::new();
 
-            let f_build = module_builder.declare_and_def(
+            let f_build = module_builder.define_function(
                 "main",
                 Signature::new_df(type_row![BIT], type_row![BIT, BIT]),
             )?;
@@ -291,7 +291,7 @@ mod test {
             let mut module_builder = ModuleBuilder::new();
 
             let f_build = module_builder
-                .declare_and_def("main", Signature::new_df(type_row![QB], type_row![QB, QB]))?;
+                .define_function("main", Signature::new_df(type_row![QB], type_row![QB, QB]))?;
 
             let [q1] = f_build.input_wires_arr();
             f_build.finish_with_outputs([q1, q1])?;

--- a/src/builder/module_builder.rs
+++ b/src/builder/module_builder.rs
@@ -142,6 +142,11 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
         name: impl Into<SmolStr>,
         typ: SimpleType,
     ) -> Result<AliasID<true>, BuildError> {
+        // TODO: add AliasDef in other containers
+        // This is currently tricky as they are not connected to anything so do
+        // not appear in topological traversals.
+        // Could be fixed by removing single-entry requirement and sorting from
+        // every 0-input node.
         let name: SmolStr = name.into();
         let linear = typ.is_linear();
         let node = self.add_child_op(ops::AliasDef {

--- a/src/builder/module_builder.rs
+++ b/src/builder/module_builder.rs
@@ -61,15 +61,14 @@ impl HugrBuilder for ModuleBuilder<Hugr> {
 }
 
 impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
-    /// Generate a builder for defining a function body graph.
-    ///
-    /// Replaces a [`OpType::Declare`] node as specified by `f_id`
-    /// with a [`OpType::Def`] node.
+    /// Replace a [`ops::Declare`] with [`ops::Def`] and return a builder for
+    /// the defining graph.
     ///
     /// # Errors
     ///
-    /// This function will return an error if there is an error in adding the node.
-    pub fn define_function(
+    /// This function will return an error if there is an error in adding the
+    /// [`OpType::Def`] node.
+    pub fn define_declaration(
         &mut self,
         f_id: &FuncID<false>,
     ) -> Result<FunctionBuilder<&mut Hugr>, BuildError> {
@@ -94,22 +93,6 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
 
         let db = DFGBuilder::create_with_io(self.hugr_mut(), f_node, signature)?;
         Ok(FunctionBuilder::from_dfg_builder(db))
-    }
-
-    /// Add a [`OpType::Def`] node and returns a builder to define the function
-    /// body graph.
-    ///
-    /// # Errors
-    ///
-    /// This function will return an error if there is an error in adding the
-    /// [`OpType::Def`] node.
-    pub fn declare_and_def(
-        &mut self,
-        name: impl Into<String>,
-        signature: Signature,
-    ) -> Result<FunctionBuilder<&mut Hugr>, BuildError> {
-        let fid = self.declare(name, signature)?;
-        self.define_function(&fid)
     }
 
     /// Declare a function with `signature` and return a handle to the declaration.
@@ -197,7 +180,7 @@ mod test {
             let f_id = module_builder
                 .declare("main", Signature::new_df(type_row![NAT], type_row![NAT]))?;
 
-            let mut f_build = module_builder.define_function(&f_id)?;
+            let mut f_build = module_builder.define_declaration(&f_id)?;
             let call = f_build.call(&f_id, f_build.input_wires())?;
 
             f_build.finish_with_outputs(call.outputs())?;
@@ -214,7 +197,7 @@ mod test {
 
             let qubit_state_type = module_builder.add_alias_declare("qubit_state", true)?;
 
-            let f_build = module_builder.declare_and_def(
+            let f_build = module_builder.define_function(
                 "main",
                 Signature::new_df(
                     vec![qubit_state_type.get_alias_type()],
@@ -222,6 +205,27 @@ mod test {
                 ),
             )?;
             n_identity(f_build)?;
+            module_builder.finish_hugr()
+        };
+        assert_matches!(build_result, Ok(_));
+        Ok(())
+    }
+
+    #[test]
+    fn local_def() -> Result<(), BuildError> {
+        let build_result = {
+            let mut module_builder = ModuleBuilder::new();
+
+            let mut f_build = module_builder
+                .define_function("main", Signature::new_df(type_row![NAT], type_row![NAT]))?;
+            let local_build = f_build
+                .define_function("local", Signature::new_df(type_row![NAT], type_row![NAT]))?;
+            let [wire] = local_build.input_wires_arr();
+            let f_id = local_build.finish_with_outputs([wire])?;
+
+            let call = f_build.call(f_id.handle(), f_build.input_wires())?;
+
+            f_build.finish_with_outputs(call.outputs())?;
             module_builder.finish_hugr()
         };
         assert_matches!(build_result, Ok(_));

--- a/src/builder/tail_loop.rs
+++ b/src/builder/tail_loop.rs
@@ -124,20 +124,15 @@ mod test {
     fn loop_with_conditional() -> Result<(), BuildError> {
         let build_result = {
             let mut module_builder = ModuleBuilder::new();
-            let main = module_builder
-                .declare("main", Signature::new_df(type_row![BIT], type_row![NAT]))?;
-
-            let s2 = module_builder.add_constant(ConstValue::i64(2))?;
-            let tru_const = module_builder.add_constant(ConstValue::true_val())?;
-
+            let mut fbuild = module_builder
+                .define_function("main", Signature::new_df(type_row![BIT], type_row![NAT]))?;
             let _fdef = {
-                let mut fbuild = module_builder.define_function(&main)?;
                 let [b1] = fbuild.input_wires_arr();
                 let loop_id = {
                     let mut loop_b =
                         fbuild.tail_loop_builder(vec![(BIT, b1)], vec![], type_row![NAT])?;
                     let signature = loop_b.loop_signature()?.clone();
-                    let const_wire = loop_b.load_const(&tru_const)?;
+                    let const_wire = loop_b.add_load_const(ConstValue::true_val())?;
                     let [b1] = loop_b.input_wires_arr();
                     let conditional_id = {
                         let predicate_inputs = vec![type_row![]; 2];
@@ -157,7 +152,7 @@ mod test {
                         let mut branch_1 = conditional_b.case_builder(1)?;
                         let [_b1] = branch_1.input_wires_arr();
 
-                        let wire = branch_1.load_const(&s2)?;
+                        let wire = branch_1.add_load_const(ConstValue::i64(2))?;
                         let break_wire = branch_1.make_break(signature, [wire])?;
                         branch_1.finish_with_outputs([break_wire])?;
 

--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -176,7 +176,7 @@ pub mod test {
 
     use super::*;
     use crate::{
-        builder::{Dataflow, DataflowSubContainer, HugrBuilder, ModuleBuilder},
+        builder::{Dataflow, DataflowSubContainer, HugrBuilder, ModuleBuilder, Container},
         ops::LeafOp,
         types::{ClassicType, LinearType, Signature, SimpleType},
     };
@@ -254,11 +254,10 @@ pub mod test {
         let hugr = {
             let mut module_builder = ModuleBuilder::new();
             let t_row = vec![SimpleType::new_sum(vec![NAT, QB])];
-            let f_id = module_builder
-                .declare("main", Signature::new_df(t_row.clone(), t_row))
+            let mut f_build = module_builder
+                .define_function("main", Signature::new_df(t_row.clone(), t_row))
                 .unwrap();
 
-            let mut f_build = module_builder.define_function(&f_id).unwrap();
             let outputs = f_build
                 .input_wires()
                 .map(|in_wire| {

--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -176,7 +176,7 @@ pub mod test {
 
     use super::*;
     use crate::{
-        builder::{Dataflow, DataflowSubContainer, HugrBuilder, ModuleBuilder, Container},
+        builder::{Container, Dataflow, DataflowSubContainer, HugrBuilder, ModuleBuilder},
         ops::LeafOp,
         types::{ClassicType, LinearType, Signature, SimpleType},
     };

--- a/src/ops/handle.rs
+++ b/src/ops/handle.rs
@@ -145,7 +145,7 @@ macro_rules! impl_nodehandle {
     };
 }
 
-impl_nodehandle!(DataflowOpID, OpTag::DataflowOp);
+impl_nodehandle!(DataflowOpID, OpTag::DataflowChild);
 impl_nodehandle!(ConditionalID, OpTag::Conditional);
 impl_nodehandle!(CaseID, OpTag::Case);
 impl_nodehandle!(DfgID, OpTag::Dfg);

--- a/src/ops/tag.rs
+++ b/src/ops/tag.rs
@@ -60,6 +60,9 @@ pub enum OpTag {
     BasicBlock,
     /// A control flow exit node.
     BasicBlockExit,
+
+    /// Can be a child to any container node.
+    ChildAnywhere,
 }
 
 impl OpTag {
@@ -79,14 +82,14 @@ impl OpTag {
             OpTag::DataflowOp => &[OpTag::Any],
             OpTag::Input => &[OpTag::DataflowOp],
             OpTag::Output => &[OpTag::DataflowOp],
-            OpTag::Function => &[OpTag::ModuleOp, OpTag::DataflowOp],
+            OpTag::Function => &[OpTag::ModuleOp],
             OpTag::Alias => &[OpTag::ModuleOp],
-            OpTag::Def => &[OpTag::Function],
+            OpTag::Def => &[OpTag::Function, OpTag::ChildAnywhere],
             OpTag::BasicBlock => &[OpTag::Any],
             OpTag::BasicBlockExit => &[OpTag::BasicBlock],
             OpTag::Case => &[OpTag::Any],
             OpTag::ModuleRoot => &[OpTag::Any],
-            OpTag::Const => &[OpTag::ModuleOp, OpTag::DataflowOp],
+            OpTag::Const => &[OpTag::ModuleOp, OpTag::ChildAnywhere],
             OpTag::Dfg => &[OpTag::DataflowOp],
             OpTag::Cfg => &[OpTag::DataflowOp],
             OpTag::ConstInput => &[OpTag::DataflowOp],
@@ -95,6 +98,7 @@ impl OpTag {
             OpTag::FnCall => &[OpTag::ConstInput],
             OpTag::LoadConst => &[OpTag::ConstInput],
             OpTag::Leaf => &[OpTag::DataflowOp],
+            OpTag::ChildAnywhere => &[OpTag::DataflowOp],
         }
     }
 
@@ -123,6 +127,7 @@ impl OpTag {
             OpTag::LoadConst => "Constant load operation",
             OpTag::Leaf => "Leaf operation",
             OpTag::ConstInput => "Dataflow operations that take a Const input.",
+            OpTag::ChildAnywhere => "Can be a child to any container node.",
         }
     }
 

--- a/src/ops/tag.rs
+++ b/src/ops/tag.rs
@@ -45,6 +45,8 @@ pub enum OpTag {
     FnCall,
     /// A constant load operation.
     LoadConst,
+    /// Operations taking const inputs.
+    ConstInput,
     /// A tail-recursive loop.
     TailLoop,
     /// A conditional operation.
@@ -77,21 +79,21 @@ impl OpTag {
             OpTag::DataflowOp => &[OpTag::Any],
             OpTag::Input => &[OpTag::DataflowOp],
             OpTag::Output => &[OpTag::DataflowOp],
-            OpTag::Function => &[OpTag::ModuleOp],
+            OpTag::Function => &[OpTag::ModuleOp, OpTag::DataflowOp],
             OpTag::Alias => &[OpTag::ModuleOp],
             OpTag::Def => &[OpTag::Function],
             OpTag::BasicBlock => &[OpTag::Any],
             OpTag::BasicBlockExit => &[OpTag::BasicBlock],
             OpTag::Case => &[OpTag::Any],
             OpTag::ModuleRoot => &[OpTag::Any],
-            // Technically, this should be ModuleOp, but we will allow it outside modules soon.
             OpTag::Const => &[OpTag::ModuleOp, OpTag::DataflowOp],
             OpTag::Dfg => &[OpTag::DataflowOp],
             OpTag::Cfg => &[OpTag::DataflowOp],
+            OpTag::ConstInput => &[OpTag::DataflowOp],
             OpTag::TailLoop => &[OpTag::DataflowOp],
             OpTag::Conditional => &[OpTag::DataflowOp],
-            OpTag::FnCall => &[OpTag::DataflowOp],
-            OpTag::LoadConst => &[OpTag::DataflowOp],
+            OpTag::FnCall => &[OpTag::ConstInput],
+            OpTag::LoadConst => &[OpTag::ConstInput],
             OpTag::Leaf => &[OpTag::DataflowOp],
         }
     }
@@ -120,6 +122,7 @@ impl OpTag {
             OpTag::FnCall => "Function call",
             OpTag::LoadConst => "Constant load operation",
             OpTag::Leaf => "Leaf operation",
+            OpTag::ConstInput => "Dataflow operations that take a Const input.",
         }
     }
 

--- a/src/ops/tag.rs
+++ b/src/ops/tag.rs
@@ -31,8 +31,8 @@ pub enum OpTag {
     /// A constant declaration.
     Const,
 
-    /// Any dataflow operation.
-    DataflowOp,
+    /// Node in a Dataflow Sibling Graph.
+    DataflowChild,
     /// A nested data-flow operation.
     Dfg,
     /// A nested control-flow operation.
@@ -60,9 +60,6 @@ pub enum OpTag {
     BasicBlock,
     /// A control flow exit node.
     BasicBlockExit,
-
-    /// Can be a child to any container node.
-    ChildAnywhere,
 }
 
 impl OpTag {
@@ -79,26 +76,25 @@ impl OpTag {
             OpTag::Any => &[],
             OpTag::None => &[OpTag::Any],
             OpTag::ModuleOp => &[OpTag::Any],
-            OpTag::DataflowOp => &[OpTag::Any],
-            OpTag::Input => &[OpTag::DataflowOp],
-            OpTag::Output => &[OpTag::DataflowOp],
+            OpTag::DataflowChild => &[OpTag::Any],
+            OpTag::Input => &[OpTag::DataflowChild],
+            OpTag::Output => &[OpTag::DataflowChild],
             OpTag::Function => &[OpTag::ModuleOp],
             OpTag::Alias => &[OpTag::ModuleOp],
-            OpTag::Def => &[OpTag::Function, OpTag::ChildAnywhere],
+            OpTag::Def => &[OpTag::Function, OpTag::DataflowChild],
             OpTag::BasicBlock => &[OpTag::Any],
             OpTag::BasicBlockExit => &[OpTag::BasicBlock],
             OpTag::Case => &[OpTag::Any],
             OpTag::ModuleRoot => &[OpTag::Any],
-            OpTag::Const => &[OpTag::ModuleOp, OpTag::ChildAnywhere],
-            OpTag::Dfg => &[OpTag::DataflowOp],
-            OpTag::Cfg => &[OpTag::DataflowOp],
-            OpTag::ConstInput => &[OpTag::DataflowOp],
-            OpTag::TailLoop => &[OpTag::DataflowOp],
-            OpTag::Conditional => &[OpTag::DataflowOp],
+            OpTag::Const => &[OpTag::ModuleOp, OpTag::DataflowChild],
+            OpTag::Dfg => &[OpTag::DataflowChild],
+            OpTag::Cfg => &[OpTag::DataflowChild],
+            OpTag::ConstInput => &[OpTag::DataflowChild],
+            OpTag::TailLoop => &[OpTag::DataflowChild],
+            OpTag::Conditional => &[OpTag::DataflowChild],
             OpTag::FnCall => &[OpTag::ConstInput],
             OpTag::LoadConst => &[OpTag::ConstInput],
-            OpTag::Leaf => &[OpTag::DataflowOp],
-            OpTag::ChildAnywhere => &[OpTag::DataflowOp],
+            OpTag::Leaf => &[OpTag::DataflowChild],
         }
     }
 
@@ -108,7 +104,7 @@ impl OpTag {
             OpTag::Any => "Any",
             OpTag::None => "None",
             OpTag::ModuleOp => "Module operations",
-            OpTag::DataflowOp => "Dataflow operations",
+            OpTag::DataflowChild => "Node in a Dataflow Sibling Graph",
             OpTag::Input => "Input node",
             OpTag::Output => "Output node",
             OpTag::Def => "Function definition",
@@ -127,7 +123,6 @@ impl OpTag {
             OpTag::LoadConst => "Constant load operation",
             OpTag::Leaf => "Leaf operation",
             OpTag::ConstInput => "Dataflow operations that take a Const input.",
-            OpTag::ChildAnywhere => "Can be a child to any container node.",
         }
     }
 
@@ -167,17 +162,17 @@ mod test {
         assert!(OpTag::Any.contains(OpTag::Any));
         assert!(OpTag::None.contains(OpTag::None));
         assert!(OpTag::ModuleOp.contains(OpTag::ModuleOp));
-        assert!(OpTag::DataflowOp.contains(OpTag::DataflowOp));
+        assert!(OpTag::DataflowChild.contains(OpTag::DataflowChild));
         assert!(OpTag::BasicBlock.contains(OpTag::BasicBlock));
 
         assert!(OpTag::Any.contains(OpTag::None));
         assert!(OpTag::Any.contains(OpTag::ModuleOp));
-        assert!(OpTag::Any.contains(OpTag::DataflowOp));
+        assert!(OpTag::Any.contains(OpTag::DataflowChild));
         assert!(OpTag::Any.contains(OpTag::BasicBlock));
 
         assert!(!OpTag::None.contains(OpTag::Any));
         assert!(!OpTag::None.contains(OpTag::ModuleOp));
-        assert!(!OpTag::None.contains(OpTag::DataflowOp));
+        assert!(!OpTag::None.contains(OpTag::DataflowChild));
         assert!(!OpTag::None.contains(OpTag::BasicBlock));
     }
 }

--- a/src/ops/validate.rs
+++ b/src/ops/validate.rs
@@ -84,7 +84,7 @@ impl ValidateOp for super::Module {
 impl ValidateOp for super::Def {
     fn validity_flags(&self) -> OpValidityFlags {
         OpValidityFlags {
-            allowed_children: OpTag::DataflowOp,
+            allowed_children: OpTag::DataflowChild,
             allowed_first_child: OpTag::Input,
             allowed_second_child: OpTag::Output,
             requires_children: true,
@@ -109,7 +109,7 @@ impl ValidateOp for super::Def {
 impl ValidateOp for super::DFG {
     fn validity_flags(&self) -> OpValidityFlags {
         OpValidityFlags {
-            allowed_children: OpTag::DataflowOp,
+            allowed_children: OpTag::DataflowChild,
             allowed_first_child: OpTag::Input,
             allowed_second_child: OpTag::Output,
             requires_children: true,
@@ -181,7 +181,7 @@ impl ValidateOp for super::Conditional {
 impl ValidateOp for super::TailLoop {
     fn validity_flags(&self) -> OpValidityFlags {
         OpValidityFlags {
-            allowed_children: OpTag::DataflowOp,
+            allowed_children: OpTag::DataflowChild,
             allowed_first_child: OpTag::Input,
             allowed_second_child: OpTag::Output,
             requires_children: true,
@@ -332,7 +332,7 @@ impl ValidateOp for BasicBlock {
             BasicBlock::Block {
                 predicate_variants, ..
             } => OpValidityFlags {
-                allowed_children: OpTag::DataflowOp,
+                allowed_children: OpTag::DataflowChild,
                 allowed_first_child: OpTag::Input,
                 allowed_second_child: OpTag::Output,
                 requires_children: true,
@@ -370,7 +370,7 @@ impl ValidateOp for super::Case {
     /// Returns the set of allowed parent operation types.
     fn validity_flags(&self) -> OpValidityFlags {
         OpValidityFlags {
-            allowed_children: OpTag::DataflowOp,
+            allowed_children: OpTag::DataflowChild,
             allowed_first_child: OpTag::Input,
             allowed_second_child: OpTag::Output,
             requires_children: true,

--- a/src/replacement/simple_replace.rs
+++ b/src/replacement/simple_replace.rs
@@ -64,7 +64,7 @@ mod test {
 
     use crate::builder::{
         BuildError, DFGBuilder, Dataflow, DataflowHugr, DataflowSubContainer, HugrBuilder,
-        ModuleBuilder,
+        ModuleBuilder, Container,
     };
     use crate::hugr::view::HugrView;
     use crate::hugr::{Hugr, Node};
@@ -89,7 +89,7 @@ mod test {
     fn make_hugr() -> Result<Hugr, BuildError> {
         let mut module_builder = ModuleBuilder::new();
         let _f_id = {
-            let mut func_builder = module_builder.declare_and_def(
+            let mut func_builder = module_builder.define_function(
                 "main",
                 Signature::new_df(type_row![QB, QB, QB], type_row![QB, QB, QB]),
             )?;

--- a/src/replacement/simple_replace.rs
+++ b/src/replacement/simple_replace.rs
@@ -63,8 +63,8 @@ mod test {
     use portgraph::Direction;
 
     use crate::builder::{
-        BuildError, DFGBuilder, Dataflow, DataflowHugr, DataflowSubContainer, HugrBuilder,
-        ModuleBuilder, Container,
+        BuildError, Container, DFGBuilder, Dataflow, DataflowHugr, DataflowSubContainer,
+        HugrBuilder, ModuleBuilder,
     };
     use crate::hugr::view::HugrView;
     use crate::hugr::{Hugr, Node};


### PR DESCRIPTION
The spec states _any_ container, however here we restrict to Dataflow containers as usage in other containers is not useful.

Builder methods are renamed for clarity (define function adds a Def from scratch now)

Closes #149