### PR TITLE
Region views of a portgraph

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/lib.rs"
 
 [dependencies]
 thiserror = "1.0.28"
-portgraph = { version = "0.6.0", features = ["serde"] }
+portgraph = { version = "0.6.0", features = ["serde", "petgraph"] }
 pyo3 = { version = "0.19.0", optional = true, features = [
     "multiple-pymethods",
 ] }
@@ -41,6 +41,7 @@ html-escape = "0.2.13"
 bitvec = { version = "1.0.1", features = ["serde"] }
 enum_dispatch = "0.3.11"
 lazy_static = "1.4.0"
+petgraph = { version="0.6.3", default-features = false}
 context-iterators = "0.2.0"
 
 [features]

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -2,6 +2,7 @@
 
 mod hugrmut;
 
+pub mod region;
 pub mod rewrite;
 pub mod serialize;
 pub mod typecheck;

--- a/src/hugr/region.rs
+++ b/src/hugr/region.rs
@@ -14,8 +14,7 @@ use super::HugrView;
 
 type FlatRegionGraph<'g> = portgraph::view::FlatRegion<'g, MultiPortGraph>;
 
-/// Single region view of a HUGR. Ignores any nodes that are not direct children
-/// of the root.
+/// Single region view of a HUGR. Includes only the root node and its direct children.
 ///
 /// For a view that includes all the descendants of the root, see [`RegionView`].
 #[derive(Clone, Debug)]
