### PR TITLE
Node metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ enum_dispatch = "0.3.11"
 lazy_static = "1.4.0"
 petgraph = { version="0.6.3", default-features = false}
 context-iterators = "0.2.0"
+serde_json = "1.0.97"
 
 [features]
 pyo3 = ["dep:pyo3"]
@@ -54,7 +55,6 @@ rmp-serde = "1.1.1"
 webbrowser = "0.8.10"
 urlencoding = "2.1.2"
 cool_asserts = "2.0.3"
-serde_json = "1.0.97"
 
 [[bench]]
 name = "bench_main"

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -1,6 +1,6 @@
 use crate::hugr::validate::InterGraphEdgeError;
 use crate::hugr::view::HugrView;
-use crate::hugr::{Node, Port, ValidationError};
+use crate::hugr::{Node, OpMetadata, Port, ValidationError};
 use crate::ops::{self, ConstValue, LeafOp, OpTrait, OpType};
 
 use std::iter;
@@ -99,6 +99,17 @@ pub trait Container {
     fn add_hugr_view(&mut self, child: &impl HugrView) -> Result<Node, BuildError> {
         let parent = self.container_node();
         Ok(self.hugr_mut().insert_from_view(parent, child)?)
+    }
+
+    /// Add metadata to the container node.
+    fn set_metadata(&mut self, meta: OpMetadata) {
+        let parent = self.container_node();
+        self.hugr_mut().set_metadata(parent, meta);
+    }
+
+    /// Add metadata to a child node.
+    fn set_child_metadata(&mut self, child: Node, meta: OpMetadata) {
+        self.hugr_mut().set_metadata(child, meta);
     }
 }
 

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -1,6 +1,6 @@
 use crate::hugr::validate::InterGraphEdgeError;
 use crate::hugr::view::HugrView;
-use crate::hugr::{Node, OpMetadata, Port, ValidationError};
+use crate::hugr::{Node, NodeMetadata, Port, ValidationError};
 use crate::ops::{self, ConstValue, LeafOp, OpTrait, OpType};
 
 use std::iter;
@@ -102,13 +102,13 @@ pub trait Container {
     }
 
     /// Add metadata to the container node.
