### PR TITLE
Fix edge serialization not compacting the nodes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ rmp-serde = "1.1.1"
 webbrowser = "0.8.10"
 urlencoding = "2.1.2"
 cool_asserts = "2.0.3"
+serde_json = "1.0.97"
 
 [[bench]]
 name = "bench_main"

--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -344,7 +344,7 @@ pub mod test {
     }
 
     #[test]
-    fn dgf_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
+    fn dfg_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
         let tp: Vec<SimpleType> = vec![ClassicType::bit().into(); 2];
         let mut dfg = DFGBuilder::new(tp.clone(), tp)?;
         let mut params: [_; 2] = dfg.input_wires_arr();


### PR DESCRIPTION
If a copy node made the op nodes non-contiguous, the edge serialization didn't translate the endpoints `Node`s.

This is a one-liner fix + a new check on the node index when deserializing + the previously-failing test.

Closes #202