@@ -34,8 +33,8 @@ pub struct FlatRegionView<'g> {
 }
 
 impl<'g> FlatRegionView<'g> {
-    /// Create a new region view of a HUGR containing only the direct children
-    /// of the root.
+    /// Create a new region view of a HUGR containing only a root and its direct
+    /// children.
     pub fn new(hugr: &'g Hugr, root: Node) -> Self {
         let Hugr {
             graph,
@@ -155,8 +154,8 @@ impl<'g> HugrView for FlatRegionView<'g> {
 
 type RegionGraph<'g> = portgraph::view::Region<'g, MultiPortGraph>;
 
-/// Single region view of a HUGR. Ignores any nodes that are not descendants of
-/// the root.
+/// Single region view of a HUGR. Includes only the root node and its
+/// descendants.
 ///
 /// For a view that includes only the direct children of the root, see
 /// [`FlatRegionView`]. Prefer using [`FlatRegionView`] over this type when
@@ -177,8 +176,8 @@ pub struct RegionView<'g> {
 }
 
 impl<'g> RegionView<'g> {
-    /// Create a new region view of a HUGR containing only the direct children
-    /// of the root.
+    /// Create a new region view of a HUGR containing only a root node and its
+    /// descendants.
     pub fn new(hugr: &'g Hugr, root: Node) -> Self {
         let Hugr {
             graph,

--- a/src/hugr/region.rs
+++ b/src/hugr/region.rs
@@ -2,11 +2,9 @@
 
 pub mod petgraph;
 
-use context_iterators::{ContextIterator, IntoContextIterator, MapCtx, WithCtx};
+use context_iterators::{ContextIterator, IntoContextIterator, MapWithCtx};
 use itertools::{Itertools, MapInto};
-use portgraph::{
-    multiportgraph::SubportIndex, Hierarchy, LinkView, MultiPortGraph, PortView, UnmanagedDenseMap,
-};
+use portgraph::{Hierarchy, LinkView, MultiPortGraph, PortView, UnmanagedDenseMap};
 
 use crate::{ops::OpType, Direction, Hugr, Node, Port};
 
@@ -69,9 +67,10 @@ impl<'g> HugrView for FlatRegionView<'g> {
     where
         Self: 'a;
 
-    type PortLinks<'a> = MapCtx<
-        WithCtx<<FlatRegionGraph<'g> as LinkView>::PortLinks<'a>, &'a Self>,
-        fn((SubportIndex, SubportIndex), &&'a Self) -> (Node, Port),
+    type PortLinks<'a> = MapWithCtx<
+        <FlatRegionGraph<'g> as LinkView>::PortLinks<'a>,
+        &'a Self,
+        (Node, Port),
     > where
         Self: 'a;
 
@@ -210,9 +209,10 @@ impl<'g> HugrView for RegionView<'g> {
     where
         Self: 'a;
 
-    type PortLinks<'a> = MapCtx<
-        WithCtx<<RegionGraph<'g> as LinkView>::PortLinks<'a>, &'a Self>,
-        fn((SubportIndex, SubportIndex), &&'a Self) -> (Node, Port),
+    type PortLinks<'a> = MapWithCtx<
+        <RegionGraph<'g> as LinkView>::PortLinks<'a>,
+        &'a Self,
+        (Node, Port),
     > where
         Self: 'a;
 

--- a/src/hugr/region.rs
+++ b/src/hugr/region.rs
@@ -1,0 +1,289 @@
+//! Region-level views of a HUGR.
+
+pub mod petgraph;
+
+use context_iterators::{ContextIterator, IntoContextIterator, MapCtx, WithCtx};
+use itertools::{Itertools, MapInto};
+use portgraph::{
+    multiportgraph::SubportIndex, Hierarchy, LinkView, MultiPortGraph, PortView, UnmanagedDenseMap,
+};
+
+use crate::{ops::OpType, Direction, Hugr, Node, Port};
+
+use super::HugrView;
+
+type FlatRegionGraph<'g> = portgraph::view::FlatRegion<'g, MultiPortGraph>;
+
+/// Single region view of a HUGR. Ignores any nodes that are not direct children
+/// of the root.
+///
+/// For a view that includes all the descendants of the root, see [`RegionView`].
+#[derive(Clone, Debug)]
+pub struct FlatRegionView<'g> {
+    /// The chosen root node.
+    root: Node,
+
+    /// The graph encoding the adjacency structure of the HUGR.
+    graph: FlatRegionGraph<'g>,
+
+    /// The node hierarchy.
+    hierarchy: &'g Hierarchy,
+
+    /// Operation types for each node.
+    op_types: &'g UnmanagedDenseMap<portgraph::NodeIndex, OpType>,
+}
+
+impl<'g> FlatRegionView<'g> {
+    /// Create a new region view of a HUGR containing only the direct children
+    /// of the root.
+    pub fn new(hugr: &'g Hugr, root: Node) -> Self {
+        let Hugr {
+            graph,
+            hierarchy,
+            op_types,
+            ..
+        } = hugr;
+        Self {
+            root,
+            graph: FlatRegionGraph::new_flat_region(graph, hierarchy, root.index),
+            hierarchy,
+            op_types,
+        }
+    }
+}
+
+impl<'g> HugrView for FlatRegionView<'g> {
+    type Nodes<'a> = MapInto<portgraph::hierarchy::Children<'a>, Node>
+    where
+        Self: 'a;
+
+    type NodePorts<'a> = MapInto<<FlatRegionGraph<'g> as PortView>::NodePortOffsets<'a>, Port>
+    where
+        Self: 'a;
+
+    type Children<'a> = MapInto<portgraph::hierarchy::Children<'a>, Node>
+    where
+        Self: 'a;
+
+    type Neighbours<'a> = MapInto<<FlatRegionGraph<'g> as LinkView>::Neighbours<'a>, Node>
+    where
+        Self: 'a;
+
+    type PortLinks<'a> = MapCtx<
+        WithCtx<<FlatRegionGraph<'g> as LinkView>::PortLinks<'a>, &'a Self>,
+        fn((SubportIndex, SubportIndex), &&'a Self) -> (Node, Port),
+    > where
+        Self: 'a;
+
+    fn root(&self) -> Node {
+        self.root
+    }
+
+    fn get_parent(&self, node: Node) -> Option<Node> {
+        self.hierarchy
+            .parent(node.index)
+            .map(Into::into)
+            .filter(|&n| n == self.root)
+    }
+
+    fn get_optype(&self, node: Node) -> &OpType {
+        self.op_types.get(node.index)
+    }
+
+    fn node_count(&self) -> usize {
+        self.hierarchy.child_count(self.root.index) + 1
+    }
+
+    fn edge_count(&self) -> usize {
+        // Faster implementation than filtering all the nodes in the internal graph.
+        self.nodes()
+            .map(|n| self.output_neighbours(n).count())
+            .sum()
+    }
+
+    fn nodes(&self) -> Self::Nodes<'_> {
+        // Faster implementation than filtering all the nodes in the internal graph.
+        self.hierarchy.children(self.root.index).map_into()
+    }
+
+    fn node_ports(&self, node: Node, dir: Direction) -> Self::NodePorts<'_> {
+        self.graph.port_offsets(node.index, dir).map_into()
+    }
+
+    fn all_node_ports(&self, node: Node) -> Self::NodePorts<'_> {
+        self.graph.all_port_offsets(node.index).map_into()
+    }
+
+    fn linked_ports(&self, node: Node, port: Port) -> Self::PortLinks<'_> {
+        let port = self.graph.port_index(node.index, port.offset).unwrap();
+        self.graph
+            .port_links(port)
+            .with_context(self)
+            .map_with_context(|(_, link), region| {
+                let port = link.port();
+                let node = region.graph.port_node(port).unwrap();
+                let offset = region.graph.port_offset(port).unwrap();
+                (node.into(), offset.into())
+            })
+    }
+
+    fn num_ports(&self, node: Node, dir: Direction) -> usize {
+        self.graph.num_ports(node.index, dir)
+    }
+
+    fn children(&self, node: Node) -> Self::Children<'_> {
+        let mut iter = self.hierarchy.children(node.index).map_into();
+        if node != self.root {
+            // Eagerly empty the iterator.
+            // Ideally we would construct an empty iterator directly, but
+            // `Children` is not `Default`.
+            while iter.next().is_some() {}
+        }
+        iter
+    }
+
+    fn neighbours(&self, node: Node, dir: Direction) -> Self::Neighbours<'_> {
+        self.graph.neighbours(node.index, dir).map_into()
+    }
+
+    fn all_neighbours(&self, node: Node) -> Self::Neighbours<'_> {
+        self.graph.all_neighbours(node.index).map_into()
+    }
+}
+
+type RegionGraph<'g> = portgraph::view::Region<'g, MultiPortGraph>;
+
+/// Single region view of a HUGR. Ignores any nodes that are not descendants of
+/// the root.
+///
+/// For a view that includes only the direct children of the root, see
+/// [`FlatRegionView`]. Prefer using [`FlatRegionView`] over this type when
+/// possible, as it is more efficient.
+#[derive(Clone, Debug)]
+pub struct RegionView<'g> {
+    /// The chosen root node.
+    root: Node,
+
+    /// The graph encoding the adjacency structure of the HUGR.
+    graph: RegionGraph<'g>,
+
+    /// The node hierarchy.
+    hierarchy: &'g Hierarchy,
+
+    /// Operation types for each node.
+    op_types: &'g UnmanagedDenseMap<portgraph::NodeIndex, OpType>,
+}
+
+impl<'g> RegionView<'g> {
+    /// Create a new region view of a HUGR containing only the direct children
+    /// of the root.
+    pub fn new(hugr: &'g Hugr, root: Node) -> Self {
+        let Hugr {
+            graph,
+            hierarchy,
+            op_types,
+            ..
+        } = hugr;
+        Self {
+            root,
+            graph: RegionGraph::new_region(graph, hierarchy, root.index),
+            hierarchy,
+            op_types,
+        }
+    }
+}
+
+impl<'g> HugrView for RegionView<'g> {
+    type Nodes<'a> = MapInto<<RegionGraph<'g> as PortView>::Nodes<'a>, Node>
+    where
+        Self: 'a;
+
+    type NodePorts<'a> = MapInto<<RegionGraph<'g> as PortView>::NodePortOffsets<'a>, Port>
+    where
+        Self: 'a;
+
+    type Children<'a> = MapInto<portgraph::hierarchy::Children<'a>, Node>
+    where
+        Self: 'a;
+
+    type Neighbours<'a> = MapInto<<RegionGraph<'g> as LinkView>::Neighbours<'a>, Node>
+    where
+        Self: 'a;
+
+    type PortLinks<'a> = MapCtx<
+        WithCtx<<RegionGraph<'g> as LinkView>::PortLinks<'a>, &'a Self>,
+        fn((SubportIndex, SubportIndex), &&'a Self) -> (Node, Port),
+    > where
+        Self: 'a;
+
+    fn root(&self) -> Node {
+        self.root
+    }
+
+    fn get_parent(&self, node: Node) -> Option<Node> {
+        self.hierarchy
+            .parent(node.index)
+            .filter(|&parent| self.graph.contains_node(parent))
+            .map(Into::into)
+    }
+
+    fn get_optype(&self, node: Node) -> &OpType {
+        self.op_types.get(node.index)
+    }
+
+    fn node_count(&self) -> usize {
+        self.graph.node_count()
+    }
+
+    fn edge_count(&self) -> usize {
+        self.graph.link_count()
+    }
+
+    fn nodes(&self) -> Self::Nodes<'_> {
+        self.graph.nodes_iter().map_into()
+    }
+
+    fn node_ports(&self, node: Node, dir: Direction) -> Self::NodePorts<'_> {
+        self.graph.port_offsets(node.index, dir).map_into()
+    }
+
+    fn all_node_ports(&self, node: Node) -> Self::NodePorts<'_> {
+        self.graph.all_port_offsets(node.index).map_into()
+    }
+
+    fn linked_ports(&self, node: Node, port: Port) -> Self::PortLinks<'_> {
+        let port = self.graph.port_index(node.index, port.offset).unwrap();
+        self.graph
+            .port_links(port)
+            .with_context(self)
+            .map_with_context(|(_, link), region| {
+                let port = link.port();
+                let node = region.graph.port_node(port).unwrap();
+                let offset = region.graph.port_offset(port).unwrap();
+                (node.into(), offset.into())
+            })
+    }
+
+    fn num_ports(&self, node: Node, dir: Direction) -> usize {
+        self.graph.num_ports(node.index, dir)
+    }
+
+    fn children(&self, node: Node) -> Self::Children<'_> {
+        let mut iter = self.hierarchy.children(node.index).map_into();
+        if !self.graph.contains_node(node.index) {
+            // Eagerly empty the iterator.
+            // Ideally we would construct an empty iterator directly, but
+            // `Children` is not `Default`.
+            while iter.next().is_some() {}
+        }
+        iter
+    }
+
+    fn neighbours(&self, node: Node, dir: Direction) -> Self::Neighbours<'_> {
+        self.graph.neighbours(node.index, dir).map_into()
+    }
+
+    fn all_neighbours(&self, node: Node) -> Self::Neighbours<'_> {
+        self.graph.all_neighbours(node.index).map_into()
+    }
+}

