### PR TITLE
[refactor] Rename Alias/Func Def/Decl nodes

### DIFF
--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -210,7 +210,7 @@ source node, to an incoming port of the target node.
 A `Static` edge represents dataflow that is statically knowable - i.e.
 the source is a compile-time constant defined in the program. Hence, the types on these edges
 do not include a resource specification. Only a few nodes may be
-sources (`Def`, `Declare` and `Const`) and targets (`Call` and `LoadConstant`) of
+sources (`FuncDefn`, `FuncDecl` and `Const`) and targets (`Call` and `LoadConstant`) of
 these edges; see
 [operations](#node-operations).
 
@@ -245,36 +245,36 @@ operations have value ports, but some have Static or other
 edges. The following operations are *only* valid as immediate children of a
 `Module` node.
 
-  - `Declare`: an external function declaration. The name of the function 
+  - `FuncDecl`: an external function declaration. The name of the function 
     and function attributes (relevant for compilation)
     define the node weight. The node has an outgoing `Static<Graph>`
     edge for each use of the function. The function name is used at link time to
     look up definitions in linked
     modules (other hugr instances specified to the linker).
   
-  - `AliasDeclare`: an external type alias declaration. At link time this can be
-    replaced with the definition. An alias declared with `AliasDeclare` is equivalent to a
+  - `AliasDecl`: an external type alias declaration. At link time this can be
+    replaced with the definition. An alias declared with `AliasDecl` is equivalent to a
     named opaque type.
 
 The following operations are valid at the module level, but *also* in dataflow
 regions:
 
   - `Const<T>` : a static constant value of type T stored in the node
-    weight. Like `Declare` and `Def` this has one `Static<T>` out-edge per use.
+    weight. Like `FuncDecl` and `FuncDefn` this has one `Static<T>` out-edge per use.
 
-  - `Def` : a function definition. Like `Declare` but with a function body.
+  - `FuncDefn` : a function definition. Like `FuncDecl` but with a function body.
     The function body is defined by the sibling graph formed by its children.
-    At link time `Declare` nodes are replaced by `Def`.
+    At link time `FuncDecl` nodes are replaced by `FuncDefn`.
 
-  - `AliasDef`: type alias definition. At link time `AliasDeclare` can be replaced with
-    `AliasDef`.
+  - `AliasDefn`: type alias definition. At link time `AliasDecl` can be replaced with
+    `AliasDefn`.
 
 
 A **loadable HUGR** is a module HUGR where all input ports are connected and there are
-no `Declare/AliasDeclare` nodes.
+no `FuncDecl/AliasDecl` nodes.
 
 An **executable HUGR** or **executable module** is a loadable HUGR where the
-root Module node has a `Def` child with function name
+root Module node has a `FuncDefn` child with function name
 “main”, that is the designated entry point. Modules that act as libraries need
 not be executable.
 
@@ -450,10 +450,10 @@ has no parent).
 | Conditional               | "                              | `Conditional`      | **C**         | `Case`                   | No edges                                 |
 | **C:** Dataflow container | "                              | `TailLoop`         | **C**         |  **D**                   | First(second) is `Input`(`Output`)       |
 | "                         | "                              | `DFG`              | **C**         |  "                       | "                                        |
-| "                         | Static                         | `Def`              | **C**         |  "                       | "                                        |
+| "                         | Static                         | `FuncDefn`              | **C**         |  "                       | "                                        |
 | "                         | ControlFlow                    | `DFB`              | CFG           |  "                       | "                                        |
 | "                         | \-                             | `Case`             | `Conditional` |  "                       | "                                        |
-| Root                      | \-                             | `Module`           | none          |  "                       | Contains main `Def` for executable HUGR. |
+| Root                      | \-                             | `Module`           | none          |  "                       | Contains main `FuncDefn` for executable HUGR. |
 
 These relationships allow to define two common varieties of sibling
 graph:
@@ -466,7 +466,7 @@ cycles. The common parent is a CFG-node.
 `Conditional`, `TailLoop` and `DFG` nodes; edges are `Value`, `Order` and `Static`;
 and must be acyclic. There is a unique Input node and Output node. All nodes must be
 reachable from the Input node, and must reach the Output node. The common parent
-may be a `Def`, `TailLoop`, `DFG`, `Case` or `DFB` node.
+may be a `FuncDefn`, `TailLoop`, `DFG`, `Case` or `DFB` node.
 
 | **Edge Kind**  | **Locality** |
 | -------------- | ------------ |
@@ -1748,11 +1748,11 @@ an edge weight.
     Conditional or TailLoop node. All incoming and outgoing edges are
     value edges.
 
-  - **Declare node**: child of a module, indicates that an external
+  - **FuncDecl node**: child of a module, indicates that an external
     function exists but without giving a definition. May be the source
     of Static-edges to Call nodes and others.
 
