### PR TITLE
Node canonicalization method in HugrMut

### DIFF
--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -9,6 +9,9 @@ pub mod typecheck;
 pub mod validate;
 pub mod view;
 
+use std::collections::VecDeque;
+use std::iter;
+
 pub(crate) use self::hugrmut::HugrMut;
 pub use self::validate::ValidationError;
 
@@ -167,6 +170,21 @@ impl Hugr {
             root,
             op_types,
         }
+    }
+
+    /// Produce a canonical ordering of the nodes.
+    ///
+    /// Used by [`HugrMut::canonicalize_nodes`] and the serialization code.
+    fn canonical_order(&self) -> impl Iterator<Item = Node> + '_ {
+        // Generate a BFS-ordered list of nodes based on the hierarchy
+        let mut queue = VecDeque::from([self.root.into()]);
+        iter::from_fn(move || {
+            let node = queue.pop_front()?;
+            for child in self.children(node) {
+                queue.push_back(child);
+            }
+            Some(node)
+        })
     }
 }
 

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -311,14 +311,7 @@ where
     fn canonicalize_nodes(&mut self, mut rekey: impl FnMut(Node, Node)) {
         // Generate the ordered list of nodes
         let mut ordered = Vec::with_capacity(self.node_count());
-        ordered.push(self.root());
-        let mut i = 0;
-        while let Some(node) = ordered.get(i).copied() {
-            for child in self.children(node) {
-                ordered.push(child);
-            }
-            i += 1;
-        }
+        ordered.extend(self.as_ref().canonical_order());
 
         // Permute the nodes in the graph to match the order.
         //

--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -1,7 +1,7 @@
 //! Serialization definition for [`Hugr`]
 //! [`Hugr`]: crate::hugr::Hugr
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use thiserror::Error;
 
 use crate::hugr::{Hugr, HugrMut};
@@ -113,14 +113,8 @@ impl TryFrom<&Hugr> for SerHugrV0 {
         // We compact the operation nodes during the serialization process,
         // and ignore the copy nodes.
         let mut node_rekey: HashMap<Node, Node> = HashMap::with_capacity(hugr.node_count());
-        // Generate a BFS-ordered list of nodes based on the hierarchy
-        let mut ordered = VecDeque::from([hugr.root()]);
-        let mut index_counter = (0..).map(|i| NodeIndex::new(i).into());
-        while let Some(node) = ordered.pop_front() {
-            node_rekey.insert(node, index_counter.next().unwrap());
-            for child in hugr.children(node) {
-                ordered.push_back(child);
-            }
+        for (order, node) in hugr.canonical_order().enumerate() {
+            node_rekey.insert(node, NodeIndex::new(order).into());
         }
 
         let mut nodes = vec![None; hugr.node_count()];


### PR DESCRIPTION
Defines the canonical order as the BFS traversal of the hierarchy.
This updates the code from #210 to enforce the canonical order when serializing.

Closes #208 