### PR TITLE
 Statically query the tag of an operation

### DIFF
--- a/src/algorithm/half_node.rs
+++ b/src/algorithm/half_node.rs
@@ -2,7 +2,7 @@ use std::hash::Hash;
 
 use super::nest_cfgs::CfgView;
 use crate::hugr::view::HugrView;
-use crate::ops::tag::OpTag;
+use crate::ops::OpTag;
 use crate::ops::OpTrait;
 use crate::{Direction, Node};
 

--- a/src/algorithm/nest_cfgs.rs
+++ b/src/algorithm/nest_cfgs.rs
@@ -44,7 +44,7 @@ use std::hash::Hash;
 use itertools::Itertools;
 
 use crate::hugr::view::HugrView;
-use crate::ops::tag::OpTag;
+use crate::ops::OpTag;
 use crate::ops::OpTrait;
 use crate::{Direction, Node};
 

--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -193,7 +193,7 @@ mod test {
 
     use crate::builder::build_traits::DataflowHugr;
     use crate::builder::{DataflowSubContainer, ModuleBuilder};
-    use crate::ops::tag::OpTag;
+    use crate::ops::OpTag;
     use crate::ops::OpTrait;
     use crate::{
         builder::{

--- a/src/builder/handle.rs
+++ b/src/builder/handle.rs
@@ -3,7 +3,7 @@
 use crate::{
     ops::{
         handle::{BasicBlockID, CaseID, DfgID, FuncID, NodeHandle, TailLoopID},
-        tag::OpTag,
+        OpTag,
     },
     Port,
 };

--- a/src/hugr/rewrite/simple_replace.rs
+++ b/src/hugr/rewrite/simple_replace.rs
@@ -8,7 +8,7 @@ use portgraph::{LinkMut, LinkView, MultiMut, NodeIndex, PortView};
 use crate::hugr::{HugrMut, HugrView, NodeMetadata};
 use crate::{
     hugr::{Node, Rewrite},
-    ops::{tag::OpTag, OpTrait, OpType},
+    ops::{OpTag, OpTrait, OpType},
     Hugr, Port,
 };
 use thiserror::Error;
@@ -264,7 +264,7 @@ mod test {
     };
     use crate::hugr::view::HugrView;
     use crate::hugr::{Hugr, Node};
-    use crate::ops::tag::OpTag;
+    use crate::ops::OpTag;
     use crate::ops::{LeafOp, OpTrait, OpType};
     use crate::types::{ClassicType, LinearType, Signature, SimpleType};
     use crate::{type_row, Port};

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -10,8 +10,8 @@ use portgraph::{LinkView, PortView};
 use thiserror::Error;
 
 use crate::hugr::typecheck::{typecheck_const, ConstTypeError};
-use crate::ops::tag::OpTag;
 use crate::ops::validate::{ChildrenEdgeData, ChildrenValidationError, EdgeValidationError};
+use crate::ops::OpTag;
 use crate::ops::{self, OpTrait, OpType, ValidateOp};
 use crate::resource::ResourceSet;
 use crate::types::ClassicType;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -15,7 +15,6 @@ use crate::{Direction, Port};
 use portgraph::NodeIndex;
 use smol_str::SmolStr;
 
-use self::tag::OpTag;
 use enum_dispatch::enum_dispatch;
 
 pub use constant::{Const, ConstValue};
@@ -23,6 +22,7 @@ pub use controlflow::{BasicBlock, Case, Conditional, TailLoop, CFG};
 pub use dataflow::{Call, CallIndirect, Input, LoadConstant, Output, DFG};
 pub use leaf::LeafOp;
 pub use module::{AliasDecl, AliasDefn, FuncDecl, FuncDefn, Module};
+pub use tag::OpTag;
 
 #[enum_dispatch(OpTrait, OpName, ValidateOp)]
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -139,13 +139,24 @@ pub trait OpName {
     fn name(&self) -> SmolStr;
 }
 
+/// Trait statically querying the tag of an operation.
+///
+/// This is implemented by all OpType variants, and always contains the dynamic
+/// tag returned by `OpType::tag(&self)`.
+pub trait OpTagged {
+    /// The name of the operation.
+    fn static_tag() -> OpTag;
+}
+
 #[enum_dispatch]
 /// Trait implemented by all OpType variants.
 pub trait OpTrait {
     /// A human-readable description of the operation.
     fn description(&self) -> &str;
+
     /// Tag identifying the operation.
     fn tag(&self) -> OpTag;
+
     /// The signature of the operation.
     ///
     /// Only dataflow operations have a non-empty signature.

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -11,8 +11,8 @@ use crate::{
 use downcast_rs::{impl_downcast, Downcast};
 use smol_str::SmolStr;
 
-use super::tag::OpTag;
-use super::{OpName, OpTrait};
+use super::OpTag;
+use super::{OpName, OpTagged, OpTrait};
 
 /// A constant value definition.
 #[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
@@ -22,13 +22,18 @@ impl OpName for Const {
         self.0.name()
     }
 }
+impl OpTagged for Const {
+    fn static_tag() -> OpTag {
+        OpTag::Const
+    }
+}
 impl OpTrait for Const {
     fn description(&self) -> &str {
         self.0.description()
     }
 
     fn tag(&self) -> OpTag {
-        OpTag::Const
+        <Self as OpTagged>::static_tag()
     }
 
     fn other_output(&self) -> Option<EdgeKind> {

--- a/src/ops/controlflow.rs
+++ b/src/ops/controlflow.rs
@@ -5,8 +5,8 @@ use smol_str::SmolStr;
 use crate::types::{EdgeKind, Signature, SimpleType, TypeRow};
 
 use super::dataflow::DataflowOpTrait;
-use super::tag::OpTag;
-use super::{impl_op_name, OpName, OpTrait};
+use super::OpTag;
+use super::{impl_op_name, OpName, OpTagged, OpTrait};
 
 /// Tail-controlled loop.
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -26,7 +26,7 @@ impl DataflowOpTrait for TailLoop {
         "A tail-controlled loop"
     }
 
-    fn tag(&self) -> OpTag {
+    fn static_tag() -> OpTag {
         OpTag::TailLoop
     }
 
@@ -75,7 +75,7 @@ impl DataflowOpTrait for Conditional {
         "HUGR conditional operation"
     }
 
-    fn tag(&self) -> OpTag {
+    fn static_tag() -> OpTag {
         OpTag::Conditional
     }
 
@@ -114,7 +114,7 @@ impl DataflowOpTrait for CFG {
         "A dataflow node defined by a child CFG"
     }
 
-    fn tag(&self) -> OpTag {
+    fn static_tag() -> OpTag {
         OpTag::Cfg
     }
 
@@ -146,6 +146,12 @@ impl OpName for BasicBlock {
             BasicBlock::DFB { .. } => "DFB".into(),
             BasicBlock::Exit { .. } => "Exit".into(),
         }
+    }
+}
+
+impl OpTagged for BasicBlock {
+    fn static_tag() -> OpTag {
+        OpTag::BasicBlock
     }
 }
 
@@ -210,13 +216,19 @@ pub struct Case {
 
 impl_op_name!(Case);
 
+impl OpTagged for Case {
+    fn static_tag() -> OpTag {
+        OpTag::Case
+    }
+}
+
 impl OpTrait for Case {
     fn description(&self) -> &str {
         "A case node inside a conditional"
     }
 
     fn tag(&self) -> OpTag {
-        OpTag::Case
+        <Self as OpTagged>::static_tag()
     }
 }
 

--- a/src/ops/dataflow.rs
+++ b/src/ops/dataflow.rs
@@ -1,13 +1,14 @@
 //! Dataflow operations.
 
-use super::{impl_op_name, tag::OpTag, OpTrait};
+use super::OpTagged;
+use super::{impl_op_name, OpTag, OpTrait};
 
 use crate::resource::ResourceSet;
 use crate::types::{ClassicType, EdgeKind, Signature, SimpleType, TypeRow};
 
 pub(super) trait DataflowOpTrait {
     fn description(&self) -> &str;
-    fn tag(&self) -> OpTag;
+    fn static_tag() -> super::OpTag;
     fn signature(&self) -> Signature;
     /// The edge kind for the non-dataflow or constant inputs of the operation,
     /// not described by the signature.
@@ -91,7 +92,7 @@ impl DataflowOpTrait for Input {
         "The input node for this dataflow subgraph"
     }
 
-    fn tag(&self) -> super::tag::OpTag {
+    fn static_tag() -> super::OpTag {
         OpTag::Input
     }
 
@@ -110,7 +111,7 @@ impl DataflowOpTrait for Output {
         "The output node for this dataflow subgraph"
     }
 
-    fn tag(&self) -> super::tag::OpTag {
+    fn static_tag() -> super::OpTag {
         OpTag::Output
     }
 
@@ -131,7 +132,7 @@ impl<T: DataflowOpTrait> OpTrait for T {
     }
 
     fn tag(&self) -> OpTag {
-        DataflowOpTrait::tag(self)
+        <Self as DataflowOpTrait>::static_tag()
     }
     fn signature(&self) -> Signature {
         DataflowOpTrait::signature(self)
@@ -142,6 +143,11 @@ impl<T: DataflowOpTrait> OpTrait for T {
 
     fn other_output(&self) -> Option<EdgeKind> {
         DataflowOpTrait::other_output(self)
+    }
+}
+impl<T: DataflowOpTrait> OpTagged for T {
+    fn static_tag() -> OpTag {
+        <Self as DataflowOpTrait>::static_tag()
     }
 }
 
@@ -162,7 +168,7 @@ impl DataflowOpTrait for Call {
         "Call a function directly"
     }
 
-    fn tag(&self) -> OpTag {
+    fn static_tag() -> super::OpTag {
         OpTag::FnCall
     }
 
@@ -187,7 +193,7 @@ impl DataflowOpTrait for CallIndirect {
         "Call a function indirectly"
     }
 
-    fn tag(&self) -> OpTag {
+    fn static_tag() -> super::OpTag {
         OpTag::FnCall
     }
 
@@ -213,7 +219,7 @@ impl DataflowOpTrait for LoadConstant {
         "Load a static constant in to the local dataflow graph"
     }
 
-    fn tag(&self) -> OpTag {
+    fn static_tag() -> super::OpTag {
         OpTag::LoadConst
     }
 
@@ -239,7 +245,7 @@ impl DataflowOpTrait for DFG {
         "A simply nested dataflow graph"
     }
 
-    fn tag(&self) -> OpTag {
+    fn static_tag() -> super::OpTag {
         OpTag::Dfg
     }
 

--- a/src/ops/handle.rs
+++ b/src/ops/handle.rs
@@ -6,7 +6,7 @@ use crate::Node;
 use derive_more::From as DerFrom;
 use smol_str::SmolStr;
 
-use super::tag::OpTag;
+use super::OpTag;
 
 /// Common trait for handles to a node.
 /// Typically wrappers around [`Node`].

--- a/src/ops/leaf.rs
+++ b/src/ops/leaf.rs
@@ -3,7 +3,7 @@
 use smol_str::SmolStr;
 
 use super::custom::ExternalOp;
-use super::{tag::OpTag, OpName, OpTrait};
+use super::{OpName, OpTag, OpTagged, OpTrait};
 use crate::{
     resource::{ResourceId, ResourceSet},
     type_row,
@@ -118,6 +118,12 @@ impl OpName for LeafOp {
     }
 }
 
+impl OpTagged for LeafOp {
+    fn static_tag() -> OpTag {
+        OpTag::Leaf
+    }
+}
+
 impl OpTrait for LeafOp {
     /// A human-readable description of the operation.
     fn description(&self) -> &str {
@@ -146,7 +152,7 @@ impl OpTrait for LeafOp {
     }
 
     fn tag(&self) -> OpTag {
-        OpTag::Leaf
+        <Self as OpTagged>::static_tag()
     }
 
     /// The signature of the operation.

--- a/src/ops/module.rs
+++ b/src/ops/module.rs
@@ -4,7 +4,8 @@ use smol_str::SmolStr;
 
 use crate::types::{ClassicType, EdgeKind, Signature, SimpleType};
 
-use super::{impl_op_name, tag::OpTag, OpTrait};
+use super::OpTagged;
+use super::{impl_op_name, OpTag, OpTrait};
 
 /// The root of a module, parent of all other `OpType`s.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -12,13 +13,19 @@ pub struct Module;
 
 impl_op_name!(Module);
 
+impl OpTagged for Module {
+    fn static_tag() -> OpTag {
+        OpTag::ModuleRoot
+    }
+}
+
 impl OpTrait for Module {
     fn description(&self) -> &str {
         "The root of a module, parent of all other `OpType`s"
     }
 
-    fn tag(&self) -> super::tag::OpTag {
-        OpTag::ModuleRoot
+    fn tag(&self) -> super::OpTag {
+        <Self as OpTagged>::static_tag()
     }
 }
 
@@ -34,13 +41,18 @@ pub struct FuncDefn {
 }
 
 impl_op_name!(FuncDefn);
+impl OpTagged for FuncDefn {
+    fn static_tag() -> OpTag {
+        OpTag::FuncDefn
+    }
+}
 impl OpTrait for FuncDefn {
     fn description(&self) -> &str {
         "A function definition"
     }
 
     fn tag(&self) -> OpTag {
-        OpTag::FuncDefn
+        <Self as OpTagged>::static_tag()
     }
 
     fn other_output(&self) -> Option<EdgeKind> {
@@ -60,14 +72,18 @@ pub struct FuncDecl {
 }
 
 impl_op_name!(FuncDecl);
-
+impl OpTagged for FuncDecl {
+    fn static_tag() -> OpTag {
+        OpTag::Function
+    }
+}
 impl OpTrait for FuncDecl {
     fn description(&self) -> &str {
         "External function declaration, linked at runtime"
     }
 
     fn tag(&self) -> OpTag {
-        OpTag::Function
+        <Self as OpTagged>::static_tag()
     }
 
     fn other_output(&self) -> Option<EdgeKind> {
@@ -86,13 +102,18 @@ pub struct AliasDefn {
     pub definition: SimpleType,
 }
 impl_op_name!(AliasDefn);
+impl OpTagged for AliasDefn {
+    fn static_tag() -> OpTag {
+        OpTag::Alias
+    }
+}
 impl OpTrait for AliasDefn {
     fn description(&self) -> &str {
         "A type alias definition"
     }
 
     fn tag(&self) -> OpTag {
-        OpTag::Alias
+        <Self as OpTagged>::static_tag()
     }
 }
 
@@ -106,13 +127,17 @@ pub struct AliasDecl {
 }
 
 impl_op_name!(AliasDecl);
-
+impl OpTagged for AliasDecl {
+    fn static_tag() -> OpTag {
+        OpTag::Alias
+    }
+}
 impl OpTrait for AliasDecl {
     fn description(&self) -> &str {
         "A type alias declaration"
     }
 
     fn tag(&self) -> OpTag {
-        OpTag::Alias
+        <Self as OpTagged>::static_tag()
     }
 }

--- a/src/ops/validate.rs
+++ b/src/ops/validate.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 use crate::types::{SimpleType, TypeRow};
 use crate::Direction;
 
-use super::{impl_validate_op, tag::OpTag, BasicBlock, OpTrait, OpType, ValidateOp};
+use super::{impl_validate_op, BasicBlock, OpTag, OpTrait, OpType, ValidateOp};
 
 /// A set of property flags required for an operation.
 #[non_exhaustive]


### PR DESCRIPTION
Adds a `OpTagged` trait, implemented for all operation structs.
`OpTrait` still has a `tag(&self)` method for dynamic computation (e.g. for `OpType`).

Drive-by: Re-export `OpTag` from `crate::op`.