### PR TITLE
Pin the miri toolchain in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install nightly-2023-06-01
-        uses: dtolnay/rust-toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2023-06-01
           components: miri, rust-src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install latest nightly
-        uses: dtolnay/rust-toolchain@nightly
+      - name: Install nightly-2023-06-01
+        uses: dtolnay/rust-toolchain
         with:
-          components: miri
+          toolchain: nightly-2023-06-01
+          components: miri, rust-src
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: v0-rust-nightly


### PR DESCRIPTION
Uses a fixed nightly toolchain to run miri.
This should get rid of the spurious [CI errors](https://github.com/CQCL-DEV/hugr/actions/runs/5343712720/jobs/9687171092) when miri is not yet available on the latest nightly.