### PR TITLE
Test validation of cyclic graph + local consts, doc failures

### DIFF
--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -731,7 +731,7 @@ mod test {
     use super::*;
     use crate::builder::{BuildError, ModuleBuilder};
     use crate::builder::{Container, Dataflow, DataflowSubContainer, HugrBuilder};
-    use crate::hugr::HugrMut;
+    use crate::hugr::{HugrError, HugrMut};
     use crate::ops::dataflow::IOTrait;
     use crate::ops::{self, ConstValue, LeafOp, OpType};
     use crate::types::{ClassicType, LinearType, Signature};
@@ -1065,6 +1065,59 @@ mod test {
             Err(ValidationError::InvalidEdges { parent, source: EdgeValidationError::CFGEdgeSignatureMismatch { .. }, .. })
                 => assert_eq!(parent, cfg)
         );
+    }
+
+    #[test]
+    fn test_ext_edge() -> Result<(), HugrError> {
+        let mut h = Hugr::new(ops::DFG {
+            signature: Signature::new_df(type_row![B, B], type_row![B]),
+        });
+        let input = h.add_op_with_parent(h.root(), ops::Input::new(type_row![B, B]))?;
+        let output = h.add_op_with_parent(h.root(), ops::Output::new(type_row![B]))?;
+        // Nested DFG B -> B
+        let sub_dfg = h.add_op_with_parent(
+            h.root(),
+            ops::DFG {
+                signature: Signature::new_linear(type_row![B]),
+            },
+        )?;
+        // this Xor has its 2nd input unconnected
+        let sub_op = {
+            let sub_input = h.add_op_with_parent(sub_dfg, ops::Input::new(type_row![B]))?;
+            let sub_output = h.add_op_with_parent(sub_dfg, ops::Output::new(type_row![B]))?;
+            let sub_op = h.add_op_with_parent(sub_dfg, LeafOp::Xor)?;
+            h.connect(sub_input, 0, sub_op, 0)?;
+            h.connect(sub_op, 0, sub_output, 0)?;
+            sub_op
+        };
+
+        h.connect(input, 0, sub_dfg, 0)?;
+        h.connect(sub_dfg, 0, output, 0)?;
+
+        assert_matches!(h.validate(), Err(ValidationError::UnconnectedPort { .. }));
+
+        h.connect(input, 1, sub_op, 1)?;
+        assert_matches!(
+            h.validate(),
+            Err(ValidationError::InterGraphEdgeError(
+                InterGraphEdgeError::MissingOrderEdge { .. }
+            ))
+        );
+        //Order edge. There must be an easier way to do this?
+        h.connect(
+            input,
+            h.get_optype(input)
+                .other_port_index(Direction::Outgoing)
+                .unwrap()
+                .index(),
+            sub_dfg,
+            h.get_optype(sub_dfg)
+                .other_port_index(Direction::Incoming)
+                .unwrap()
+                .index(),
+        )?;
+        h.validate().unwrap();
+        Ok(())
     }
 
     #[test]

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -1161,18 +1161,7 @@ mod test {
         // XXX TODO FIXME This should fail, but succeeds:
         h.validate().unwrap();
         // Now include the LoadConstant node in the causal cone
-        h.connect(
-            input,
-            h.get_optype(input)
-                .other_port_index(Direction::Outgoing)
-                .unwrap()
-                .index(),
-            lcst,
-            h.get_optype(lcst)
-                .other_port_index(Direction::Incoming)
-                .unwrap()
-                .index(),
-        )?;
+        h.add_other_edge(input, lcst)?;
         h.validate().unwrap();
         Ok(())
     }


### PR DESCRIPTION
* `test_cyclic` creates a cyclic DFG, and this validates :-(. We don't have anything in validation to look for this.
* `test_local_const` creates a graph with a LoadConstant node that is not in the causal cone of the Input. This passes validation, because the DfsPostOrder used in `validate_children_dag` currently traverses *both ways* along edges :-(, I think validation should fail here, and that the fix is in portgraph.
   * `test_local_const` then goes on to add the missing edge, and that still passes, but if we fixed the traversal to only go forwards, `validate_children_dag` would then fail as it wouldn't have visited the Const node (but would count it in the children); we'd then need the fix detailed inside `validate_children_dag`

I'd love to turn these into "expected-fail" tests but that looks quite hard, best plan appears to be to use [cargo-nextest](https://nexte.st/)