### PR TITLE
Remove LinearType; ClassicTypes are the only subtype of SimpleTypes

### DIFF
--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -156,9 +156,9 @@ As well as the type, dataflow edges are also parametrized by a
     [Non-local Edges](#non-local-edges)
 
 
-`SimpleType` $\supset$ `ClassicType`
-
 ```
+SimpleType ⊃ ClassicType -- In the absence of unicode: "SimpleType is a superset of ClassicType"
+
 EdgeKind ::= Hierarchy | Value(Locality, SimpleType) | Static(Local | Ext, ClassicType) | Order | ControlFlow
 
 Locality ::= Local | Ext | Dom

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -139,8 +139,9 @@ of edge for different relationships.
 
 `Value` and `Static` edges are sometimes referred to as _dataflow_ edges.
 A `Value` edge can carry data of any `SimpleType`: either a `ClassicType`
-(ordinary classical data) or a `LinearType` (data which cannot be copied,
-including quantum data). A `Static` edge can only carry a `ClassicType`. For
+(ordinary classical data, which can be freely copied or discarded) or a
+`LinearType` (which cannot - e.g. anything including quantum data).
+A `Static` edge can only carry a `ClassicType`. For
 more details see the [Type System](#type-system) section.
 
 As well as the type, dataflow edges are also parametrized by a
@@ -1042,7 +1043,7 @@ ClassicType ::= int<N>
               | Container(ClassicType)
 LinearType ::= Qubit
               | QPaque(Name, #)
-              | Container(LinearType)
+              | Container(SimpleType)  -- Sometimes called 'Qontainer'
 ```
 
 SimpleTypes are the types of *values* which can be sent down wires,
@@ -1065,8 +1066,8 @@ Container types are defined in terms of statically-known element types.
 Besides `Array<N>`, `Sum` and `Tuple`, these also include variable-sized
 types: `Graph`, `Map` and
 `List` (TODO: can we leave those to the Tierkreis resource?). `NewType`
-allows named newtypes to be used. Containers are linear if any of their
-components are linear.
+allows named newtypes to be used. Containers are classic (copyable) only
+if all of their components are classic.
 
 
 
@@ -1099,7 +1100,7 @@ ports can have any number of connected edges (0 is equivalent to a discard).
 
 Our linear types behave like other values passed down a wire. Quantum
 gates behave just like other nodes on the graph with inputs and outputs,
-but there is only one edge leaving or entering each port. In fully
+but there is only one edge leaving (or entering) each port. In fully
 qubit-counted contexts programs take in a number of qubits as input and
 return the same number, with no discarding. See
 [quantum resource](#quantum-resource)
@@ -1135,20 +1136,12 @@ resource requirements.
 We will likely also want to add a fixed set of attributes to certain
 subsets of `TYPE`. In Tierkreis these are called “type constraints”. For
 example, the `Map` type can only be constructed when the type that we
-map from is `Hashable`. For the Hugr, we may need this `Hashable`
-constraint, as well as a `Nonlinear` constraint. Finally there may be a
-`const-able` or `serializable` constraint meaning that the value can be
-put into a `const`-node: this implies the type is `Nonlinear` (but not
-vice versa).
+map from is `Hashable`. For the Hugr, we will need this `Hashable`
+constraint, as well as a `Classic` constraint.
 
-**TODO**: is this set of constraints (nonlinear, const-able, hashable)
-fixed? Then Map is in the core HUGR spec.
-
-Or, can extensions (resources) add new constraints? This is probably too
-complex, but then both hashable and Map could be in the Tierkreis
-resource.
-
-(Or, can we do Map without hashable?)
+**TODO**: fix this set of constraints (classic/copyable, hashable);
+extensions/resources *cannot* add new constraints. Use hashable for
+static type parameters, put Map in Tierkreis resource not core spec.
 
 ### Resources
 

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -1097,7 +1097,7 @@ arbitrary `SimpleType`s and the subset of `ClassicType`s. Only `ClassicType`s
 may be used more than once or discarded; the former must always be used
 exactly once. This leads to a constraint on the HUGR that outgoing ports
 must have exactly one edge leaving them unless they are `ClassicType`, where
-outgoing ports may have anynum number of connected edges (0 is equivalent
+outgoing ports may have any number of connected edges (0 is equivalent
 to a discard). All incoming ports must have exactly one edge connected to them.
 
 # Our linear types behave like other values passed down a wire.

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -138,9 +138,9 @@ of edge for different relationships.
   children.
 
 `Value` and `Static` edges are sometimes referred to as _dataflow_ edges.
-A `Value` edge can carry data of any `SimpleType`: either a `ClassicType`
-(ordinary classical data, which can be freely copied or discarded) or a
-`LinearType` (which cannot - e.g. anything including quantum data).
+A `Value` edge can carry data of any `SimpleType`: these include the `ClassicType`s
+(which can be freely copied or discarded - i.e. ordinary classical data)
+as well as anything which cannot - e.g. quantum data.
 A `Static` edge can only carry a `ClassicType`. For
 more details see the [Type System](#type-system) section.
 
@@ -156,9 +156,9 @@ As well as the type, dataflow edges are also parametrized by a
     [Non-local Edges](#non-local-edges)
 
 
-```
-SimpleType ::= ClassicType | LinearType
+`SimpleType` $\supset$ `ClassicType`
 
+```
 EdgeKind ::= Hierarchy | Value(Locality, SimpleType) | Static(Local | Ext, ClassicType) | Order | ControlFlow
 
 Locality ::= Local | Ext | Dom
@@ -176,7 +176,7 @@ edges, with `Static` edges following `Value` edges in the ordering.
 Note that the locality is not fixed or even specified by the signature.
 
 A source port with a `ClassicType` may have any number of edges associated with
-it (including zero, which means "discard"). A port with a `LinearType`, and a target port of any type,
+it (including zero, which means "discard"). Any other port
 must have exactly one edge associated with it. This captures the property of
 linear types that the value is used exactly once. See [Linearity](#linearity).
 
@@ -1022,12 +1022,11 @@ A grammar of available types is defined below.
 ```haskell
 Type ::= [Resources]SimpleType
 -- Rows are ordered lists, not sets
-#    ::= #(LinearType), #(ClassicType) 
+#    ::= #(SimpleType)
 #(T) ::= (T)*
 
 Resources ::= (Resource)* -- set not list
 
-SimpleType  ::= ClassicType | LinearType
 Container(T) ::= List(T)
               | Tuple(#(T))
               | Array<u64>(T)
@@ -1041,9 +1040,10 @@ ClassicType ::= int<N>
               | Graph[R](#, #)
               | Opaque(Name, #)
               | Container(ClassicType)
-LinearType ::= Qubit
+SimpleType ::= Qubit
               | QPaque(Name, #)
               | Container(SimpleType)  -- Sometimes called 'Qontainer'
+              | ClassicType
 ```
 
 SimpleTypes are the types of *values* which can be sent down wires,
@@ -1093,18 +1093,19 @@ i.e. this does not affect behaviour of the HUGR. Row types are used
 ### Linearity
 
 For expressing and rewriting quantum programs we draw a distinction between
-`ClassicType` and `LinearType`, the latter being values which must be used
+arbitrary `SimpleType`s and the subset of `ClassicType`s. Only `ClassicType`s
+may be used more than once or discarded; the former must always be used
 exactly once. This leads to a constraint on the HUGR that outgoing ports
-of `LinearType` must have exactly one edge leaving them. `ClassicType` outgoing
-ports can have any number of connected edges (0 is equivalent to a discard).
+must have exactly one edge leaving them unless they are `ClassicType`, where
+outgoing ports may have anynum number of connected edges (0 is equivalent
+to a discard). All incoming ports must have exactly one edge connected to them.
 
-Our linear types behave like other values passed down a wire. Quantum
-gates behave just like other nodes on the graph with inputs and outputs,
-but there is only one edge leaving (or entering) each port. In fully
-qubit-counted contexts programs take in a number of qubits as input and
-return the same number, with no discarding. See
-[quantum resource](#quantum-resource)
-for more.
+# Our linear types behave like other values passed down a wire.
+# Quantum gates behave just like other nodes on the graph with
+# inputs and outputs, but there is only one edge leaving (or entering) each port.
+In fully qubit-counted contexts programs take in a number of qubits
+as input and return the same number, with no discarding. See
+[quantum resource](#quantum-resource) for more.
 
 ### Resources
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -4,8 +4,7 @@ use thiserror::Error;
 
 use crate::hugr::{HugrError, Node, ValidationError, Wire};
 use crate::ops::handle::{BasicBlockID, CfgID, ConditionalID, DfgID, FuncID, TailLoopID};
-
-use crate::types::LinearType;
+use crate::types::SimpleType;
 
 pub mod handle;
 pub use handle::BuildHandle;
@@ -63,7 +62,7 @@ pub enum BuildError {
 
     /// Can't copy a linear type
     #[error("Can't copy linear type: {0:?}.")]
-    NoCopyLinear(LinearType),
+    NoCopyLinear(SimpleType),
 
     /// Error in CircuitBuilder
     #[error("Error in CircuitBuilder: {0}.")]
@@ -72,7 +71,7 @@ pub enum BuildError {
 
 #[cfg(test)]
 mod test {
-    use crate::types::{ClassicType, LinearType, Signature, SimpleType};
+    use crate::types::{ClassicType, Signature, SimpleType};
     use crate::Hugr;
 
     use super::handle::BuildHandle;
@@ -82,7 +81,7 @@ mod test {
     pub(super) const NAT: SimpleType = SimpleType::Classic(ClassicType::i64());
     pub(super) const F64: SimpleType = SimpleType::Classic(ClassicType::F64);
     pub(super) const BIT: SimpleType = SimpleType::Classic(ClassicType::bit());
-    pub(super) const QB: SimpleType = SimpleType::Linear(LinearType::Qubit);
+    pub(super) const QB: SimpleType = SimpleType::Qubit;
 
     /// Wire up inputs of a Dataflow container to the outputs.
     pub(super) fn n_identity<T: DataflowSubContainer>(

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -16,7 +16,7 @@ use crate::{
     types::EdgeKind,
 };
 
-use crate::types::{LinearType, Signature, SimpleType, TypeRow};
+use crate::types::{Signature, SimpleType, TypeRow};
 
 use itertools::Itertools;
 
@@ -660,7 +660,7 @@ fn wire_up<T: Dataflow + ?Sized>(
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ValueKind {
     Classic,
-    Linear(LinearType),
+    Linear(SimpleType),
     Const,
 }
 
@@ -671,10 +671,13 @@ fn get_value_kind(base: &Hugr, src: Node, src_offset: Port) -> ValueKind {
     let wire_kind = base.get_optype(src).port_kind(src_offset).unwrap();
     match wire_kind {
         EdgeKind::Static(_) => ValueKind::Const,
-        EdgeKind::Value(simple_type) => match simple_type {
-            SimpleType::Classic(_) => ValueKind::Classic,
-            SimpleType::Linear(typ) => ValueKind::Linear(typ),
-        },
+        EdgeKind::Value(simple_type) => {
+            if simple_type.is_linear() {
+                ValueKind::Linear(simple_type)
+            } else {
+                ValueKind::Classic
+            }
+        }
         _ => {
             panic!("Wires can only be Const or Value kind")
         }

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -614,7 +614,7 @@ fn wire_up<T: Dataflow + ?Sized>(
     if let EdgeKind::Value(typ) = base.get_optype(src).port_kind(src_offset).unwrap() {
         if !local_source {
             // Non-local value sources require a state edge to an ancestor of dst
-            if typ.is_linear() {
+            if !typ.is_classical() {
                 let val_err: ValidationError = InterGraphEdgeError::NonClassicalData {
                     from: src,
                     from_offset: Port::new_outgoing(src_port),
@@ -646,7 +646,7 @@ fn wire_up<T: Dataflow + ?Sized>(
             // TODO: Avoid adding duplicate edges
             // This should be easy with https://github.com/CQCL-DEV/hugr/issues/130
             base.add_other_edge(src, src_sibling)?;
-        } else if typ.is_linear() && base.linked_ports(src, src_offset).next().is_some() {
+        } else if !typ.is_classical() && base.linked_ports(src, src_offset).next().is_some() {
             // Don't copy linear edges.
             return Err(BuildError::NoCopyLinear(typ));
         }

--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -195,6 +195,7 @@ mod test {
     use crate::builder::{DataflowSubContainer, ModuleBuilder};
     use crate::ops::tag::OpTag;
     use crate::ops::OpTrait;
+    use crate::types::SimpleType;
     use crate::{
         builder::{
             test::{n_identity, BIT, NAT, QB},
@@ -203,7 +204,7 @@ mod test {
         ops::LeafOp,
         resource::ResourceSet,
         type_row,
-        types::{LinearType, Signature},
+        types::Signature,
         Wire,
     };
 
@@ -304,7 +305,7 @@ mod test {
             Ok(module_builder.finish_hugr()?)
         };
 
-        assert_eq!(builder(), Err(BuildError::NoCopyLinear(LinearType::Qubit)));
+        assert_eq!(builder(), Err(BuildError::NoCopyLinear(SimpleType::Qubit)));
     }
 
     #[test]

--- a/src/builder/module_builder.rs
+++ b/src/builder/module_builder.rs
@@ -132,7 +132,7 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
         // Could be fixed by removing single-entry requirement and sorting from
         // every 0-input node.
         let name: SmolStr = name.into();
-        let linear = typ.is_linear();
+        let linear = !typ.is_classical();
         let node = self.add_child_op(ops::AliasDefn {
             name: name.clone(),
             definition: typ,

--- a/src/builder/module_builder.rs
+++ b/src/builder/module_builder.rs
@@ -132,13 +132,13 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
         // Could be fixed by removing single-entry requirement and sorting from
         // every 0-input node.
         let name: SmolStr = name.into();
-        let linear = !typ.is_classical();
+        let classical = typ.is_classical();
         let node = self.add_child_op(ops::AliasDefn {
             name: name.clone(),
             definition: typ,
         })?;
 
-        Ok(AliasID::new(node, name, linear))
+        Ok(AliasID::new(node, name, classical))
     }
 
     /// Add a [`OpType::AliasDecl`] node and return a handle to the Alias.
@@ -148,15 +148,15 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
     pub fn add_alias_declare(
         &mut self,
         name: impl Into<SmolStr>,
-        linear: bool,
+        classical: bool,
     ) -> Result<AliasID<false>, BuildError> {
         let name: SmolStr = name.into();
         let node = self.add_child_op(ops::AliasDecl {
             name: name.clone(),
-            linear,
+            classical,
         })?;
 
-        Ok(AliasID::new(node, name, linear))
+        Ok(AliasID::new(node, name, classical))
     }
 }
 
@@ -196,7 +196,7 @@ mod test {
         let build_result = {
             let mut module_builder = ModuleBuilder::new();
 
-            let qubit_state_type = module_builder.add_alias_declare("qubit_state", true)?;
+            let qubit_state_type = module_builder.add_alias_declare("qubit_state", false)?;
 
             let f_build = module_builder.define_function(
                 "main",

--- a/src/hugr/region.rs
+++ b/src/hugr/region.rs
@@ -332,13 +332,13 @@ mod test {
         builder::{Container, Dataflow, DataflowSubContainer, HugrBuilder, ModuleBuilder},
         ops::{handle::NodeHandle, LeafOp},
         type_row,
-        types::{ClassicType, LinearType, Signature, SimpleType},
+        types::{ClassicType, Signature, SimpleType},
     };
 
     use super::*;
 
     const NAT: SimpleType = SimpleType::Classic(ClassicType::i64());
-    const QB: SimpleType = SimpleType::Linear(LinearType::Qubit);
+    const QB: SimpleType = SimpleType::Qubit;
 
     /// Make a module hugr with a fn definition containing an inner dfg node.
     ///

--- a/src/hugr/rewrite/simple_replace.rs
+++ b/src/hugr/rewrite/simple_replace.rs
@@ -266,12 +266,12 @@ mod test {
     use crate::hugr::{Hugr, Node};
     use crate::ops::tag::OpTag;
     use crate::ops::{LeafOp, OpTrait, OpType};
-    use crate::types::{ClassicType, LinearType, Signature, SimpleType};
+    use crate::types::{ClassicType, Signature, SimpleType};
     use crate::{type_row, Port};
 
     use super::SimpleReplacement;
 
-    const QB: SimpleType = SimpleType::Linear(LinearType::Qubit);
+    const QB: SimpleType = SimpleType::Qubit;
 
     /// Creates a hugr like the following:
     /// --   H   --
@@ -511,7 +511,7 @@ mod test {
 
     #[test]
     fn test_replace_cx_cross() {
-        let q_row: Vec<SimpleType> = vec![LinearType::Qubit.into(), LinearType::Qubit.into()];
+        let q_row: Vec<SimpleType> = vec![SimpleType::Qubit, SimpleType::Qubit];
         let mut builder = DFGBuilder::new(q_row.clone(), q_row).unwrap();
         let mut circ = builder.as_circuit(builder.input_wires().collect());
         circ.append(LeafOp::CX, [0, 1]).unwrap();

--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -246,7 +246,7 @@ pub mod test {
             ModuleBuilder,
         },
         ops::{dataflow::IOTrait, Input, LeafOp, Module, Output, DFG},
-        types::{ClassicType, LinearType, Signature, SimpleType},
+        types::{ClassicType, Signature, SimpleType},
         Port,
     };
     use itertools::Itertools;
@@ -255,7 +255,7 @@ pub mod test {
     };
 
     const NAT: SimpleType = SimpleType::Classic(ClassicType::i64());
-    const QB: SimpleType = SimpleType::Linear(LinearType::Qubit);
+    const QB: SimpleType = SimpleType::Qubit;
 
     #[test]
     fn empty_hugr_serialize() {
@@ -425,7 +425,7 @@ pub mod test {
 
     #[test]
     fn hierarchy_order() {
-        let qb: SimpleType = LinearType::Qubit.into();
+        let qb = SimpleType::Qubit;
         let dfg = DFGBuilder::new([qb.clone()].to_vec(), [qb.clone()].to_vec()).unwrap();
         let [old_in, out] = dfg.io();
         let w = dfg.input_wires();

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -740,13 +740,13 @@ mod test {
     use crate::hugr::{HugrError, HugrMut};
     use crate::ops::dataflow::IOTrait;
     use crate::ops::{self, ConstValue, LeafOp, OpType};
-    use crate::types::{ClassicType, LinearType, Signature};
+    use crate::types::{ClassicType, Signature};
     use crate::Direction;
     use crate::{type_row, Node};
 
     const NAT: SimpleType = SimpleType::Classic(ClassicType::i64());
     const B: SimpleType = SimpleType::Classic(ClassicType::bit());
-    const Q: SimpleType = SimpleType::Linear(LinearType::Qubit);
+    const Q: SimpleType = SimpleType::Qubit;
 
     /// Creates a hugr with a single function definition that copies a bit `copies` times.
     ///

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -174,9 +174,11 @@ impl ConstValue {
 
     /// Constant Sum over Tuples, used as predicates.
     pub fn predicate(tag: usize, variant_rows: impl IntoIterator<Item = TypeRow>) -> Self {
+        let variants = TypeRow::predicate_variants_row(variant_rows);
+        assert!(variants.get(tag) == Some(&SimpleType::new_unit()));
         ConstValue::Sum {
             tag,
-            variants: TypeRow::predicate_variants_row(variant_rows),
+            variants,
             val: Box::new(Self::unit()),
         }
     }

--- a/src/ops/handle.rs
+++ b/src/ops/handle.rs
@@ -1,6 +1,6 @@
 //! Handles to nodes in HUGR.
 //!
-use crate::types::{ClassicType, Container, LinearType, SimpleType};
+use crate::types::{ClassicType, Container, SimpleType};
 use crate::Node;
 
 use derive_more::From as DerFrom;
@@ -86,7 +86,7 @@ impl<const DEF: bool> AliasID<DEF> {
     /// Construct new AliasID
     pub fn get_alias_type(&self) -> SimpleType {
         if self.linear {
-            Container::<LinearType>::Alias(self.name.clone()).into()
+            Container::<SimpleType>::Alias(self.name.clone()).into()
         } else {
             Container::<ClassicType>::Alias(self.name.clone()).into()
         }

--- a/src/ops/handle.rs
+++ b/src/ops/handle.rs
@@ -74,21 +74,25 @@ pub struct FuncID<const DEF: bool>(Node);
 pub struct AliasID<const DEF: bool> {
     node: Node,
     name: SmolStr,
-    linear: bool,
+    classical: bool,
 }
 
 impl<const DEF: bool> AliasID<DEF> {
     /// Construct new AliasID
-    pub fn new(node: Node, name: SmolStr, linear: bool) -> Self {
-        Self { node, name, linear }
+    pub fn new(node: Node, name: SmolStr, classical: bool) -> Self {
+        Self {
+            node,
+            name,
+            classical,
+        }
     }
 
     /// Construct new AliasID
     pub fn get_alias_type(&self) -> SimpleType {
-        if self.linear {
-            Container::<SimpleType>::Alias(self.name.clone()).into()
-        } else {
+        if self.classical {
             Container::<ClassicType>::Alias(self.name.clone()).into()
+        } else {
+            Container::<SimpleType>::Alias(self.name.clone()).into()
         }
     }
     /// Retrieve the underlying core type

--- a/src/ops/leaf.rs
+++ b/src/ops/leaf.rs
@@ -7,9 +7,7 @@ use super::{tag::OpTag, OpName, OpTrait};
 use crate::{
     resource::{ResourceId, ResourceSet},
     type_row,
-    types::{
-        ClassicType, EdgeKind, LinearType, Signature, SignatureDescription, SimpleType, TypeRow,
-    },
+    types::{ClassicType, EdgeKind, Signature, SignatureDescription, SimpleType, TypeRow},
 };
 
 /// Dataflow operations with no children.
@@ -85,7 +83,7 @@ pub enum LeafOp {
 impl Default for LeafOp {
     fn default() -> Self {
         Self::Noop {
-            ty: SimpleType::default(),
+            ty: SimpleType::Qubit,
         }
     }
 }
@@ -153,7 +151,7 @@ impl OpTrait for LeafOp {
     fn signature(&self) -> Signature {
         // Static signatures. The `TypeRow`s in the `Signature` use a
         // copy-on-write strategy, so we can avoid unnecessary allocations.
-        const Q: SimpleType = SimpleType::Linear(LinearType::Qubit);
+        const Q: SimpleType = SimpleType::Qubit;
         const B: SimpleType = SimpleType::Classic(ClassicType::bit());
         const F: SimpleType = SimpleType::Classic(ClassicType::F64);
 

--- a/src/ops/leaf.rs
+++ b/src/ops/leaf.rs
@@ -217,11 +217,6 @@ impl OpTrait for LeafOp {
 }
 
 impl LeafOp {
-    /// Returns the number of linear inputs (also outputs) of the operation.
-    pub fn linear_count(&self) -> usize {
-        self.signature().linear().count()
-    }
-
     /// Returns true if the operation has only classical inputs and outputs.
     pub fn is_pure_classical(&self) -> bool {
         self.signature().purely_classical()

--- a/src/ops/module.rs
+++ b/src/ops/module.rs
@@ -114,8 +114,8 @@ impl OpTrait for AliasDefn {
 pub struct AliasDecl {
     /// Alias name
     pub name: SmolStr,
-    /// Flag to signify type is linear
-    pub linear: bool,
+    /// Flag to signify type is classical
+    pub classical: bool,
 }
 
 impl_op_name!(AliasDecl);

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,7 +11,7 @@ use std::ops::Index;
 use pyo3::prelude::*;
 
 pub use custom::CustomType;
-pub use simple::{ClassicType, Container, LinearType, SimpleType, TypeRow};
+pub use simple::{ClassicType, Container, SimpleType, TypeRow};
 
 use smol_str::SmolStr;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -35,7 +35,7 @@ pub enum EdgeKind {
 }
 
 impl EdgeKind {
-    /// Returns whether the type contains only linear data.
+    /// Returns whether the type might contain linear data.
     pub fn is_linear(&self) -> bool {
         match self {
             EdgeKind::Value(t) => !t.is_classical(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -38,7 +38,7 @@ impl EdgeKind {
     /// Returns whether the type contains only linear data.
     pub fn is_linear(&self) -> bool {
         match self {
-            EdgeKind::Value(t) => t.is_linear(),
+            EdgeKind::Value(t) => !t.is_classical(),
             _ => false,
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -76,23 +76,6 @@ impl Signature {
     }
 }
 impl Signature {
-    /// Returns the linear part of the signature
-    /// TODO: This fails when mixing different linear types.
-    #[inline(always)]
-    pub fn linear(&self) -> impl Iterator<Item = &SimpleType> {
-        debug_assert_eq!(
-            self.input
-                .iter()
-                .filter(|t| t.is_linear())
-                .collect::<Vec<_>>(),
-            self.output
-                .iter()
-                .filter(|t| t.is_linear())
-                .collect::<Vec<_>>()
-        );
-        self.input.iter().filter(|t| t.is_linear())
-    }
-
     /// Returns the type of a [`Port`]. Returns `None` if the port is out of bounds.
     pub fn get(&self, port: Port) -> Option<EdgeKind> {
         if port.direction() == Direction::Incoming && port.index() >= self.input.len() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -69,12 +69,6 @@ impl Signature {
         self.static_input.is_empty() && self.input.is_empty() && self.output.is_empty()
     }
 
-    /// Returns whether the data wires in the signature are purely linear.
-    #[inline(always)]
-    pub fn purely_linear(&self) -> bool {
-        self.input.purely_linear() && self.output.purely_linear()
-    }
-
     /// Returns whether the data wires in the signature are purely classical.
     #[inline(always)]
     pub fn purely_classical(&self) -> bool {

--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -205,11 +205,6 @@ impl PrimType for SimpleType {
 }
 
 impl SimpleType {
-    /// Returns whether the type contains linear data (perhaps as well as classical)
-    pub fn is_linear(&self) -> bool {
-        !self.is_classical()
-    }
-
     /// Returns whether the type contains only classic data.
     pub fn is_classical(&self) -> bool {
         matches!(self, Self::Classic(_))

--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -254,44 +254,33 @@ impl SimpleType {
     }
 }
 
-/// Implementations of Into and TryFrom for SimpleType and &'a SimpleType.
-macro_rules! impl_from_into_simple_type {
-    ($target:ident, $matcher:pat, $unpack:expr, $new:expr) => {
-        impl From<$target> for SimpleType {
-            fn from(typ: $target) -> Self {
-                $new(typ)
-            }
-        }
-
-        impl TryFrom<SimpleType> for $target {
-            type Error = &'static str;
-
-            fn try_from(op: SimpleType) -> Result<Self, Self::Error> {
-                match op {
-                    $matcher => Ok($unpack),
-                    _ => Err("Invalid type conversion"),
-                }
-            }
-        }
-
-        impl<'a> TryFrom<&'a SimpleType> for &'a $target {
-            type Error = &'static str;
-
-            fn try_from(op: &'a SimpleType) -> Result<Self, Self::Error> {
-                match op {
-                    $matcher => Ok($unpack),
-                    _ => Err("Invalid type conversion"),
-                }
-            }
-        }
-    };
+impl From<ClassicType> for SimpleType {
+    fn from(typ: ClassicType) -> Self {
+        SimpleType::Classic(typ)
+    }
 }
-impl_from_into_simple_type!(
-    ClassicType,
-    SimpleType::Classic(typ),
-    typ,
-    SimpleType::Classic
-);
+
+impl TryFrom<SimpleType> for ClassicType {
+    type Error = &'static str;
+
+    fn try_from(op: SimpleType) -> Result<Self, Self::Error> {
+        match op {
+            SimpleType::Classic(typ) => Ok(typ),
+            _ => Err("Invalid type conversion"),
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a SimpleType> for &'a ClassicType {
+    type Error = &'static str;
+
+    fn try_from(op: &'a SimpleType) -> Result<Self, Self::Error> {
+        match op {
+            SimpleType::Classic(typ) => Ok(typ),
+            _ => Err("Invalid type conversion"),
+        }
+    }
+}
 
 /// List of types, used for function signatures.
 #[derive(Clone, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]

--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -371,17 +371,6 @@ impl TypeRow {
         }
     }
 
-    /// Create a new row from a Cow slice of types.
-    ///
-    /// See [`type_row!`] for a more ergonomic way to create a statically allocated rows.
-    ///
-    /// [`type_row!`]: crate::macros::type_row.
-    pub fn from(types: impl Into<Cow<'static, [SimpleType]>>) -> Self {
-        Self {
-            types: types.into(),
-        }
-    }
-
     /// Iterator over the types in the row.
     pub fn iter(&self) -> impl Iterator<Item = &SimpleType> {
         self.types.iter()
@@ -427,7 +416,9 @@ where
     T: Into<Cow<'static, [SimpleType]>>,
 {
     fn from(types: T) -> Self {
-        Self::from(types.into())
+        Self {
+            types: types.into(),
+        }
     }
 }
 

--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -307,12 +307,6 @@ impl TypeRow {
         self.types.len() == 0
     }
 
-    /// Returns whether the row contains only linear data.
-    #[inline(always)]
-    pub fn purely_linear(&self) -> bool {
-        self.types.iter().all(|typ| typ.is_linear())
-    }
-
     /// Returns whether the row contains only classic data.
     #[inline(always)]
     pub fn purely_classical(&self) -> bool {

--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -53,8 +53,8 @@ pub trait PrimType {
     // across ClassicType and SimpleType
     // currently used to constrain Container<T>
 
-    /// Is this type linear? (I.e. does it have any linear components?)
-    const LINEAR: bool;
+    /// Is this type classical? (I.e. can it be copied - not if it has *any* linear component)
+    const CLASSIC: bool;
 }
 
 /// A type that represents a container of other types.
@@ -197,11 +197,11 @@ impl Display for ClassicType {
 }
 
 impl PrimType for ClassicType {
-    const LINEAR: bool = false;
+    const CLASSIC: bool = true;
 }
 
 impl PrimType for SimpleType {
-    const LINEAR: bool = true;
+    const CLASSIC: bool = false;
 }
 
 impl SimpleType {

--- a/src/types/simple/serialize.rs
+++ b/src/types/simple/serialize.rs
@@ -70,27 +70,30 @@ impl<T: PrimType + Into<SimpleType>> From<Container<T>> for SerSimpleType {
         match value {
             Container::Sum(inner) => SerSimpleType::Sum {
                 row: inner,
-                l: T::LINEAR,
+                l: !T::CLASSIC,
             },
             Container::List(inner) => SerSimpleType::List {
                 inner: box_convert(*inner),
-                l: T::LINEAR,
+                l: !T::CLASSIC,
             },
             Container::Tuple(inner) => SerSimpleType::Tuple {
                 row: inner,
-                l: T::LINEAR,
+                l: !T::CLASSIC,
             },
             Container::Map(inner) => SerSimpleType::Map {
                 k: Box::new(inner.0.into()),
                 v: Box::new(inner.1.into()),
-                l: T::LINEAR,
+                l: !T::CLASSIC,
             },
             Container::Array(inner, len) => SerSimpleType::Array {
                 inner: box_convert(*inner),
                 len,
-                l: T::LINEAR,
+                l: !T::CLASSIC,
             },
-            Container::Alias(name) => SerSimpleType::Alias { name, l: T::LINEAR },
+            Container::Alias(name) => SerSimpleType::Alias {
+                name,
+                l: !T::CLASSIC,
+            },
         }
     }
 }

--- a/src/types/simple/serialize.rs
+++ b/src/types/simple/serialize.rs
@@ -2,7 +2,6 @@ use super::ClassicType;
 
 use super::Container;
 
-use super::LinearType;
 use super::PrimType;
 
 use smol_str::SmolStr;
@@ -116,24 +115,16 @@ impl From<ClassicType> for SerSimpleType {
     }
 }
 
-impl From<LinearType> for SerSimpleType {
-    fn from(value: LinearType) -> Self {
-        match value {
-            LinearType::Qubit => SerSimpleType::Q,
-            LinearType::Container(c) => c.into(),
-            LinearType::Qpaque(inner) => SerSimpleType::Opaque {
-                custom: inner,
-                l: true,
-            },
-        }
-    }
-}
-
 impl From<SimpleType> for SerSimpleType {
     fn from(value: SimpleType) -> Self {
         match value {
-            SimpleType::Linear(l) => l.into(),
             SimpleType::Classic(c) => c.into(),
+            SimpleType::Qubit => SerSimpleType::Q,
+            SimpleType::Qontainer(c) => c.into(),
+            SimpleType::Qpaque(inner) => SerSimpleType::Opaque {
+                custom: inner,
+                l: true,
+            },
         }
     }
 }
@@ -156,7 +147,7 @@ where
 impl From<SerSimpleType> for SimpleType {
     fn from(value: SerSimpleType) -> Self {
         match value {
-            SerSimpleType::Q => LinearType::Qubit.into(),
+            SerSimpleType::Q => SimpleType::Qubit,
             SerSimpleType::I { width } => ClassicType::Int(width).into(),
             SerSimpleType::F => ClassicType::F64.into(),
             SerSimpleType::S => ClassicType::String.into(),
@@ -206,7 +197,7 @@ impl From<SerSimpleType> for SimpleType {
             } => Container::<ClassicType>::Array(box_convert_try(*inner), len).into(),
             SerSimpleType::Alias { name: s, l: true } => Container::<SimpleType>::Alias(s).into(),
             SerSimpleType::Alias { name: s, l: false } => Container::<ClassicType>::Alias(s).into(),
-            SerSimpleType::Opaque { custom: c, l: true } => LinearType::Qpaque(c).into(),
+            SerSimpleType::Opaque { custom: c, l: true } => SimpleType::Qpaque(c),
             SerSimpleType::Opaque {
                 custom: c,
                 l: false,

--- a/src/types/simple/serialize.rs
+++ b/src/types/simple/serialize.rs
@@ -167,7 +167,7 @@ impl From<SerSimpleType> for SimpleType {
             SerSimpleType::Tuple {
                 row: inner,
                 l: true,
-            } => Container::<LinearType>::Tuple(box_convert_try(*inner)).into(),
+            } => Container::<SimpleType>::Tuple(box_convert_try(*inner)).into(),
             SerSimpleType::Tuple {
                 row: inner,
                 l: false,
@@ -175,22 +175,20 @@ impl From<SerSimpleType> for SimpleType {
             SerSimpleType::Sum {
                 row: inner,
                 l: true,
-            } => Container::<LinearType>::Sum(box_convert_try(*inner)).into(),
+            } => Container::<SimpleType>::Sum(box_convert_try(*inner)).into(),
             SerSimpleType::Sum {
                 row: inner,
                 l: false,
             } => Container::<ClassicType>::Sum(box_convert_try(*inner)).into(),
             SerSimpleType::List { inner, l: true } => {
-                Container::<LinearType>::List(box_convert_try(*inner)).into()
+                Container::<SimpleType>::List(box_convert_try(*inner)).into()
             }
             SerSimpleType::List { inner, l: false } => {
                 Container::<ClassicType>::List(box_convert_try(*inner)).into()
             }
-            SerSimpleType::Map { k, v, l: true } => Container::<LinearType>::Map(Box::new((
-                (*k).try_into().unwrap(),
-                (*v).try_into().unwrap(),
-            )))
-            .into(),
+            SerSimpleType::Map { k, v, l: true } => {
+                Container::<SimpleType>::Map(Box::new(((*k).try_into().unwrap(), *v))).into()
+            }
             SerSimpleType::Map { k, v, l: false } => Container::<ClassicType>::Map(Box::new((
                 (*k).try_into().unwrap(),
                 (*v).try_into().unwrap(),
@@ -200,13 +198,13 @@ impl From<SerSimpleType> for SimpleType {
                 inner,
                 len,
                 l: true,
-            } => Container::<LinearType>::Array(box_convert_try(*inner), len).into(),
+            } => Container::<SimpleType>::Array(box_convert_try(*inner), len).into(),
             SerSimpleType::Array {
                 inner,
                 len,
                 l: false,
             } => Container::<ClassicType>::Array(box_convert_try(*inner), len).into(),
-            SerSimpleType::Alias { name: s, l: true } => Container::<LinearType>::Alias(s).into(),
+            SerSimpleType::Alias { name: s, l: true } => Container::<SimpleType>::Alias(s).into(),
             SerSimpleType::Alias { name: s, l: false } => Container::<ClassicType>::Alias(s).into(),
             SerSimpleType::Opaque { custom: c, l: true } => LinearType::Qpaque(c).into(),
             SerSimpleType::Opaque {


### PR DESCRIPTION
First step in refactoring the type hierarchy! (I'm heading towards the creation of a Hashable subset of ClassicType but it's a long way to go)

There seemed some confusion in the type hierarchy here. Partly this stems from that TypeRow always contains SimpleType, so statically Container<T> can have tuples of SimpleType (regardless of T). However, if we imagine that TypeRow might be parameterized by the type contained within it (hint hint - that PR is upcoming, but I found there was a lot to sort out first) then the old LinearType should not have the option of `Container<LinearType>` but `Container<SimpleType>` as that's the only way we'd be able to have "mixed" types like Tuple(Qubit,Int).

After sorting out Linear/Simple confusion it didn't seem that LinearType really meant anything: SimpleTypes could be anything (classic/linear/both), so you have to treat them as linear as *they might be*; only ClassicTypes can definitely be copied/discarded. This is a straightforward subtyping relation, i.e., you can do anything to a ClassicType that you can to a SimpleType, *plus* you can copy/discard it.

Hence, it seemed that the best thing was to inline LinearType into SimpleType. So, there is now SimpleType::Qubit, SimpleType::Qpaque, and then it seemed consistent to call it SimpleType::Qontainer *ducks*.

There were some other fixes/tidies first too, see individual commits, <strike>including that predicate types can have linear components.</strike> (EDIT: the latter now removed, work on the aforementioned parameterization of TypeRow revealed that including linear bits in predicates is a bigger can of worms than I'd realized.)

Thoughts/questions: I am not convinced by the removal of LinearType (de40c363ac7764489e32a2b68fc4b8bcfd2e3096). It might be useful just to separate these out, but I think the more useful idea might be to remove all plays on `is_linear` (replacing only with `is_classic`), so maybe even consider NonClassicType?!