### PR TITLE
[Tests] Rrefactor nest_cfg tests to use CFG-rooted Hugrs (and RegionView's)

### DIFF
--- a/src/algorithm/half_node.rs
+++ b/src/algorithm/half_node.rs
@@ -2,7 +2,6 @@ use std::hash::Hash;
 
 use super::nest_cfgs::CfgView;
 use crate::hugr::view::HugrView;
-use crate::ops::handle::{CfgID, NodeHandle};
 use crate::ops::tag::OpTag;
 use crate::ops::OpTrait;
 use crate::{Direction, Node};
@@ -31,8 +30,8 @@ struct HalfNodeView<'a, H> {
 
 impl<'a, H: HugrView> HalfNodeView<'a, H> {
     #[allow(unused)]
-    pub(crate) fn new(h: &'a H, cfg: CfgID) -> Self {
-        let mut children = h.children(cfg.node());
+    pub(crate) fn new(h: &'a H) -> Self {
+        let mut children = h.children(h.root());
         let entry = children.next().unwrap(); // Panic if malformed
         let exit = children.next().unwrap();
         assert_eq!(h.get_optype(exit).tag(), OpTag::BasicBlockExit);
@@ -95,6 +94,7 @@ mod test {
     use super::super::nest_cfgs::{test::*, EdgeClassifier};
     use super::{HalfNode, HalfNodeView};
     use crate::builder::BuildError;
+    use crate::hugr::region::FlatRegionView;
     use crate::ops::handle::NodeHandle;
     use itertools::Itertools;
     use std::collections::HashSet;
@@ -112,7 +112,8 @@ mod test {
         //               |          \-> right -/                 |
         //               \---<---<---<---<---<---<---<---<---<---/
         // Allowing to identity two nested regions (and fixing the problem with a SimpleCfgView on the same example)
-        let v = HalfNodeView::new(&h, cfg_id);
+        let region = FlatRegionView::new(&h, cfg_id.node());
+        let v = HalfNodeView::new(&region);
         let edge_classes = EdgeClassifier::get_edge_classes(&v);
         let HalfNodeView { h: _, entry, exit } = v;
 

--- a/src/algorithm/half_node.rs
+++ b/src/algorithm/half_node.rs
@@ -94,13 +94,12 @@ mod test {
     use super::super::nest_cfgs::{test::*, EdgeClassifier};
     use super::{HalfNode, HalfNodeView};
     use crate::builder::BuildError;
-    use crate::hugr::region::FlatRegionView;
     use crate::ops::handle::NodeHandle;
     use itertools::Itertools;
     use std::collections::HashSet;
     #[test]
     fn test_cond_in_loop_combined_headers() -> Result<(), BuildError> {
-        let (h, cfg_id, main, tail) = build_conditional_in_loop_cfg(false)?;
+        let (h, main, tail) = build_conditional_in_loop_cfg(false)?;
         //               /-> left --\
         //  entry -> main            > merge -> tail -> exit
         //            |  \-> right -/             |
@@ -112,8 +111,7 @@ mod test {
         //               |          \-> right -/                 |
         //               \---<---<---<---<---<---<---<---<---<---/
         // Allowing to identity two nested regions (and fixing the problem with a SimpleCfgView on the same example)
-        let region = FlatRegionView::new(&h, cfg_id.node());
-        let v = HalfNodeView::new(&region);
+        let v = HalfNodeView::new(&h);
         let edge_classes = EdgeClassifier::get_edge_classes(&v);
         let HalfNodeView { h: _, entry, exit } = v;
 

--- a/src/algorithm/nest_cfgs.rs
+++ b/src/algorithm/nest_cfgs.rs
@@ -397,16 +397,12 @@ impl<T: Copy + Clone + PartialEq + Eq + Hash> EdgeClassifier<T> {
 #[cfg(test)]
 pub(crate) mod test {
     use super::*;
-    use crate::builder::{
-        BuildError, CFGBuilder, Container, Dataflow, DataflowSubContainer, HugrBuilder,
-        ModuleBuilder, SubContainer,
-    };
-    use crate::hugr::region::FlatRegionView;
+    use crate::builder::{BuildError, CFGBuilder, Container, DataflowSubContainer, HugrBuilder};
     use crate::ops::{
-        handle::{BasicBlockID, CfgID, ConstID, NodeHandle},
+        handle::{BasicBlockID, ConstID, NodeHandle},
         ConstValue,
     };
-    use crate::types::{ClassicType, Signature, SimpleType};
+    use crate::types::{ClassicType, SimpleType};
     use crate::{type_row, Hugr};
     const NAT: SimpleType = SimpleType::Classic(ClassicType::i64());
 
@@ -429,19 +425,12 @@ pub(crate) mod test {
         //               /-> left --\
         // entry -> split            > merge -> head -> tail -> exit
         //               \-> right -/             \-<--<-/
-        let mut module_builder = ModuleBuilder::new();
-        let main = module_builder.declare("main", Signature::new_df(vec![NAT], type_row![NAT]))?;
-        let pred_const = module_builder.add_constant(ConstValue::simple_predicate(0, 2))?; // Nothing here cares which
-        let const_unit = module_builder.add_constant(ConstValue::simple_unary_predicate())?;
+        let mut cfg_builder = CFGBuilder::new(type_row![NAT], type_row![NAT])?;
+        let mut entry_builder = cfg_builder.simple_entry_builder(type_row![NAT], 1)?;
+        let pred_const = entry_builder.add_constant(ConstValue::simple_predicate(0, 2))?; // Nothing here cares which
+        let const_unit = entry_builder.add_constant(ConstValue::simple_unary_predicate())?;
 
-        let mut func_builder = module_builder.define_declaration(&main)?;
-        let [int] = func_builder.input_wires_arr();
-
-        let mut cfg_builder = func_builder.cfg_builder(vec![(NAT, int)], type_row![NAT])?;
-        let entry = n_identity(
-            cfg_builder.simple_entry_builder(type_row![NAT], 1)?,
-            &const_unit,
-        )?;
+        let entry = n_identity(entry_builder, &const_unit)?;
         let (split, merge) = build_if_then_else_merge(&mut cfg_builder, &pred_const, &const_unit)?;
         cfg_builder.branch(&entry, 0, &split)?;
         let (head, tail) = build_loop(&mut cfg_builder, &pred_const, &const_unit)?;
@@ -449,16 +438,12 @@ pub(crate) mod test {
         cfg_builder.branch(&merge, 0, &head)?;
         let exit = cfg_builder.exit_block();
         cfg_builder.branch(&tail, 0, &exit)?;
-        let cfg_id = cfg_builder.finish_sub_container()?;
 
-        func_builder.finish_with_outputs(cfg_id.outputs())?;
-        let h = module_builder.finish_hugr()?;
+        let h = cfg_builder.finish_hugr()?;
 
         let (entry, exit) = (entry.node(), exit.node());
         let (split, merge, head, tail) = (split.node(), merge.node(), head.node(), tail.node());
-        let edge_classes = EdgeClassifier::get_edge_classes(&SimpleCfgView::new(
-            &FlatRegionView::new(&h, cfg_id.node()),
-        ));
+        let edge_classes = EdgeClassifier::get_edge_classes(&SimpleCfgView::new(&h));
         let [&left,&right] = edge_classes.keys().filter(|(s,_)| *s == split).map(|(_,t)|t).collect::<Vec<_>>()[..] else {panic!("Split node should have two successors");};
 
         let classes = group_by(edge_classes);
@@ -482,35 +467,23 @@ pub(crate) mod test {
         //      \-> right -/     \-<--<-/
         // Here we would like two consecutive regions, but there is no *edge* between
         // the conditional and the loop to indicate the boundary, so we cannot separate them.
-        let mut module_builder = ModuleBuilder::new();
-        let main = module_builder.declare("main", Signature::new_df(vec![NAT], type_row![NAT]))?;
-        let pred_const = module_builder.add_constant(ConstValue::simple_predicate(0, 2))?; // Nothing here cares which
-        let const_unit = module_builder.add_constant(ConstValue::simple_unary_predicate())?;
+        let mut cfg_builder = CFGBuilder::new(type_row![NAT], type_row![NAT])?;
+        let mut entry = cfg_builder.simple_entry_builder(type_row![NAT], 2)?;
+        let pred_const = entry.add_constant(ConstValue::simple_predicate(0, 2))?; // Nothing here cares which
+        let const_unit = entry.add_constant(ConstValue::simple_unary_predicate())?;
 
-        let mut func_builder = module_builder.define_declaration(&main)?;
-        let [int] = func_builder.input_wires_arr();
-
-        let mut cfg_builder = func_builder.cfg_builder(vec![(NAT, int)], type_row![NAT])?;
-        let entry = n_identity(
-            cfg_builder.simple_entry_builder(type_row![NAT], 2)?,
-            &pred_const,
-        )?;
+        let entry = n_identity(entry, &pred_const)?;
         let merge = build_then_else_merge_from_if(&mut cfg_builder, &const_unit, entry)?;
         let tail = build_loop_from_header(&mut cfg_builder, &pred_const, merge)?;
         cfg_builder.branch(&merge, 0, &tail)?; // trivial "loop body"
         let exit = cfg_builder.exit_block();
         cfg_builder.branch(&tail, 0, &exit)?;
-        let cfg_id = cfg_builder.finish_sub_container()?;
 
-        func_builder.finish_with_outputs(cfg_id.outputs())?;
-
-        let h = module_builder.finish_hugr()?;
+        let h = cfg_builder.finish_hugr()?;
 
         let (entry, exit) = (entry.node(), exit.node());
         let (merge, tail) = (merge.node(), tail.node());
-        let edge_classes = EdgeClassifier::get_edge_classes(&SimpleCfgView::new(
-            &FlatRegionView::new(&h, cfg_id.node()),
-        ));
+        let edge_classes = EdgeClassifier::get_edge_classes(&SimpleCfgView::new(&h));
         let [&left,&right] = edge_classes.keys().filter(|(s,_)| *s == entry).map(|(_,t)|t).collect::<Vec<_>>()[..] else {panic!("Entry node should have two successors");};
 
         let classes = group_by(edge_classes);
@@ -529,15 +502,14 @@ pub(crate) mod test {
 
     #[test]
     fn test_cond_in_loop_separate_headers() -> Result<(), BuildError> {
-        let (h, cfg_id, head, tail) = build_conditional_in_loop_cfg(true)?;
+        let (h, head, tail) = build_conditional_in_loop_cfg(true)?;
         let head = head.node();
         let tail = tail.node();
         //                        /-> left --\
         //  entry -> head -> split            > merge -> tail -> exit
         //             |          \-> right -/             |
         //             \---<---<---<---<---<---<---<---<---/
-        let view = FlatRegionView::new(&h, cfg_id.node());
-        let v = SimpleCfgView::new(&view);
+        let v = SimpleCfgView::new(&h);
         let edge_classes = EdgeClassifier::get_edge_classes(&v);
         let SimpleCfgView { h: _, entry, exit } = v;
         // split is unique successor of head
@@ -571,7 +543,7 @@ pub(crate) mod test {
 
     #[test]
     fn test_cond_in_loop_combined_headers() -> Result<(), BuildError> {
-        let (h, cfg_id, head, tail) = build_conditional_in_loop_cfg(false)?;
+        let (h, head, tail) = build_conditional_in_loop_cfg(false)?;
         let head = head.node();
         let tail = tail.node();
         //               /-> left --\
@@ -580,8 +552,7 @@ pub(crate) mod test {
         //             \---<---<---<---<---<--<---/
         // Here we would like an indication that we can make two nested regions,
         // but there is no edge to act as entry to a region containing just the conditional :-(.
-        let view = FlatRegionView::new(&h, cfg_id.node());
-        let v = SimpleCfgView::new(&view);
+        let v = SimpleCfgView::new(&h);
         let edge_classes = EdgeClassifier::get_edge_classes(&v);
         let SimpleCfgView { h: _, entry, exit } = v;
         // merge is unique predecessor of tail
@@ -683,22 +654,16 @@ pub(crate) mod test {
     // Build a CFG, returning the Hugr
     pub fn build_conditional_in_loop_cfg(
         separate_headers: bool,
-    ) -> Result<(Hugr, CfgID, BasicBlockID, BasicBlockID), BuildError> {
+    ) -> Result<(Hugr, BasicBlockID, BasicBlockID), BuildError> {
         //let sum2_type = SimpleType::new_predicate(2);
 
-        let mut module_builder = ModuleBuilder::new();
-        let main = module_builder.declare("main", Signature::new_df(vec![NAT], type_row![NAT]))?;
-        let pred_const = module_builder.add_constant(ConstValue::simple_predicate(0, 2))?; // Nothing here cares which
-        let const_unit = module_builder.add_constant(ConstValue::simple_unary_predicate())?;
+        let mut cfg_builder = CFGBuilder::new(type_row![NAT], type_row![NAT])?;
+        let mut entry_builder = cfg_builder.simple_entry_builder(type_row![NAT], 1)?;
 
-        let mut func_builder = module_builder.define_declaration(&main)?;
-        let [int] = func_builder.input_wires_arr();
+        let pred_const = entry_builder.add_constant(ConstValue::simple_predicate(0, 2))?; // Nothing here cares which
+        let const_unit = entry_builder.add_constant(ConstValue::simple_unary_predicate())?;
 
-        let mut cfg_builder = func_builder.cfg_builder(vec![(NAT, int)], type_row![NAT])?;
-        let entry = n_identity(
-            cfg_builder.simple_entry_builder(type_row![NAT], 1)?,
-            &const_unit,
-        )?;
+        let entry = n_identity(entry_builder, &const_unit)?;
         let (split, merge) = build_if_then_else_merge(&mut cfg_builder, &pred_const, &const_unit)?;
 
         let (head, tail) = if separate_headers {
@@ -717,12 +682,7 @@ pub(crate) mod test {
         cfg_builder.branch(&entry, 0, &head)?;
         cfg_builder.branch(&tail, 0, &exit)?;
 
-        let cfg_id = cfg_builder.finish_sub_container()?;
-
-        func_builder.finish_with_outputs(cfg_id.outputs())?;
-
-        let h = module_builder.finish_hugr()?;
-
-        Ok((h, *cfg_id.handle(), head, tail))
+        let h = cfg_builder.finish_hugr()?;
+        Ok((h, head, tail))
     }
 }


### PR DESCRIPTION
The first commit shows we no longer need to pass the parent of the Cfg into the "CfgView" wrapper classes, because FlatRegionView does that work for us :-). (We still need this extra level of indirection, over a view onto the Hugr, because using types other than hugr::Node will allow us to increase the power of the analysis, as `HalfNodeView` demonstrates; but it's a little easier now).

The second commit rewrites the tests to use CFG-rooted Hugrs, avoiding the enclosing module/function/etc. stuff. This greatly simplifies the tests, and means that (for these tests) we don't even need FlatRegionView (but we would if performing this analysis on a real Hugr).