### PR TITLE
Add coverage check.

### DIFF
--- a/.github/workflows/compare-coverage
+++ b/.github/workflows/compare-coverage
@@ -26,4 +26,4 @@ echo "line coverage here: ${LINECOVPERCENT}%"
 MAIN_LINECOVPERCENT=`line_cov_percent main`
 echo "line coverage on main: ${MAIN_LINECOVPERCENT}%"
 
-if (( $(echo "${MAIN_LINECOVPERCENT} > ${LINECOVPERCENT}" | bc -l) )); then exit 1 ; fi
+if (( $(echo "${MAIN_LINECOVPERCENT} > ${LINECOVPERCENT} + 0.01" | bc -l) )); then exit 1 ; fi

--- a/.github/workflows/compare-coverage
+++ b/.github/workflows/compare-coverage
@@ -26,4 +26,4 @@ echo "line coverage here: ${LINECOVPERCENT}%"
 MAIN_LINECOVPERCENT=`line_cov_percent main`
 echo "line coverage on main: ${MAIN_LINECOVPERCENT}%"
 
-if (( $(echo "${MAIN_LINECOVPERCENT} > ${LINECOVPERCENT} + 0.01" | bc -l) )); then exit 1 ; fi
+if (( $(echo "${MAIN_LINECOVPERCENT} > ${LINECOVPERCENT} + 0.03" | bc -l) )); then exit 1 ; fi

--- a/.github/workflows/compare-coverage
+++ b/.github/workflows/compare-coverage
@@ -1,0 +1,29 @@
+#!/usr/bin/bash
+
+# Compare line coverage of current branch with `main`; exit 1 if it is less.
+
+set -e
+
+export RUSTFLAGS="-C instrument-coverage"
+
+BRANCH=`git rev-parse --abbrev-ref HEAD`
+
+# Print total line coverage on branch (branch name passed as argument).
+line_cov_percent() {
+    rm -f *.profraw *.profdata
+    CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+    git checkout -q $1
+    TGT=`cargo test --tests 2>&1 | grep Running | awk -F'[()]' '{print $2}'`
+    llvm-profdata merge -sparse default_*.profraw -o hugr.profdata
+    llvm-cov report --ignore-filename-regex='/.cargo/registry' --instr-profile=hugr.profdata --object ${TGT} | grep TOTAL | awk '{print $10}' | tr -dc '[:digit:].'
+    git checkout -q ${CURRENT_BRANCH} # go back to where we were
+    rm -f *.profraw *.profdata # clean up
+}
+
+LINECOVPERCENT=`line_cov_percent ${BRANCH}`
+echo "line coverage here: ${LINECOVPERCENT}%"
+
+MAIN_LINECOVPERCENT=`line_cov_percent main`
+echo "line coverage on main: ${MAIN_LINECOVPERCENT}%"
+
+if (( $(echo "${MAIN_LINECOVPERCENT} > ${LINECOVPERCENT}" | bc -l) )); then exit 1 ; fi

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,22 @@
+name: Coverage
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: "0" # because we need `main` as well
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install llvm
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "16.0" # should match version used by rustc
+      - name: Compare coverage with main branch
+        run: ./.github/workflows/compare-coverage


### PR DESCRIPTION
On this run the check took 3m38s which makes it the slowest of the CI checks ("tests (nightly, true)" took 3m0s).

I took the simplest approach which was:
* run on PR only;
* compute coverage both for PR branch and for main;
* compare only the total line coverage (ignoring function coverage and region coverage whatever that is, and ignoring individual file reports).

This means we don't need to store anything persistently, but we do need to run the coverage checks _twice_, which increases the run time.

Obviously we could refine the checks in future, e.g. to include function coverage statistics. We could also look into running on push to main and storing the result persistently, but I'm not very happy with how tket does this (by pushing a file to the magic `gh-pages` branch).