### PR TITLE
Replace broken url_encode with urlencoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ criterion = { version = "0.5.1", features = ["html_reports"] }
 rstest = "0.17.0"
 rmp-serde = "1.1.1"
 webbrowser = "0.8.10"
-url-escape = "0.1.1"
+urlencoding = "2.1.2"
 cool_asserts = "2.0.3"
 
 [[bench]]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Display};
 
-/// Write a comma seperated list of of some types.
+/// Write a comma separated list of of some types.
 /// Like debug_list, but using the Display instance rather than Debug,
 /// and not adding surrounding square brackets.
 pub fn display_list<T>(ts: &[T], f: &mut fmt::Formatter) -> fmt::Result
@@ -28,7 +28,7 @@ pub(crate) mod test {
     #[cfg(not(ci_run))]
     pub(crate) fn viz_dotstr(dotstr: &str) {
         let mut base: String = "https://dreampuf.github.io/GraphvizOnline/#".into();
-        url_escape::encode_query_to_string(dotstr, &mut base);
+        base.push_str(&urlencoding::encode(dotstr));
         webbrowser::open(&base).unwrap();
     }
 }


### PR DESCRIPTION
`urlencoding` is a lot more stable. Fixes #176.