-  - **Def node**: child of a module node, defines a function (by being
+  - **FuncDefn node**: child of a module node, defines a function (by being
     parent to the function’s body). May be the source of Static-edges to
     Call nodes and others.
 
@@ -1950,10 +1950,10 @@ including `Module`.
 | Node type      | `Value` | `Order` | `Static` | `ControlFlow` | `Hierarchy` | Children |
 | -------------- | ------- | ------- |--------- | ------------- | ----------- | -------- | 
 | Root           | 0, 0    | 0, 0    | 0, 0     | 0, 0          | 0, ✱        |          |
-| `Def`          | 0, 0    | 0, 0    | 0, ✱     | 0, 0          | 1, +        | DSG      |
-| `Declare`      | 0, 0    | 0, 0    | 0, ✱     | 0, 0          | 1, 0        |          |
-| `AliasDef`     | 0, 0    | 0, 0    | 0, 0     | 0, 0          | 1, 0        |          |
-| `AliasDeclare` | 0, 0    | 0, 0    | 0, 0     | 0, 0          | 1, 0        |          |
+| `FuncDefn`          | 0, 0    | 0, 0    | 0, ✱     | 0, 0          | 1, +        | DSG      |
+| `FuncDecl`      | 0, 0    | 0, 0    | 0, ✱     | 0, 0          | 1, 0        |          |
+| `AliasDefn`     | 0, 0    | 0, 0    | 0, 0     | 0, 0          | 1, 0        |          |
+| `AliasDecl` | 0, 0    | 0, 0    | 0, 0     | 0, 0          | 1, 0        |          |
 | `Const`        | 0, 0    | 0, 0    | 0, ✱     | 0, 0          | 1, 0        |          |
 | `LoadConstant` | 0, 1    | +, ✱    | 1, 0     | 0, 0          | 1, 0        |          |
 | `Input`        | 0, ✱    | 0, ✱    | 0, 0     | 0, 0          | 1, 0        |          |

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -68,19 +68,19 @@ pub trait Container {
         Ok((const_n, typ).into())
     }
 
-    /// Add a [`ops::Def`] node and returns a builder to define the function
+    /// Add a [`ops::FuncDef`] node and returns a builder to define the function
     /// body graph.
     ///
     /// # Errors
     ///
     /// This function will return an error if there is an error in adding the
-    /// [`ops::Def`] node.
+    /// [`ops::FuncDef`] node.
     fn define_function(
         &mut self,
         name: impl Into<String>,
         signature: Signature,
     ) -> Result<FunctionBuilder<&mut Hugr>, BuildError> {
-        let f_node = self.add_child_op(ops::Def {
+        let f_node = self.add_child_op(ops::FuncDef {
             name: name.into(),
             signature: signature.clone(),
         })?;
@@ -508,8 +508,8 @@ pub trait Dataflow: Container {
     /// # Errors
     ///
     /// This function will return an error if there is an error adding the Call
-    /// node, or if `function` does not refer to a [`ops::Declare`] or
-    /// [`ops::Def`] node.
+    /// node, or if `function` does not refer to a [`ops::FuncDeclare`] or
+    /// [`ops::FuncDef`] node.
     fn call<const DEFINED: bool>(
         &mut self,
         function: &FuncID<DEFINED>,
@@ -518,12 +518,12 @@ pub trait Dataflow: Container {
         let hugr = self.hugr();
         let def_op = hugr.get_optype(function.node());
         let signature = match def_op {
-            OpType::Def(ops::Def { signature, .. })
-            | OpType::Declare(ops::Declare { signature, .. }) => signature.clone(),
+            OpType::FuncDef(ops::FuncDef { signature, .. })
+            | OpType::FuncDeclare(ops::FuncDeclare { signature, .. }) => signature.clone(),
             _ => {
                 return Err(BuildError::UnexpectedType {
                     node: function.node(),
-                    op_desc: "Declare/Def",
+                    op_desc: "FuncDeclare/FuncDef",
                 })
             }
         };

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -508,7 +508,7 @@ pub trait Dataflow: Container {
     /// # Errors
     ///
     /// This function will return an error if there is an error adding the Call
-    /// node, or if `function` does not refer to a [`ops::FuncDeclare`] or
+    /// node, or if `function` does not refer to a [`ops::FuncDecl`] or
     /// [`ops::FuncDef`] node.
     fn call<const DEFINED: bool>(
         &mut self,
@@ -519,11 +519,11 @@ pub trait Dataflow: Container {
         let def_op = hugr.get_optype(function.node());
         let signature = match def_op {
             OpType::FuncDef(ops::FuncDef { signature, .. })
-            | OpType::FuncDeclare(ops::FuncDeclare { signature, .. }) => signature.clone(),
+            | OpType::FuncDecl(ops::FuncDecl { signature, .. }) => signature.clone(),
             _ => {
                 return Err(BuildError::UnexpectedType {
                     node: function.node(),
-                    op_desc: "FuncDeclare/FuncDef",
+                    op_desc: "FuncDecl/FuncDef",
                 })
             }
         };

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -68,19 +68,19 @@ pub trait Container {
         Ok((const_n, typ).into())
     }
 
-    /// Add a [`ops::FuncDef`] node and returns a builder to define the function
+    /// Add a [`ops::FuncDefn`] node and returns a builder to define the function
     /// body graph.
     ///
     /// # Errors
     ///
     /// This function will return an error if there is an error in adding the
-    /// [`ops::FuncDef`] node.
+    /// [`ops::FuncDefn`] node.
     fn define_function(
         &mut self,
         name: impl Into<String>,
         signature: Signature,
     ) -> Result<FunctionBuilder<&mut Hugr>, BuildError> {
-        let f_node = self.add_child_op(ops::FuncDef {
+        let f_node = self.add_child_op(ops::FuncDefn {
             name: name.into(),
             signature: signature.clone(),
         })?;
@@ -509,7 +509,7 @@ pub trait Dataflow: Container {
     ///
     /// This function will return an error if there is an error adding the Call
     /// node, or if `function` does not refer to a [`ops::FuncDecl`] or
-    /// [`ops::FuncDef`] node.
+    /// [`ops::FuncDefn`] node.
     fn call<const DEFINED: bool>(
         &mut self,
         function: &FuncID<DEFINED>,
@@ -518,12 +518,12 @@ pub trait Dataflow: Container {
         let hugr = self.hugr();
         let def_op = hugr.get_optype(function.node());
         let signature = match def_op {
-            OpType::FuncDef(ops::FuncDef { signature, .. })
+            OpType::FuncDefn(ops::FuncDefn { signature, .. })
             | OpType::FuncDecl(ops::FuncDecl { signature, .. }) => signature.clone(),
             _ => {
                 return Err(BuildError::UnexpectedType {
                     node: function.node(),
-                    op_desc: "FuncDecl/FuncDef",
+                    op_desc: "FuncDecl/FuncDefn",
                 })
             }
         };

--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -125,16 +125,16 @@ impl<B, T> DFGWrapper<B, T> {
     }
 }
 
-/// Builder for a [`ops::Def`] node
+/// Builder for a [`ops::FuncDef`] node
 pub type FunctionBuilder<B> = DFGWrapper<B, BuildHandle<FuncID<true>>>;
 
 impl FunctionBuilder<Hugr> {
-    /// Initialize a builder for a Def rooted HUGR
+    /// Initialize a builder for a FuncDef rooted HUGR
     /// # Errors
     ///
     /// Error in adding DFG child nodes.
     pub fn new(name: impl Into<String>, signature: Signature) -> Result<Self, BuildError> {
-        let op = ops::Def {
+        let op = ops::FuncDef {
             signature: signature.clone(),
             name: name.into(),
         };

--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -125,16 +125,16 @@ impl<B, T> DFGWrapper<B, T> {
     }
 }
 
-/// Builder for a [`ops::FuncDef`] node
+/// Builder for a [`ops::FuncDefn`] node
 pub type FunctionBuilder<B> = DFGWrapper<B, BuildHandle<FuncID<true>>>;
 
 impl FunctionBuilder<Hugr> {
-    /// Initialize a builder for a FuncDef rooted HUGR
+    /// Initialize a builder for a FuncDefn rooted HUGR
     /// # Errors
     ///
     /// Error in adding DFG child nodes.
     pub fn new(name: impl Into<String>, signature: Signature) -> Result<Self, BuildError> {
-        let op = ops::FuncDef {
+        let op = ops::FuncDefn {
             signature: signature.clone(),
             name: name.into(),
         };

--- a/src/builder/module_builder.rs
+++ b/src/builder/module_builder.rs
@@ -116,24 +116,24 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
         Ok(declare_n.into())
     }
 
-    /// Add a [`OpType::AliasDef`] node and return a handle to the Alias.
+    /// Add a [`OpType::AliasDefn`] node and return a handle to the Alias.
     ///
     /// # Errors
     ///
-    /// Error in adding [`OpType::AliasDef`] child node.
+    /// Error in adding [`OpType::AliasDefn`] child node.
     pub fn add_alias_def(
         &mut self,
         name: impl Into<SmolStr>,
         typ: SimpleType,
     ) -> Result<AliasID<true>, BuildError> {
-        // TODO: add AliasDef in other containers
+        // TODO: add AliasDefn in other containers
         // This is currently tricky as they are not connected to anything so do
         // not appear in topological traversals.
         // Could be fixed by removing single-entry requirement and sorting from
         // every 0-input node.
         let name: SmolStr = name.into();
         let linear = typ.is_linear();
-        let node = self.add_child_op(ops::AliasDef {
+        let node = self.add_child_op(ops::AliasDefn {
             name: name.clone(),
             definition: typ,
         })?;

--- a/src/builder/module_builder.rs
+++ b/src/builder/module_builder.rs
@@ -62,7 +62,7 @@ impl HugrBuilder for ModuleBuilder<Hugr> {
 }
 
 impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
-    /// Replace a [`ops::FuncDeclare`] with [`ops::FuncDef`] and return a builder for
+    /// Replace a [`ops::FuncDecl`] with [`ops::FuncDef`] and return a builder for
     /// the defining graph.
     ///
     /// # Errors
@@ -74,14 +74,14 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
         f_id: &FuncID<false>,
     ) -> Result<FunctionBuilder<&mut Hugr>, BuildError> {
         let f_node = f_id.node();
-        let (signature, name) = if let OpType::FuncDeclare(ops::FuncDeclare { signature, name }) =
+        let (signature, name) = if let OpType::FuncDecl(ops::FuncDecl { signature, name }) =
             self.hugr().get_optype(f_node)
         {
             (signature.clone(), name.clone())
         } else {
             return Err(BuildError::UnexpectedType {
                 node: f_node,
-                op_desc: "OpType::FuncDeclare",
+                op_desc: "OpType::FuncDecl",
             });
         };
         self.hugr_mut().replace_op(
@@ -101,14 +101,14 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
     /// # Errors
     ///
     /// This function will return an error if there is an error in adding the
-    /// [`OpType::FuncDeclare`] node.
+    /// [`OpType::FuncDecl`] node.
     pub fn declare(
         &mut self,
         name: impl Into<String>,
         signature: Signature,
     ) -> Result<FuncID<false>, BuildError> {
         // TODO add param names to metadata
-        let declare_n = self.add_child_op(ops::FuncDeclare {
+        let declare_n = self.add_child_op(ops::FuncDecl {
             signature,
             name: name.into(),
         })?;

--- a/src/builder/module_builder.rs
+++ b/src/builder/module_builder.rs
@@ -62,13 +62,13 @@ impl HugrBuilder for ModuleBuilder<Hugr> {
 }
 
 impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
-    /// Replace a [`ops::FuncDecl`] with [`ops::FuncDef`] and return a builder for
+    /// Replace a [`ops::FuncDecl`] with [`ops::FuncDefn`] and return a builder for
     /// the defining graph.
     ///
     /// # Errors
     ///
     /// This function will return an error if there is an error in adding the
-    /// [`OpType::FuncDef`] node.
+    /// [`OpType::FuncDefn`] node.
     pub fn define_declaration(
         &mut self,
         f_id: &FuncID<false>,
@@ -86,7 +86,7 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
         };
         self.hugr_mut().replace_op(
             f_node,
-            ops::FuncDef {
+            ops::FuncDefn {
                 name,
                 signature: signature.clone(),
             },

--- a/src/builder/module_builder.rs
+++ b/src/builder/module_builder.rs
@@ -141,17 +141,17 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
         Ok(AliasID::new(node, name, linear))
     }
 
-    /// Add a [`OpType::AliasDeclare`] node and return a handle to the Alias.
+    /// Add a [`OpType::AliasDecl`] node and return a handle to the Alias.
     /// # Errors
     ///
-    /// Error in adding [`OpType::AliasDeclare`] child node.
+    /// Error in adding [`OpType::AliasDecl`] child node.
     pub fn add_alias_declare(
         &mut self,
         name: impl Into<SmolStr>,
         linear: bool,
     ) -> Result<AliasID<false>, BuildError> {
         let name: SmolStr = name.into();
-        let node = self.add_child_op(ops::AliasDeclare {
+        let node = self.add_child_op(ops::AliasDecl {
             name: name.clone(),
             linear,
         })?;

--- a/src/builder/module_builder.rs
+++ b/src/builder/module_builder.rs
@@ -62,31 +62,31 @@ impl HugrBuilder for ModuleBuilder<Hugr> {
 }
 
 impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
-    /// Replace a [`ops::Declare`] with [`ops::Def`] and return a builder for
+    /// Replace a [`ops::FuncDeclare`] with [`ops::FuncDef`] and return a builder for
     /// the defining graph.
     ///
     /// # Errors
     ///
     /// This function will return an error if there is an error in adding the
-    /// [`OpType::Def`] node.
+    /// [`OpType::FuncDef`] node.
     pub fn define_declaration(
         &mut self,
         f_id: &FuncID<false>,
     ) -> Result<FunctionBuilder<&mut Hugr>, BuildError> {
         let f_node = f_id.node();
-        let (signature, name) = if let OpType::Declare(ops::Declare { signature, name }) =
+        let (signature, name) = if let OpType::FuncDeclare(ops::FuncDeclare { signature, name }) =
             self.hugr().get_optype(f_node)
         {
             (signature.clone(), name.clone())
         } else {
             return Err(BuildError::UnexpectedType {
                 node: f_node,
-                op_desc: "OpType::Declare",
+                op_desc: "OpType::FuncDeclare",
             });
         };
         self.hugr_mut().replace_op(
             f_node,
-            ops::Def {
+            ops::FuncDef {
                 name,
                 signature: signature.clone(),
             },
@@ -101,14 +101,14 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
     /// # Errors
     ///
     /// This function will return an error if there is an error in adding the
-    /// [`OpType::Declare`] node.
+    /// [`OpType::FuncDeclare`] node.
     pub fn declare(
         &mut self,
         name: impl Into<String>,
         signature: Signature,
     ) -> Result<FuncID<false>, BuildError> {
         // TODO add param names to metadata
-        let declare_n = self.add_child_op(ops::Declare {
+        let declare_n = self.add_child_op(ops::FuncDeclare {
             signature,
             name: name.into(),
         })?;

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -366,7 +366,7 @@ mod test {
         let f: Node = builder
             .add_op_with_parent(
                 module,
-                ops::FuncDef {
+                ops::FuncDefn {
                     name: "main".into(),
                     signature: Signature::new_df(type_row![NAT], type_row![NAT, NAT]),
                 },

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -366,7 +366,7 @@ mod test {
         let f: Node = builder
             .add_op_with_parent(
                 module,
-                ops::Def {
+                ops::FuncDef {
                     name: "main".into(),
                     signature: Signature::new_df(type_row![NAT], type_row![NAT, NAT]),
                 },

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -436,7 +436,7 @@ impl<'a> ValidationContext<'a> {
                     return typecheck_const(&typ, val).map_err(ValidationError::from);
                 } else {
                     // If const edges aren't coming from const nodes, they're graph
-                    // edges coming from Declare or Def
+                    // edges coming from FuncDeclare or FuncDef
                     return if OpTag::Function.contains(from_optype.tag()) {
                         Ok(())
                     } else {
@@ -746,7 +746,7 @@ mod test {
     ///
     /// Returns the hugr and the node index of the definition.
     fn make_simple_hugr(copies: usize) -> (Hugr, Node) {
-        let def_op: OpType = ops::Def {
+        let def_op: OpType = ops::FuncDef {
             name: "main".into(),
             signature: Signature::new_df(type_row![B], vec![B; copies]),
         }
@@ -827,7 +827,7 @@ mod test {
 
     #[test]
     fn invalid_root() {
-        let declare_op: OpType = ops::Declare {
+        let declare_op: OpType = ops::FuncDeclare {
             name: "main".into(),
             signature: Default::default(),
         }
@@ -906,7 +906,7 @@ mod test {
         let new_def = b
             .add_op_with_parent(
                 root,
-                ops::Def {
+                ops::FuncDef {
                     signature: def_sig,
                     name: "main".into(),
                 },

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -436,7 +436,7 @@ impl<'a> ValidationContext<'a> {
                     return typecheck_const(&typ, val).map_err(ValidationError::from);
                 } else {
                     // If const edges aren't coming from const nodes, they're graph
-                    // edges coming from FuncDecl or FuncDef
+                    // edges coming from FuncDecl or FuncDefn
                     return if OpTag::Function.contains(from_optype.tag()) {
                         Ok(())
                     } else {
@@ -746,7 +746,7 @@ mod test {
     ///
     /// Returns the hugr and the node index of the definition.
     fn make_simple_hugr(copies: usize) -> (Hugr, Node) {
-        let def_op: OpType = ops::FuncDef {
+        let def_op: OpType = ops::FuncDefn {
             name: "main".into(),
             signature: Signature::new_df(type_row![B], vec![B; copies]),
         }
@@ -906,7 +906,7 @@ mod test {
         let new_def = b
             .add_op_with_parent(
                 root,
-                ops::FuncDef {
+                ops::FuncDefn {
                     signature: def_sig,
                     name: "main".into(),
                 },

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -436,7 +436,7 @@ impl<'a> ValidationContext<'a> {
                     return typecheck_const(&typ, val).map_err(ValidationError::from);
                 } else {
                     // If const edges aren't coming from const nodes, they're graph
-                    // edges coming from FuncDeclare or FuncDef
+                    // edges coming from FuncDecl or FuncDef
                     return if OpTag::Function.contains(from_optype.tag()) {
                         Ok(())
                     } else {
@@ -827,7 +827,7 @@ mod test {
 
     #[test]
     fn invalid_root() {
-        let declare_op: OpType = ops::FuncDeclare {
+        let declare_op: OpType = ops::FuncDecl {
             name: "main".into(),
             signature: Default::default(),
         }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -24,7 +24,7 @@ pub use constant::{Const, ConstValue};
 pub use controlflow::{BasicBlock, Case, Conditional, TailLoop, CFG};
 pub use dataflow::{Call, CallIndirect, Input, LoadConstant, Output, DFG};
 pub use leaf::LeafOp;
-pub use module::{AliasDeclare, AliasDef, Declare, Def, Module};
+pub use module::{AliasDeclare, AliasDef, FuncDeclare, FuncDef, Module};
 
 #[enum_dispatch(OpTrait, OpName, ValidateOp)]
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -35,8 +35,8 @@ pub use module::{AliasDeclare, AliasDef, Declare, Def, Module};
 #[serde(tag = "op")]
 pub enum OpType {
     Module,
-    Def,
-    Declare,
+    FuncDef,
+    FuncDeclare,
     AliasDeclare,
     AliasDef,
     Const,

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -24,7 +24,7 @@ pub use constant::{Const, ConstValue};
 pub use controlflow::{BasicBlock, Case, Conditional, TailLoop, CFG};
 pub use dataflow::{Call, CallIndirect, Input, LoadConstant, Output, DFG};
 pub use leaf::LeafOp;
-pub use module::{AliasDeclare, AliasDef, FuncDeclare, FuncDef, Module};
+pub use module::{AliasDeclare, AliasDef, FuncDecl, FuncDef, Module};
 
 #[enum_dispatch(OpTrait, OpName, ValidateOp)]
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -36,7 +36,7 @@ pub use module::{AliasDeclare, AliasDef, FuncDeclare, FuncDef, Module};
 pub enum OpType {
     Module,
     FuncDef,
-    FuncDeclare,
+    FuncDecl,
     AliasDeclare,
     AliasDef,
     Const,

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -24,7 +24,7 @@ pub use constant::{Const, ConstValue};
 pub use controlflow::{BasicBlock, Case, Conditional, TailLoop, CFG};
 pub use dataflow::{Call, CallIndirect, Input, LoadConstant, Output, DFG};
 pub use leaf::LeafOp;
-pub use module::{AliasDeclare, AliasDefn, FuncDecl, FuncDefn, Module};
+pub use module::{AliasDecl, AliasDefn, FuncDecl, FuncDefn, Module};
 
 #[enum_dispatch(OpTrait, OpName, ValidateOp)]
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -37,7 +37,7 @@ pub enum OpType {
     Module,
     FuncDefn,
     FuncDecl,
-    AliasDeclare,
+    AliasDecl,
     AliasDefn,
     Const,
     Input,

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -24,7 +24,7 @@ pub use constant::{Const, ConstValue};
 pub use controlflow::{BasicBlock, Case, Conditional, TailLoop, CFG};
 pub use dataflow::{Call, CallIndirect, Input, LoadConstant, Output, DFG};
 pub use leaf::LeafOp;
-pub use module::{AliasDeclare, AliasDef, FuncDecl, FuncDefn, Module};
+pub use module::{AliasDeclare, AliasDefn, FuncDecl, FuncDefn, Module};
 
 #[enum_dispatch(OpTrait, OpName, ValidateOp)]
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -38,7 +38,7 @@ pub enum OpType {
     FuncDefn,
     FuncDecl,
     AliasDeclare,
-    AliasDef,
+    AliasDefn,
     Const,
     Input,
     Output,

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -24,7 +24,7 @@ pub use constant::{Const, ConstValue};
 pub use controlflow::{BasicBlock, Case, Conditional, TailLoop, CFG};
 pub use dataflow::{Call, CallIndirect, Input, LoadConstant, Output, DFG};
 pub use leaf::LeafOp;
-pub use module::{AliasDeclare, AliasDef, FuncDecl, FuncDef, Module};
+pub use module::{AliasDeclare, AliasDef, FuncDecl, FuncDefn, Module};
 
 #[enum_dispatch(OpTrait, OpName, ValidateOp)]
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -35,7 +35,7 @@ pub use module::{AliasDeclare, AliasDef, FuncDecl, FuncDef, Module};
 #[serde(tag = "op")]
 pub enum OpType {
     Module,
-    FuncDef,
+    FuncDefn,
     FuncDecl,
     AliasDeclare,
     AliasDef,

--- a/src/ops/handle.rs
+++ b/src/ops/handle.rs
@@ -59,7 +59,7 @@ pub struct ModuleID(Node);
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, DerFrom, Debug)]
 /// Handle to a [def](crate::ops::OpType::FuncDef)
-/// or [declare](crate::ops::OpType::FuncDeclare) node.
+/// or [declare](crate::ops::OpType::FuncDecl) node.
 ///
 /// The `DEF` const generic is used to indicate whether the function is
 /// defined or just declared.

--- a/src/ops/handle.rs
+++ b/src/ops/handle.rs
@@ -67,7 +67,7 @@ pub struct FuncID<const DEF: bool>(Node);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Handle to an [AliasDefn](crate::ops::OpType::AliasDefn)
-/// or [AliasDeclare](crate::ops::OpType::AliasDeclare) node.
+/// or [AliasDecl](crate::ops::OpType::AliasDecl) node.
 ///
 /// The `DEF` const generic is used to indicate whether the function is
 /// defined or just declared.

--- a/src/ops/handle.rs
+++ b/src/ops/handle.rs
@@ -58,7 +58,7 @@ pub struct ModuleRootID(Node);
 pub struct ModuleID(Node);
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, DerFrom, Debug)]
-/// Handle to a [def](crate::ops::OpType::FuncDef)
+/// Handle to a [def](crate::ops::OpType::FuncDefn)
 /// or [declare](crate::ops::OpType::FuncDecl) node.
 ///
 /// The `DEF` const generic is used to indicate whether the function is

--- a/src/ops/handle.rs
+++ b/src/ops/handle.rs
@@ -66,7 +66,7 @@ pub struct ModuleID(Node);
 pub struct FuncID<const DEF: bool>(Node);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-/// Handle to an [AliasDef](crate::ops::OpType::AliasDef)
+/// Handle to an [AliasDefn](crate::ops::OpType::AliasDefn)
 /// or [AliasDeclare](crate::ops::OpType::AliasDeclare) node.
 ///
 /// The `DEF` const generic is used to indicate whether the function is

--- a/src/ops/handle.rs
+++ b/src/ops/handle.rs
@@ -58,8 +58,8 @@ pub struct ModuleRootID(Node);
 pub struct ModuleID(Node);
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, DerFrom, Debug)]
-/// Handle to a [def](crate::ops::OpType::Def)
-/// or [declare](crate::ops::OpType::Declare) node.
+/// Handle to a [def](crate::ops::OpType::FuncDef)
+/// or [declare](crate::ops::OpType::FuncDeclare) node.
 ///
 /// The `DEF` const generic is used to indicate whether the function is
 /// defined or just declared.

--- a/src/ops/module.rs
+++ b/src/ops/module.rs
@@ -98,16 +98,16 @@ impl OpTrait for AliasDefn {
 
 /// A type alias declaration. Resolved at link time.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct AliasDeclare {
+pub struct AliasDecl {
     /// Alias name
     pub name: SmolStr,
     /// Flag to signify type is linear
     pub linear: bool,
 }
 
-impl_op_name!(AliasDeclare);
+impl_op_name!(AliasDecl);
 
-impl OpTrait for AliasDeclare {
+impl OpTrait for AliasDecl {
     fn description(&self) -> &str {
         "A type alias declaration"
     }

--- a/src/ops/module.rs
+++ b/src/ops/module.rs
@@ -26,21 +26,21 @@ impl OpTrait for Module {
 ///
 /// Children nodes are the body of the definition.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct Def {
+pub struct FuncDef {
     /// Name of function
     pub name: String,
     /// Signature of the function
     pub signature: Signature,
 }
 
-impl_op_name!(Def);
-impl OpTrait for Def {
+impl_op_name!(FuncDef);
+impl OpTrait for FuncDef {
     fn description(&self) -> &str {
         "A function definition"
     }
 
     fn tag(&self) -> OpTag {
-        OpTag::Def
+        OpTag::FuncDef
     }
 
     fn other_output(&self) -> Option<EdgeKind> {
@@ -52,16 +52,16 @@ impl OpTrait for Def {
 
 /// External function declaration, linked at runtime.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct Declare {
+pub struct FuncDeclare {
     /// Name of function
     pub name: String,
     /// Signature of the function
     pub signature: Signature,
 }
 
-impl_op_name!(Declare);
+impl_op_name!(FuncDeclare);
 
-impl OpTrait for Declare {
+impl OpTrait for FuncDeclare {
     fn description(&self) -> &str {
         "External function declaration, linked at runtime"
     }

--- a/src/ops/module.rs
+++ b/src/ops/module.rs
@@ -52,16 +52,16 @@ impl OpTrait for FuncDef {
 
 /// External function declaration, linked at runtime.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct FuncDeclare {
+pub struct FuncDecl {
     /// Name of function
     pub name: String,
     /// Signature of the function
     pub signature: Signature,
 }
 
-impl_op_name!(FuncDeclare);
+impl_op_name!(FuncDecl);
 
-impl OpTrait for FuncDeclare {
+impl OpTrait for FuncDecl {
     fn description(&self) -> &str {
         "External function declaration, linked at runtime"
     }

--- a/src/ops/module.rs
+++ b/src/ops/module.rs
@@ -26,21 +26,21 @@ impl OpTrait for Module {
 ///
 /// Children nodes are the body of the definition.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct FuncDef {
+pub struct FuncDefn {
     /// Name of function
     pub name: String,
     /// Signature of the function
     pub signature: Signature,
 }
 
-impl_op_name!(FuncDef);
-impl OpTrait for FuncDef {
+impl_op_name!(FuncDefn);
+impl OpTrait for FuncDefn {
     fn description(&self) -> &str {
         "A function definition"
     }
 
     fn tag(&self) -> OpTag {
-        OpTag::FuncDef
+        OpTag::FuncDefn
     }
 
     fn other_output(&self) -> Option<EdgeKind> {

--- a/src/ops/module.rs
+++ b/src/ops/module.rs
@@ -79,14 +79,14 @@ impl OpTrait for FuncDecl {
 
 /// A type alias definition, used only for debug/metadata.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct AliasDef {
+pub struct AliasDefn {
     /// Alias name
     pub name: SmolStr,
     /// Aliased type
     pub definition: SimpleType,
 }
-impl_op_name!(AliasDef);
-impl OpTrait for AliasDef {
+impl_op_name!(AliasDefn);
+impl OpTrait for AliasDefn {
     fn description(&self) -> &str {
         "A type alias definition"
     }

--- a/src/ops/tag.rs
+++ b/src/ops/tag.rs
@@ -29,7 +29,7 @@ pub enum OpTag {
     /// A constant declaration.
     Const,
     /// A function definition.
-    FuncDef,
+    FuncDefn,
 
     /// Node in a Dataflow Sibling Graph.
     DataflowChild,
@@ -81,7 +81,7 @@ impl OpTag {
             OpTag::Output => &[OpTag::DataflowChild],
             OpTag::Function => &[OpTag::ModuleOp],
             OpTag::Alias => &[OpTag::ModuleOp],
-            OpTag::FuncDef => &[OpTag::Function, OpTag::DataflowChild],
+            OpTag::FuncDefn => &[OpTag::Function, OpTag::DataflowChild],
             OpTag::BasicBlock => &[OpTag::Any],
             OpTag::BasicBlockExit => &[OpTag::BasicBlock],
             OpTag::Case => &[OpTag::Any],
@@ -107,7 +107,7 @@ impl OpTag {
             OpTag::DataflowChild => "Node in a Dataflow Sibling Graph",
             OpTag::Input => "Input node",
             OpTag::Output => "Output node",
-            OpTag::FuncDef => "Function definition",
+            OpTag::FuncDefn => "Function definition",
             OpTag::BasicBlock => "Basic block",
             OpTag::BasicBlockExit => "Exit basic block node",
             OpTag::Case => "Case",

--- a/src/ops/tag.rs
+++ b/src/ops/tag.rs
@@ -22,14 +22,14 @@ pub enum OpTag {
     ModuleOp,
     /// Root module operation.
     ModuleRoot,
-    /// A function definition.
-    Def,
     /// A function definition or declaration.
     Function,
     /// A type alias.
     Alias,
     /// A constant declaration.
     Const,
+    /// A function definition.
+    FuncDef,
 
     /// Node in a Dataflow Sibling Graph.
     DataflowChild,
@@ -81,7 +81,7 @@ impl OpTag {
             OpTag::Output => &[OpTag::DataflowChild],
             OpTag::Function => &[OpTag::ModuleOp],
             OpTag::Alias => &[OpTag::ModuleOp],
-            OpTag::Def => &[OpTag::Function, OpTag::DataflowChild],
+            OpTag::FuncDef => &[OpTag::Function, OpTag::DataflowChild],
             OpTag::BasicBlock => &[OpTag::Any],
             OpTag::BasicBlockExit => &[OpTag::BasicBlock],
             OpTag::Case => &[OpTag::Any],
@@ -107,7 +107,7 @@ impl OpTag {
             OpTag::DataflowChild => "Node in a Dataflow Sibling Graph",
             OpTag::Input => "Input node",
             OpTag::Output => "Output node",
-            OpTag::Def => "Function definition",
+            OpTag::FuncDef => "Function definition",
             OpTag::BasicBlock => "Basic block",
             OpTag::BasicBlockExit => "Exit basic block node",
             OpTag::Case => "Case",

--- a/src/ops/validate.rs
+++ b/src/ops/validate.rs
@@ -532,11 +532,10 @@ mod test {
 }
 
 use super::{
-    AliasDeclare, AliasDefn, Call, CallIndirect, Const, FuncDecl, Input, LeafOp, LoadConstant,
-    Output,
+    AliasDecl, AliasDefn, Call, CallIndirect, Const, FuncDecl, Input, LeafOp, LoadConstant, Output,
 };
 impl_validate_op!(FuncDecl);
-impl_validate_op!(AliasDeclare);
+impl_validate_op!(AliasDecl);
 impl_validate_op!(AliasDefn);
 impl_validate_op!(Input);
 impl_validate_op!(Output);

--- a/src/ops/validate.rs
+++ b/src/ops/validate.rs
@@ -532,12 +532,12 @@ mod test {
 }
 
 use super::{
-    AliasDeclare, AliasDef, Call, CallIndirect, Const, FuncDecl, Input, LeafOp, LoadConstant,
+    AliasDeclare, AliasDefn, Call, CallIndirect, Const, FuncDecl, Input, LeafOp, LoadConstant,
     Output,
 };
 impl_validate_op!(FuncDecl);
 impl_validate_op!(AliasDeclare);
-impl_validate_op!(AliasDef);
+impl_validate_op!(AliasDefn);
 impl_validate_op!(Input);
 impl_validate_op!(Output);
 impl_validate_op!(Const);

--- a/src/ops/validate.rs
+++ b/src/ops/validate.rs
@@ -81,7 +81,7 @@ impl ValidateOp for super::Module {
     }
 }
 
-impl ValidateOp for super::Def {
+impl ValidateOp for super::FuncDef {
     fn validity_flags(&self) -> OpValidityFlags {
         OpValidityFlags {
             allowed_children: OpTag::DataflowChild,
@@ -532,9 +532,10 @@ mod test {
 }
 
 use super::{
-    AliasDeclare, AliasDef, Call, CallIndirect, Const, Declare, Input, LeafOp, LoadConstant, Output,
+    AliasDeclare, AliasDef, Call, CallIndirect, Const, FuncDeclare, Input, LeafOp, LoadConstant,
+    Output,
 };
-impl_validate_op!(Declare);
+impl_validate_op!(FuncDeclare);
 impl_validate_op!(AliasDeclare);
 impl_validate_op!(AliasDef);
 impl_validate_op!(Input);

--- a/src/ops/validate.rs
+++ b/src/ops/validate.rs
@@ -81,7 +81,7 @@ impl ValidateOp for super::Module {
     }
 }
 
-impl ValidateOp for super::FuncDef {
+impl ValidateOp for super::FuncDefn {
     fn validity_flags(&self) -> OpValidityFlags {
         OpValidityFlags {
             allowed_children: OpTag::DataflowChild,

--- a/src/ops/validate.rs
+++ b/src/ops/validate.rs
@@ -532,10 +532,10 @@ mod test {
 }
 
 use super::{
-    AliasDeclare, AliasDef, Call, CallIndirect, Const, FuncDeclare, Input, LeafOp, LoadConstant,
+    AliasDeclare, AliasDef, Call, CallIndirect, Const, FuncDecl, Input, LeafOp, LoadConstant,
     Output,
 };
-impl_validate_op!(FuncDeclare);
+impl_validate_op!(FuncDecl);
 impl_validate_op!(AliasDeclare);
 impl_validate_op!(AliasDef);
 impl_validate_op!(Input);

--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -67,7 +67,7 @@ pub enum Container<T: PrimType> {
     Sum(Box<TypeRow>),
     /// Known size array of T.
     Array(Box<T>, usize),
-    /// Alias defined in AliasDef or AliasDeclare nodes.
+    /// Alias defined in AliasDefn or AliasDeclare nodes.
     Alias(SmolStr),
 }
 

--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -67,7 +67,7 @@ pub enum Container<T: PrimType> {
     Sum(Box<TypeRow>),
     /// Known size array of T.
     Array(Box<T>, usize),
-    /// Alias defined in AliasDefn or AliasDeclare nodes.
+    /// Alias defined in AliasDefn or AliasDecl nodes.
     Alias(SmolStr),
 }
 


### PR DESCRIPTION
Def => FuncDefn
Declare => FuncDeclare (there are a couple of uses of "Declare" as a verb that I've preserved)
Alias => AliasDefn
AliasDeclare => AliasDecl

Also update spec.