-    fn set_metadata(&mut self, meta: OpMetadata) {
+    fn set_metadata(&mut self, meta: NodeMetadata) {
         let parent = self.container_node();
         self.hugr_mut().set_metadata(parent, meta);
     }
 
     /// Add metadata to a child node.
-    fn set_child_metadata(&mut self, child: Node, meta: OpMetadata) {
+    fn set_child_metadata(&mut self, child: Node, meta: NodeMetadata) {
         self.hugr_mut().set_metadata(child, meta);
     }
 }

--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -189,6 +189,7 @@ impl<T> HugrBuilder for DFGWrapper<Hugr, T> {
 #[cfg(test)]
 mod test {
     use cool_asserts::assert_matches;
+    use serde_json::json;
 
     use crate::builder::build_traits::DataflowHugr;
     use crate::builder::{DataflowSubContainer, ModuleBuilder};
@@ -343,8 +344,9 @@ mod test {
     #[test]
     fn insert_hugr() -> Result<(), BuildError> {
         // Create a simple DFG
-        let dfg_builder = DFGBuilder::new(type_row![BIT], type_row![BIT])?;
+        let mut dfg_builder = DFGBuilder::new(type_row![BIT], type_row![BIT])?;
         let [i1] = dfg_builder.input_wires_arr();
+        dfg_builder.set_metadata(json!(42));
         let dfg_hugr = dfg_builder.finish_hugr_with_outputs([i1])?;
 
         // Create a module, and insert the DFG into it

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -41,6 +41,9 @@ pub struct Hugr {
 
     /// Operation types for each node.
     op_types: UnmanagedDenseMap<portgraph::NodeIndex, OpType>,
+
+    /// Operation metadata
+    metadata: UnmanagedDenseMap<portgraph::NodeIndex, OpMetadata>,
 }
 
 impl Default for Hugr {
@@ -149,6 +152,9 @@ impl Hugr {
     }
 }
 
+/// Arbitrary metadata for an operation.
+pub type OpMetadata = serde_json::Value;
+
 /// Internal API for HUGRs, not intended for use by users.
 impl Hugr {
     /// Create a new Hugr, with a single root node.
@@ -169,6 +175,7 @@ impl Hugr {
             hierarchy,
             root,
             op_types,
+            metadata: UnmanagedDenseMap::with_capacity(nodes),
         }
     }
 

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -42,8 +42,8 @@ pub struct Hugr {
     /// Operation types for each node.
     op_types: UnmanagedDenseMap<portgraph::NodeIndex, OpType>,
 
-    /// Operation metadata
-    metadata: UnmanagedDenseMap<portgraph::NodeIndex, OpMetadata>,
+    /// Node metadata
+    metadata: UnmanagedDenseMap<portgraph::NodeIndex, NodeMetadata>,
 }
 
 impl Default for Hugr {
@@ -152,8 +152,8 @@ impl Hugr {
     }
 }
 
-/// Arbitrary metadata for an operation.
-pub type OpMetadata = serde_json::Value;
+/// Arbitrary metadata for a node.
+pub type NodeMetadata = serde_json::Value;
 
 /// Internal API for HUGRs, not intended for use by users.
 impl Hugr {

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -9,7 +9,7 @@ use crate::hugr::{Direction, HugrError, HugrView, Node};
 use crate::ops::OpType;
 use crate::{Hugr, Port};
 
-use super::OpMetadata;
+use super::NodeMetadata;
 
 /// Functions for low-level building of a HUGR. (Or, in the future, a subregion thereof)
 pub(crate) trait HugrMut {
@@ -24,10 +24,10 @@ pub(crate) trait HugrMut {
     fn remove_node(&mut self, node: Node) -> Result<(), HugrError>;
 
     /// Returns the metadata associated with a node.
-    fn get_metadata_mut(&mut self, node: Node) -> &mut OpMetadata;
+    fn get_metadata_mut(&mut self, node: Node) -> &mut NodeMetadata;
 
     /// Returns the metadata associated with a node.
-    fn set_metadata(&mut self, node: Node, metadata: OpMetadata) {
+    fn set_metadata(&mut self, node: Node, metadata: NodeMetadata) {
         *self.get_metadata_mut(node) = metadata;
     }
 
@@ -169,7 +169,7 @@ where
         Ok(())
     }
 
-    fn get_metadata_mut(&mut self, node: Node) -> &mut OpMetadata {
+    fn get_metadata_mut(&mut self, node: Node) -> &mut NodeMetadata {
         self.as_mut().metadata.get_mut(node.index)
     }
 

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -26,7 +26,7 @@ pub(crate) trait HugrMut {
     /// Returns the metadata associated with a node.
     fn get_metadata_mut(&mut self, node: Node) -> &mut NodeMetadata;
 
-    /// Returns the metadata associated with a node.
+    /// Sets the metadata associated with a node.
     fn set_metadata(&mut self, node: Node, metadata: NodeMetadata) {
         *self.get_metadata_mut(node) = metadata;
     }

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -9,6 +9,8 @@ use crate::hugr::{Direction, HugrError, HugrView, Node};
 use crate::ops::OpType;
 use crate::{Hugr, Port};
 
+use super::OpMetadata;
+
 /// Functions for low-level building of a HUGR. (Or, in the future, a subregion thereof)
 pub(crate) trait HugrMut {
     /// Add a node to the graph.
@@ -20,6 +22,14 @@ pub(crate) trait HugrMut {
     ///
     /// Panics if the node is the root node.
     fn remove_node(&mut self, node: Node) -> Result<(), HugrError>;
+
+    /// Returns the metadata associated with a node.
+    fn get_metadata_mut(&mut self, node: Node) -> &mut OpMetadata;
+
+    /// Returns the metadata associated with a node.
+    fn set_metadata(&mut self, node: Node, metadata: OpMetadata) {
+        *self.get_metadata_mut(node) = metadata;
+    }
 
     /// Connect two nodes at the given ports.
     ///
@@ -157,6 +167,10 @@ where
         self.as_mut().graph.remove_node(node.index);
         self.as_mut().op_types.remove(node.index);
         Ok(())
+    }
+
+    fn get_metadata_mut(&mut self, node: Node) -> &mut OpMetadata {
+        self.as_mut().metadata.get_mut(node.index)
     }
 
     fn connect(

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -297,20 +297,24 @@ where
 
     fn insert_hugr(&mut self, root: Node, mut other: Hugr) -> Result<Node, HugrError> {
         let (other_root, node_map) = insert_hugr_internal(self.as_mut(), root, &other)?;
-        // Update the optypes, taking them from the other graph.
+        // Update the optypes and metadata, taking them from the other graph.
         for (&node, &new_node) in node_map.iter() {
             let optype = other.op_types.take(node);
             self.as_mut().op_types.set(new_node, optype);
+            let meta = other.metadata.take(node);
+            self.as_mut().set_metadata(node.into(), meta);
         }
         Ok(other_root)
     }
 
     fn insert_from_view(&mut self, root: Node, other: &impl HugrView) -> Result<Node, HugrError> {
         let (other_root, node_map) = insert_hugr_internal(self.as_mut(), root, other)?;
-        // Update the optypes, copying them from the other graph.
+        // Update the optypes and metadata, copying them from the other graph.
         for (&node, &new_node) in node_map.iter() {
             let optype = other.get_optype(node.into());
             self.as_mut().op_types.set(new_node, optype.clone());
+            let meta = other.get_metadata(node.into());
+            self.as_mut().set_metadata(node.into(), meta.clone());
         }
         Ok(other_root)
     }

--- a/src/hugr/region.rs
+++ b/src/hugr/region.rs
@@ -10,7 +10,7 @@ use portgraph::{Hierarchy, LinkView, MultiPortGraph, PortView, UnmanagedDenseMap
 
 use crate::{ops::OpType, Direction, Hugr, Node, Port};
 
-use super::HugrView;
+use super::{HugrView, OpMetadata};
 
 type FlatRegionGraph<'g> = portgraph::view::FlatRegion<'g, MultiPortGraph>;
 
@@ -30,6 +30,9 @@ pub struct FlatRegionView<'g> {
 
     /// Operation types for each node.
     op_types: &'g UnmanagedDenseMap<portgraph::NodeIndex, OpType>,
+
+    /// Operation types for each node.
+    metadata: &'g UnmanagedDenseMap<portgraph::NodeIndex, OpMetadata>,
 }
 
 impl<'g> FlatRegionView<'g> {
@@ -40,6 +43,7 @@ impl<'g> FlatRegionView<'g> {
             graph,
             hierarchy,
             op_types,
+            metadata,
             ..
         } = hugr;
         Self {
@@ -47,6 +51,7 @@ impl<'g> FlatRegionView<'g> {
             graph: FlatRegionGraph::new_flat_region(graph, hierarchy, root.index),
             hierarchy,
             op_types,
+            metadata,
         }
     }
 }
@@ -91,6 +96,11 @@ impl<'g> HugrView for FlatRegionView<'g> {
     #[inline]
     fn get_optype(&self, node: Node) -> &OpType {
         self.op_types.get(node.index)
+    }
+
+    #[inline]
+    fn get_metadata(&self, node: Node) -> &OpMetadata {
+        self.metadata.get(node.index)
     }
 
     #[inline]
@@ -181,6 +191,9 @@ pub struct RegionView<'g> {
 
     /// Operation types for each node.
     op_types: &'g UnmanagedDenseMap<portgraph::NodeIndex, OpType>,
+
+    /// Operation types for each node.
+    metadata: &'g UnmanagedDenseMap<portgraph::NodeIndex, OpMetadata>,
 }
 
 impl<'g> RegionView<'g> {
@@ -191,6 +204,7 @@ impl<'g> RegionView<'g> {
             graph,
             hierarchy,
             op_types,
+            metadata,
             ..
         } = hugr;
         Self {
@@ -198,6 +212,7 @@ impl<'g> RegionView<'g> {
             graph: RegionGraph::new_region(graph, hierarchy, root.index),
             hierarchy,
             op_types,
+            metadata,
         }
     }
 }
@@ -242,6 +257,11 @@ impl<'g> HugrView for RegionView<'g> {
     #[inline]
     fn get_optype(&self, node: Node) -> &OpType {
         self.op_types.get(node.index)
+    }
+
+    #[inline]
+    fn get_metadata(&self, node: Node) -> &OpMetadata {
+        self.metadata.get(node.index)
     }
 
     #[inline]

--- a/src/hugr/region.rs
+++ b/src/hugr/region.rs
@@ -10,7 +10,7 @@ use portgraph::{Hierarchy, LinkView, MultiPortGraph, PortView, UnmanagedDenseMap
 
 use crate::{ops::OpType, Direction, Hugr, Node, Port};
 
-use super::{HugrView, OpMetadata};
+use super::{HugrView, NodeMetadata};
 
 type FlatRegionGraph<'g> = portgraph::view::FlatRegion<'g, MultiPortGraph>;
 
@@ -32,7 +32,7 @@ pub struct FlatRegionView<'g> {
     op_types: &'g UnmanagedDenseMap<portgraph::NodeIndex, OpType>,
 
     /// Operation types for each node.
-    metadata: &'g UnmanagedDenseMap<portgraph::NodeIndex, OpMetadata>,
+    metadata: &'g UnmanagedDenseMap<portgraph::NodeIndex, NodeMetadata>,
 }
 
 impl<'g> FlatRegionView<'g> {
@@ -99,7 +99,7 @@ impl<'g> HugrView for FlatRegionView<'g> {
     }
 
     #[inline]
-    fn get_metadata(&self, node: Node) -> &OpMetadata {
+    fn get_metadata(&self, node: Node) -> &NodeMetadata {
         self.metadata.get(node.index)
     }
 
@@ -193,7 +193,7 @@ pub struct RegionView<'g> {
     op_types: &'g UnmanagedDenseMap<portgraph::NodeIndex, OpType>,
 
     /// Operation types for each node.
-    metadata: &'g UnmanagedDenseMap<portgraph::NodeIndex, OpMetadata>,
+    metadata: &'g UnmanagedDenseMap<portgraph::NodeIndex, NodeMetadata>,
 }
 
 impl<'g> RegionView<'g> {
@@ -260,7 +260,7 @@ impl<'g> HugrView for RegionView<'g> {
     }
 
     #[inline]
-    fn get_metadata(&self, node: Node) -> &OpMetadata {
+    fn get_metadata(&self, node: Node) -> &NodeMetadata {
         self.metadata.get(node.index)
     }
 

--- a/src/hugr/region.rs
+++ b/src/hugr/region.rs
@@ -31,7 +31,7 @@ pub struct FlatRegionView<'g> {
     /// Operation types for each node.
     op_types: &'g UnmanagedDenseMap<portgraph::NodeIndex, OpType>,
 
-    /// Operation types for each node.
+    /// Metadata types for each node.
     metadata: &'g UnmanagedDenseMap<portgraph::NodeIndex, NodeMetadata>,
 }
 
@@ -192,7 +192,7 @@ pub struct RegionView<'g> {
     /// Operation types for each node.
     op_types: &'g UnmanagedDenseMap<portgraph::NodeIndex, OpType>,
 
-    /// Operation types for each node.
+    /// Metadata types for each node.
     metadata: &'g UnmanagedDenseMap<portgraph::NodeIndex, NodeMetadata>,
 }
 

--- a/src/hugr/rewrite/simple_replace.rs
+++ b/src/hugr/rewrite/simple_replace.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 use itertools::Itertools;
 use portgraph::{LinkMut, LinkView, MultiMut, NodeIndex, PortView};
 
-use crate::hugr::{HugrMut, HugrView, OpMetadata};
+use crate::hugr::{HugrMut, HugrView, NodeMetadata};
 use crate::{
     hugr::{Node, Rewrite},
     ops::{tag::OpTag, OpTrait, OpType},
@@ -101,7 +101,7 @@ impl Rewrite for SimpleReplacement {
             index_map.insert(node.index, new_node_index.index);
 
             // Move the metadata
-            let meta: &OpMetadata = self.replacement.get_metadata(node);
+            let meta: &NodeMetadata = self.replacement.get_metadata(node);
             h.set_metadata(node, meta.clone());
         }
         // Add edges between all newly added nodes matching those in replacement.

--- a/src/hugr/rewrite/simple_replace.rs
+++ b/src/hugr/rewrite/simple_replace.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 use itertools::Itertools;
 use portgraph::{LinkMut, LinkView, MultiMut, NodeIndex, PortMut, PortView};
 
-use crate::hugr::{HugrMut, HugrView};
+use crate::hugr::{HugrMut, HugrView, OpMetadata};
 use crate::{
     hugr::{Node, Rewrite},
     ops::{tag::OpTag, OpTrait, OpType},
@@ -99,6 +99,10 @@ impl Rewrite for SimpleReplacement {
             let op: &OpType = self.replacement.get_optype(node);
             let new_node_index = h.add_op_after(self_output_node_index, op.clone()).unwrap();
             index_map.insert(node.index, new_node_index.index);
+
+            // Move the metadata
+            let meta: &OpMetadata = self.replacement.get_metadata(node);
+            h.set_metadata(node, meta.clone());
         }
         // Add edges between all newly added nodes matching those in replacement.
         // TODO This will probably change when implicit copies are implemented.

--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -290,6 +290,7 @@ pub mod test {
             hierarchy: h,
             root,
             op_types,
+            metadata: Default::default(),
         };
 
         let v = rmp_serde::to_vec_named(&hg).unwrap();
@@ -376,7 +377,7 @@ pub mod test {
         hugr.disconnect(old_in, Port::new_outgoing(0)).unwrap();
         hugr.connect(new_in, 0, out, 0).unwrap();
         hugr.move_before_sibling(new_in, old_in).unwrap();
-        hugr.remove_node(old_in).unwrap();
+        hugr.remove_op(old_in).unwrap();
         hugr.validate().unwrap();
 
         let ser = serde_json::to_vec(&hugr).unwrap();

--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -436,7 +436,7 @@ pub mod test {
         hugr.disconnect(old_in, Port::new_outgoing(0)).unwrap();
         hugr.connect(new_in, 0, out, 0).unwrap();
         hugr.move_before_sibling(new_in, old_in).unwrap();
-        hugr.remove_op(old_in).unwrap();
+        hugr.remove_node(old_in).unwrap();
         hugr.validate().unwrap();
 
         let ser = serde_json::to_vec(&hugr).unwrap();

--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -1,6 +1,7 @@
 //! Serialization definition for [`Hugr`]
 //! [`Hugr`]: crate::hugr::Hugr
 
+use serde_json::json;
 use std::collections::HashMap;
 use thiserror::Error;
 
@@ -47,6 +48,9 @@ struct SerHugrV0 {
     nodes: Vec<NodeSer>,
     /// for each edge: (src, src_offset, tgt, tgt_offset)
     edges: Vec<[(Node, Option<u16>); 2]>,
+    /// for each node: (metadata)
+    #[serde(default)]
+    metadata: Vec<serde_json::Value>,
 }
 
 /// Errors that can occur while serializing a HUGR.
@@ -118,13 +122,16 @@ impl TryFrom<&Hugr> for SerHugrV0 {
         }
 
         let mut nodes = vec![None; hugr.node_count()];
+        let mut metadata = vec![json!(null); hugr.node_count()];
         for n in hugr.nodes() {
             let parent = node_rekey[&hugr.get_parent(n).unwrap_or(n)];
             let opt = hugr.get_optype(n);
-            nodes[node_rekey[&n].index.index()] = Some(NodeSer {
+            let new_node = node_rekey[&n].index.index();
+            nodes[new_node] = Some(NodeSer {
                 parent,
                 op: opt.clone(),
             });
+            metadata[new_node] = hugr.get_metadata(n).clone();
         }
         let nodes = nodes
             .into_iter()
@@ -160,13 +167,23 @@ impl TryFrom<&Hugr> for SerHugrV0 {
             })
             .collect();
 
-        Ok(Self { nodes, edges })
+        Ok(Self {
+            nodes,
+            edges,
+            metadata,
+        })
     }
 }
 
 impl TryFrom<SerHugrV0> for Hugr {
     type Error = HUGRSerializationError;
-    fn try_from(SerHugrV0 { nodes, edges }: SerHugrV0) -> Result<Self, Self::Error> {
+    fn try_from(
+        SerHugrV0 {
+            nodes,
+            edges,
+            metadata,
+        }: SerHugrV0,
+    ) -> Result<Self, Self::Error> {
         // Root must be first node
         let mut nodes = nodes.into_iter();
         let NodeSer {
@@ -182,6 +199,11 @@ impl TryFrom<SerHugrV0> for Hugr {
 
         for node_ser in nodes {
             hugr.add_op_with_parent(node_ser.parent, node_ser.op)?;
+        }
+
+        for (node, metadata) in metadata.into_iter().enumerate() {
+            let node = NodeIndex::new(node).into();
+            hugr.set_metadata(node, metadata);
         }
 
         let unwrap_offset = |node: Node, offset, dir, hugr: &Hugr| -> Result<usize, Self::Error> {
@@ -231,6 +253,9 @@ pub mod test {
     use portgraph::{
         multiportgraph::MultiPortGraph, Hierarchy, LinkMut, PortMut, PortView, UnmanagedDenseMap,
     };
+
+    const NAT: SimpleType = SimpleType::Classic(ClassicType::i64());
+    const QB: SimpleType = SimpleType::Linear(LinearType::Qubit);
 
     #[test]
     fn empty_hugr_serialize() {
@@ -301,9 +326,43 @@ pub mod test {
 
     #[test]
     fn weighted_hugr_ser() {
-        const NAT: SimpleType = SimpleType::Classic(ClassicType::i64());
-        const QB: SimpleType = SimpleType::Linear(LinearType::Qubit);
+        let hugr = {
+            let mut module_builder = ModuleBuilder::new();
+            module_builder.set_metadata(json!({"name": "test"}));
 
+            let t_row = vec![SimpleType::new_sum(vec![NAT, QB])];
+            let mut f_build = module_builder
+                .define_function("main", Signature::new_df(t_row.clone(), t_row))
+                .unwrap();
+
+            let outputs = f_build
+                .input_wires()
+                .map(|in_wire| {
+                    f_build
+                        .add_dataflow_op(
+                            LeafOp::Noop {
+                                ty: f_build.get_wire_type(in_wire).unwrap(),
+                            },
+                            [in_wire],
+                        )
+                        .unwrap()
+                        .out_wire(0)
+                })
+                .collect_vec();
+            f_build.set_metadata(json!(42));
+            f_build.finish_with_outputs(outputs).unwrap();
+
+            module_builder.finish_hugr().unwrap()
+        };
+
+        let ser_hugr: SerHugrV0 = (&hugr).try_into().unwrap();
+        // HUGR internal structures are not preserved across serialization, so
+        // test equality on SerHugrV0 instead.
+        assert_eq!(ser_roundtrip(&ser_hugr), ser_hugr);
+    }
+
+    #[test]
+    fn metadata_hugr_ser() {
         let hugr = {
             let mut module_builder = ModuleBuilder::new();
             let t_row = vec![SimpleType::new_sum(vec![NAT, QB])];

--- a/src/hugr/view.rs
+++ b/src/hugr/view.rs
@@ -8,7 +8,7 @@ use context_iterators::{ContextIterator, IntoContextIterator, MapCtx, MapWithCtx
 use itertools::{Itertools, MapInto};
 use portgraph::{multiportgraph, LinkView, MultiPortGraph, PortView};
 
-use super::{Hugr, OpMetadata};
+use super::{Hugr, NodeMetadata};
 use super::{Node, Port};
 use crate::ops::OpType;
 use crate::Direction;
@@ -56,7 +56,7 @@ pub trait HugrView: sealed::HugrInternals {
     fn get_optype(&self, node: Node) -> &OpType;
 
     /// Returns the metadata associated with a node.
-    fn get_metadata(&self, node: Node) -> &OpMetadata;
+    fn get_metadata(&self, node: Node) -> &NodeMetadata;
 
     /// Returns the number of nodes in the hugr.
     fn node_count(&self) -> usize;
@@ -234,7 +234,7 @@ where
     }
 
     #[inline]
-    fn get_metadata(&self, node: Node) -> &OpMetadata {
+    fn get_metadata(&self, node: Node) -> &NodeMetadata {
         self.as_ref().metadata.get(node.index)
     }
 }

--- a/src/hugr/view.rs
+++ b/src/hugr/view.rs
@@ -8,7 +8,7 @@ use context_iterators::{ContextIterator, IntoContextIterator, MapCtx, MapWithCtx
 use itertools::{Itertools, MapInto};
 use portgraph::{multiportgraph, LinkView, MultiPortGraph, PortView};
 
-use super::Hugr;
+use super::{Hugr, OpMetadata};
 use super::{Node, Port};
 use crate::ops::OpType;
 use crate::Direction;
@@ -54,6 +54,9 @@ pub trait HugrView: sealed::HugrInternals {
 
     /// Returns the operation type of a node.
     fn get_optype(&self, node: Node) -> &OpType;
+
+    /// Returns the metadata associated with a node.
+    fn get_metadata(&self, node: Node) -> &OpMetadata;
 
     /// Returns the number of nodes in the hugr.
     fn node_count(&self) -> usize;
@@ -228,6 +231,11 @@ where
     #[inline]
     fn all_neighbours(&self, node: Node) -> Self::Neighbours<'_> {
         self.as_ref().graph.all_neighbours(node.index).map_into()
+    }
+
+    #[inline]
+    fn get_metadata(&self, node: Node) -> &OpMetadata {
+        self.as_ref().metadata.get(node.index)
     }
 }
 


### PR DESCRIPTION
This is a proposal for basic metadata support in the HUGR.
It adds a new SecondaryMap from nodes to a `OpMetadata` type, currently aliased to `serde_json::Value`.

The specification doesn't specify whether this map should be in or alongside the Hugr, but doing it like this lets us seamlessly integrate it into building, serializing, and rewriting (the serialization remains backwards-compatible).

The metadata itself is fully unstructured. We may want to enforce some minimal schema in the future, perhaps requiring a dictionary at the head so we can more easily merge different values, but that's left as future work.

Closes #235.