### PR TITLE
doc: Crate name as README title + add reexport

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ The HUGR specification (still in draft) is [here](specification/hugr.md).
 
 -   `pyo3`: Enable Python bindings via pyo3.
 
+## Usage
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+quantinuum-hugr = "0.1"
+```
+
+The library crate is called `hugr`.
+
 ## License
 
 This project is licensed under Apache License, Version 2.0 ([LICENSE][] or http://www.apache.org/licenses/LICENSE-2.0).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-hugr
-====
+quantinuum-hugr
+===============
 
 [![build_status][]](https://github.com/CQCL/hugr/actions)
 [![msrv][]](https://github.com/CQCL/hugr)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,6 @@ pub mod types;
 mod utils;
 
 pub use crate::hugr::{
-    Direction, Hugr, Node, Port, Replace, ReplaceError, SimpleReplacement, Wire,
+    Direction, Hugr, HugrView, Node, Port, Replace, ReplaceError, SimpleReplacement, Wire,
 };
 pub use crate::resource::Resource;


### PR DESCRIPTION
- Clarify the package vs library name difference. Closes #67 
- Reexport `HugrView` on the crate's root.