--- a/src/hugr/region/petgraph.rs
+++ b/src/hugr/region/petgraph.rs
@@ -1,0 +1,168 @@
+//! Implementations of petgraph's traits for Hugr Region views.
+
+use super::{FlatRegionView, RegionView};
+use crate::hugr::HugrView;
+use crate::ops::OpType;
+use crate::types::EdgeKind;
+use crate::{Node, Port};
+
+use context_iterators::{ContextIterator, IntoContextIterator, MapCtx, WithCtx};
+use petgraph::visit::NodeRef;
+use portgraph::NodeIndex;
+
+type MapWithCtx<I, Ctx, O> = MapCtx<WithCtx<I, Ctx>, fn(<I as Iterator>::Item, &Ctx) -> O>;
+
+macro_rules! impl_region_petgraph_traits {
+    ($hugr:ident) => {
+        impl<'a> petgraph::visit::GraphBase for $hugr<'a> {
+            type NodeId = Node;
+            type EdgeId = ((Node, Port), (Node, Port));
+        }
+
+        impl<'a> petgraph::visit::GraphProp for $hugr<'a> {
+            type EdgeType = petgraph::Directed;
+        }
+
+        impl<'a> petgraph::visit::NodeCount for $hugr<'a> {
+            fn node_count(&self) -> usize {
+                HugrView::node_count(self)
+            }
+        }
+
+        impl<'a> petgraph::visit::NodeIndexable for $hugr<'a> {
+            fn node_bound(&self) -> usize {
+                HugrView::node_count(self)
+            }
+
+            fn to_index(&self, ix: Self::NodeId) -> usize {
+                ix.index.into()
+            }
+
+            fn from_index(&self, ix: usize) -> Self::NodeId {
+                NodeIndex::new(ix).into()
+            }
+        }
+
+        impl<'a> petgraph::visit::EdgeCount for $hugr<'a> {
+            fn edge_count(&self) -> usize {
+                HugrView::edge_count(self)
+            }
+        }
+
+        impl<'a> petgraph::visit::Data for $hugr<'a> {
+            type NodeWeight = OpType;
+            type EdgeWeight = EdgeKind;
+        }
+
+        impl<'g, 'a> petgraph::visit::IntoNodeIdentifiers for &'g $hugr<'a> {
+            type NodeIdentifiers = <$hugr<'a> as HugrView>::Nodes<'g>;
+
+            fn node_identifiers(self) -> Self::NodeIdentifiers {
+                self.nodes()
+            }
+        }
+
+        impl<'g, 'a> petgraph::visit::IntoNodeReferences for &'g $hugr<'a>
+        where
+            'g: 'a,
+        {
+            type NodeRef = HugrNodeRef<'a>;
+            type NodeReferences =
+                MapWithCtx<<$hugr<'a> as HugrView>::Nodes<'a>, Self, HugrNodeRef<'a>>;
+
+            fn node_references(self) -> Self::NodeReferences {
+                self.nodes()
+                    .with_context(self)
+                    .map_with_context(|n, &hugr| HugrNodeRef::from_node(n, hugr))
+            }
+        }
+
+        impl<'g, 'a> petgraph::visit::IntoNeighbors for &'g $hugr<'a> {
+            type Neighbors = <$hugr<'a> as HugrView>::Neighbours<'g>;
+
+            fn neighbors(self, n: Self::NodeId) -> Self::Neighbors {
+                self.all_neighbours(n)
+            }
+        }
+
+        impl<'g, 'a> petgraph::visit::IntoNeighborsDirected for &'g $hugr<'a> {
+            type NeighborsDirected = <$hugr<'a> as HugrView>::Neighbours<'g>;
+
+            fn neighbors_directed(
+                self,
+                n: Self::NodeId,
+                d: petgraph::Direction,
+            ) -> Self::NeighborsDirected {
+                self.neighbours(n, d.into())
+            }
+        }
+
+        impl<'a> petgraph::visit::Visitable for $hugr<'a> {
+            type Map = std::collections::HashSet<Self::NodeId>;
+
+            fn visit_map(&self) -> Self::Map {
+                std::collections::HashSet::new()
+            }
+
+            fn reset_map(&self, map: &mut Self::Map) {
+                map.clear();
+            }
+        }
+
+        impl<'a> petgraph::visit::GetAdjacencyMatrix for $hugr<'a> {
+            type AdjMatrix = std::collections::HashSet<(Self::NodeId, Self::NodeId)>;
+
+            fn adjacency_matrix(&self) -> Self::AdjMatrix {
+                let mut matrix = std::collections::HashSet::new();
+                for node in self.nodes() {
+                    for neighbour in self.output_neighbours(node) {
+                        matrix.insert((node, neighbour));
+                    }
+                }
+                matrix
+            }
+
+            fn is_adjacent(
+                &self,
+                matrix: &Self::AdjMatrix,
+                a: Self::NodeId,
+                b: Self::NodeId,
+            ) -> bool {
+                matrix.contains(&(a, b))
+            }
+        }
+    };
+}
+
+impl_region_petgraph_traits!(FlatRegionView);
+impl_region_petgraph_traits!(RegionView);
+
+/// Reference to a Hugr node and its associated OpType.
+#[derive(Debug, Clone, Copy)]
+pub struct HugrNodeRef<'a> {
+    node: Node,
+    op: &'a OpType,
+}
+
+impl<'a> HugrNodeRef<'a> {
+    pub(self) fn from_node(node: Node, hugr: &'a impl HugrView) -> Self {
+        Self {
+            node,
+            op: hugr.get_optype(node),
+        }
+    }
+}
+
+impl NodeRef for HugrNodeRef<'_> {
+    type NodeId = Node;
+
+    type Weight = OpType;
+
+    fn id(&self) -> Self::NodeId {
+        self.node
+    }
+
+    fn weight(&self) -> &Self::Weight {
+        self.op
+    }
+}

