### PR TITLE
[refactor] Add a more general constructor for DFGBuilder

### DIFF
--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -59,19 +59,27 @@ impl DFGBuilder<Hugr> {
     /// # Errors
     ///
     /// Error in adding DFG child nodes.
-    pub fn new(
-        input: impl Into<TypeRow>,
-        output: impl Into<TypeRow>,
-    ) -> Result<DFGBuilder<Hugr>, BuildError> {
-        let input = input.into();
-        let output = output.into();
-        let signature = Signature::new_df(input, output);
+    pub fn new(signature: Signature) -> Result<DFGBuilder<Hugr>, BuildError> {
         let dfg_op = ops::DFG {
             signature: signature.clone(),
         };
         let base = Hugr::new(dfg_op);
         let root = base.root();
         DFGBuilder::create_with_io(base, root, signature)
+    }
+
+    /// Begin building a new DFG rooted HUGR, which doesn't contain any static
+    /// inputs or resource requirements
+    ///
+    /// # Errors
+    ///
+    /// Error in adding DFG child nodes.
+    pub fn new_df(
+        input: impl Into<TypeRow>,
+        output: impl Into<TypeRow>,
+    ) -> Result<DFGBuilder<Hugr>, BuildError> {
+        let signature = Signature::new_df(input.into(), output.into());
+        DFGBuilder::new(signature)
     }
 }
 
@@ -331,7 +339,7 @@ mod test {
 
     #[test]
     fn dfg_hugr() -> Result<(), BuildError> {
-        let dfg_builder = DFGBuilder::new(type_row![BIT], type_row![BIT])?;
+        let dfg_builder = DFGBuilder::new_df(type_row![BIT], type_row![BIT])?;
 
         let [i1] = dfg_builder.input_wires_arr();
         let hugr = dfg_builder.finish_hugr_with_outputs([i1])?;
@@ -345,7 +353,7 @@ mod test {
     #[test]
     fn insert_hugr() -> Result<(), BuildError> {
         // Create a simple DFG
-        let dfg_builder = DFGBuilder::new(type_row![BIT], type_row![BIT])?;
+        let dfg_builder = DFGBuilder::new_df(type_row![BIT], type_row![BIT])?;
         let [i1] = dfg_builder.input_wires_arr();
         let dfg_hugr = dfg_builder.finish_hugr_with_outputs([i1])?;
 

--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -376,15 +376,13 @@ mod test {
 
     #[test]
     fn lift_node() -> Result<(), BuildError> {
-        let mut module_builder = ModuleBuilder::new();
-
         let ab_resources = ResourceSet::from_iter(["A".into(), "B".into()]);
         let c_resources = ResourceSet::singleton(&"C".into());
         let abc_resources = ab_resources.clone().union(&c_resources);
 
         let mut parent_sig = Signature::new_df(type_row![BIT], type_row![BIT]);
         parent_sig.output_resources = abc_resources.clone();
-        let mut parent = module_builder.define_function("parent", parent_sig)?;
+        let mut parent = DFGBuilder::new(parent_sig)?;
 
         let mut add_c_sig = Signature::new_df(type_row![BIT], type_row![BIT]);
         add_c_sig.input_resources = ab_resources.clone();
@@ -438,8 +436,8 @@ mod test {
 
         let add_c = add_c.finish_with_outputs(wires)?;
         let [w] = add_c.outputs_arr();
-        parent.finish_with_outputs([w])?;
-        module_builder.finish_hugr()?;
+        parent.set_outputs([w])?;
+        parent.finish_hugr()?;
 
         Ok(())
     }

--- a/src/hugr/rewrite/simple_replace.rs
+++ b/src/hugr/rewrite/simple_replace.rs
@@ -319,7 +319,7 @@ mod test {
     /// ┤ H ├┤ X ├
     /// └───┘└───┘
     fn make_dfg_hugr() -> Result<Hugr, BuildError> {
-        let mut dfg_builder = DFGBuilder::new(type_row![QB, QB], type_row![QB, QB])?;
+        let mut dfg_builder = DFGBuilder::new_df(type_row![QB, QB], type_row![QB, QB])?;
         let [wire0, wire1] = dfg_builder.input_wires_arr();
         let wire2 = dfg_builder.add_dataflow_op(LeafOp::H, vec![wire0])?;
         let wire3 = dfg_builder.add_dataflow_op(LeafOp::H, vec![wire1])?;
@@ -334,7 +334,7 @@ mod test {
     /// ┤ H ├
     /// └───┘
     fn make_dfg_hugr2() -> Result<Hugr, BuildError> {
-        let mut dfg_builder = DFGBuilder::new(type_row![QB, QB], type_row![QB, QB])?;
+        let mut dfg_builder = DFGBuilder::new_df(type_row![QB, QB], type_row![QB, QB])?;
         let [wire0, wire1] = dfg_builder.input_wires_arr();
         let wire2 = dfg_builder.add_dataflow_op(LeafOp::H, vec![wire1])?;
         let wire2out = wire2.outputs().exactly_one().unwrap();
@@ -509,7 +509,7 @@ mod test {
     #[test]
     fn test_replace_cx_cross() {
         let q_row: Vec<SimpleType> = vec![LinearType::Qubit.into(), LinearType::Qubit.into()];
-        let mut builder = DFGBuilder::new(q_row.clone(), q_row).unwrap();
+        let mut builder = DFGBuilder::new_df(q_row.clone(), q_row).unwrap();
         let mut circ = builder.as_circuit(builder.input_wires().collect());
         circ.append(LeafOp::CX, [0, 1]).unwrap();
         circ.append(LeafOp::CX, [1, 0]).unwrap();
@@ -555,7 +555,7 @@ mod test {
         let one_bit: Vec<SimpleType> = vec![ClassicType::bit().into()];
         let two_bit: Vec<SimpleType> = vec![ClassicType::bit().into(), ClassicType::bit().into()];
 
-        let mut builder = DFGBuilder::new(one_bit.clone(), one_bit.clone()).unwrap();
+        let mut builder = DFGBuilder::new_df(one_bit.clone(), one_bit.clone()).unwrap();
         let inw = builder.input_wires().exactly_one().unwrap();
         let outw = builder
             .add_dataflow_op(LeafOp::Xor, [inw, inw])
@@ -564,7 +564,7 @@ mod test {
         let [input, _] = builder.io();
         let mut h = builder.finish_hugr_with_outputs(outw).unwrap();
 
-        let mut builder = DFGBuilder::new(two_bit, one_bit).unwrap();
+        let mut builder = DFGBuilder::new_df(two_bit, one_bit).unwrap();
         let inw = builder.input_wires();
         let outw = builder.add_dataflow_op(LeafOp::Xor, inw).unwrap().outputs();
         let [repl_input, repl_output] = builder.io();

--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -338,7 +338,7 @@ pub mod test {
     #[test]
     fn dfg_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
         let tp: Vec<SimpleType> = vec![ClassicType::bit().into(); 2];
-        let mut dfg = DFGBuilder::new(tp.clone(), tp)?;
+        let mut dfg = DFGBuilder::new_df(tp.clone(), tp)?;
         let mut params: [_; 2] = dfg.input_wires_arr();
         for p in params.iter_mut() {
             *p = dfg
@@ -366,7 +366,7 @@ pub mod test {
     #[test]
     fn hierarchy_order() {
         let qb: SimpleType = LinearType::Qubit.into();
-        let dfg = DFGBuilder::new([qb.clone()].to_vec(), [qb.clone()].to_vec()).unwrap();
+        let dfg = DFGBuilder::new_df([qb.clone()].to_vec(), [qb.clone()].to_vec()).unwrap();
         let [old_in, out] = dfg.io();
         let w = dfg.input_wires();
         let mut hugr = dfg.finish_hugr_with_outputs(w).unwrap();


### PR DESCRIPTION
Simplify the `lift_node` test case as suggested in #240 by @acl-cqc. I.e. remove the ModuleBuilder and using a DFGBuilder as the root of the graph.

In order to do this, a more general constructor for DFGBuilder is needed, which allows the resource requirements for the DFG to be specified