### PR TITLE
Don't run miri for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,21 +35,6 @@ jobs:
         env:
           RUSTDOCFLAGS: "-Dwarnings"
 
-  miri:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install nightly-2023-06-01
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2023-06-01
-          components: miri, rust-src
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: v0-rust-nightly
-      - name: Run miri
-        run: cargo miri test
-
   benches:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch: {}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/unsoundness.yml
+++ b/.github/workflows/unsoundness.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main 
+  workflow_dispatch: {}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/unsoundness.yml
+++ b/.github/workflows/unsoundness.yml
@@ -1,0 +1,30 @@
+name: Unsoundness checks
+
+on:
+  push:
+    branches:
+      - main 
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "--cfg=ci_run"
+  MIRIFLAGS: '-Zmiri-permissive-provenance' # Required due to warnings in bitvec 1.0.1
+
+jobs:
+
+   miri:
+    name: "Miri"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Miri
+        run: |
+          rustup toolchain install nightly --component miri
+          rustup override set nightly
+          cargo miri setup
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v0-miri
+      - name: Test with Miri
+        run: cargo miri test


### PR DESCRIPTION
Only runs on `main`. I copied the [official example](https://github.com/rust-lang/miri#running-miri-on-ci).

Adds a workflow_dispatch trigger so we can run it on other branches when needed.