--- a/src/hugr/region/petgraph.rs
+++ b/src/hugr/region/petgraph.rs
@@ -6,11 +6,9 @@ use crate::ops::OpType;
 use crate::types::EdgeKind;
 use crate::{Node, Port};
 
-use context_iterators::{ContextIterator, IntoContextIterator, MapCtx, WithCtx};
+use context_iterators::{ContextIterator, IntoContextIterator, MapWithCtx};
 use petgraph::visit::NodeRef;
 use portgraph::NodeIndex;
-
-type MapWithCtx<I, Ctx, O> = MapCtx<WithCtx<I, Ctx>, fn(<I as Iterator>::Item, &Ctx) -> O>;
 
 macro_rules! impl_region_petgraph_traits {
     ($hugr:ident) => {

--- a/src/hugr/view.rs
+++ b/src/hugr/view.rs
@@ -8,6 +8,8 @@ use context_iterators::{ContextIterator, IntoContextIterator, MapCtx, MapWithCtx
 use itertools::{Itertools, MapInto};
 use portgraph::{multiportgraph, LinkView, PortView};
 
+type MapWithCtx<I, Ctx, O> = MapCtx<WithCtx<I, Ctx>, fn(<I as Iterator>::Item, &Ctx) -> O>;
+
 use super::Hugr;
 use super::{Node, Port};
 use crate::ops::OpType;

--- a/src/hugr/view.rs
+++ b/src/hugr/view.rs
@@ -8,8 +8,6 @@ use context_iterators::{ContextIterator, IntoContextIterator, MapCtx, MapWithCtx
 use itertools::{Itertools, MapInto};
 use portgraph::{multiportgraph, LinkView, PortView};
 
-type MapWithCtx<I, Ctx, O> = MapCtx<WithCtx<I, Ctx>, fn(<I as Iterator>::Item, &Ctx) -> O>;
-
 use super::Hugr;
 use super::{Node, Port};
 use crate::ops::OpType;


### PR DESCRIPTION
Adds a `RegionView` and `FlatRegionView` hugr views that show a single region in the Hugr, either containing all the descendant nodes or just the direct children of the root.

These regions implement `petgraph`'s visit traits, exposing the internal graph. Closes #125 

### Not in this PR:

- We do not implement `petgraph::visit::IntoEdgeReferences` nor the `IntoEdge*` derivates.

  The weight of an edge should be an `EdgeKind`s, but petgraph requires the iterators to return an `EdgeRef : Copy` which has a method that returns an `&EdgeKind`.
  Since the edge kinds are computed on the fly from the signature we have to store them somewhere temporarily, but `EdgeRef` is `Copy` so it cannot contain it.
  I tried some alternatives with cached structures on the iterators, but it quickly became lifetime hell.
  I'll leave that for later; the algorithms that we currently want to use do not require those traits.
  
- The region's petgraph-exposed graph contains the root and all edges.

  We may want to remove the root when running algorithms, and maybe filter the kind of edges (parametrically, as it depends on the problem). The current formulation works for toposorting and dominators (#192), but we could add some extra options in the future.