### PR TITLE
Allow linear elements in predicates

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -4,8 +4,7 @@ use thiserror::Error;
 
 use crate::hugr::{HugrError, Node, ValidationError, Wire};
 use crate::ops::handle::{BasicBlockID, CfgID, ConditionalID, DfgID, FuncID, TailLoopID};
-
-use crate::types::LinearType;
+use crate::types::SimpleType;
 
 pub mod handle;
 pub use handle::BuildHandle;
@@ -63,7 +62,7 @@ pub enum BuildError {
 
     /// Can't copy a linear type
     #[error("Can't copy linear type: {0:?}.")]
-    NoCopyLinear(LinearType),
+    NoCopyLinear(SimpleType),
 
     /// Error in CircuitBuilder
     #[error("Error in CircuitBuilder: {0}.")]
@@ -72,7 +71,7 @@ pub enum BuildError {
 
 #[cfg(test)]
 mod test {
-    use crate::types::{ClassicType, LinearType, Signature, SimpleType};
+    use crate::types::{ClassicType, Signature, SimpleType};
     use crate::Hugr;
 
     use super::handle::BuildHandle;
@@ -82,7 +81,7 @@ mod test {
     pub(super) const NAT: SimpleType = SimpleType::Classic(ClassicType::i64());
     pub(super) const F64: SimpleType = SimpleType::Classic(ClassicType::F64);
     pub(super) const BIT: SimpleType = SimpleType::Classic(ClassicType::bit());
-    pub(super) const QB: SimpleType = SimpleType::Linear(LinearType::Qubit);
+    pub(super) const QB: SimpleType = SimpleType::Qubit;
 
     /// Wire up inputs of a Dataflow container to the outputs.
     pub(super) fn n_identity<T: DataflowSubContainer>(

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -16,7 +16,7 @@ use crate::{
     types::EdgeKind,
 };
 
-use crate::types::{LinearType, Signature, SimpleType, TypeRow};
+use crate::types::{Signature, SimpleType, TypeRow};
 
 use itertools::Itertools;
 
@@ -660,7 +660,7 @@ fn wire_up<T: Dataflow + ?Sized>(
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ValueKind {
     Classic,
-    Linear(LinearType),
+    Linear(SimpleType),
     Const,
 }
 
@@ -671,10 +671,13 @@ fn get_value_kind(base: &Hugr, src: Node, src_offset: Port) -> ValueKind {
     let wire_kind = base.get_optype(src).port_kind(src_offset).unwrap();
     match wire_kind {
         EdgeKind::Static(_) => ValueKind::Const,
-        EdgeKind::Value(simple_type) => match simple_type {
-            SimpleType::Classic(_) => ValueKind::Classic,
-            SimpleType::Linear(typ) => ValueKind::Linear(typ),
-        },
+        EdgeKind::Value(simple_type) => {
+            if simple_type.is_linear() {
+                ValueKind::Linear(simple_type)
+            } else {
+                ValueKind::Classic
+            }
+        }
         _ => {
             panic!("Wires can only be Const or Value kind")
         }

--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -195,6 +195,7 @@ mod test {
     use crate::builder::{DataflowSubContainer, ModuleBuilder};
     use crate::ops::tag::OpTag;
     use crate::ops::OpTrait;
+    use crate::types::SimpleType;
     use crate::{
         builder::{
             test::{n_identity, BIT, NAT, QB},
@@ -203,7 +204,7 @@ mod test {
         ops::LeafOp,
         resource::ResourceSet,
         type_row,
-        types::{LinearType, Signature},
+        types::Signature,
         Wire,
     };
 
@@ -304,7 +305,7 @@ mod test {
             Ok(module_builder.finish_hugr()?)
         };
 
-        assert_eq!(builder(), Err(BuildError::NoCopyLinear(LinearType::Qubit)));
+        assert_eq!(builder(), Err(BuildError::NoCopyLinear(SimpleType::Qubit)));
     }
 
     #[test]

--- a/src/hugr/region.rs
+++ b/src/hugr/region.rs
@@ -332,13 +332,13 @@ mod test {
         builder::{Container, Dataflow, DataflowSubContainer, HugrBuilder, ModuleBuilder},
         ops::{handle::NodeHandle, LeafOp},
         type_row,
-        types::{ClassicType, LinearType, Signature, SimpleType},
+        types::{ClassicType, Signature, SimpleType},
     };
 
     use super::*;
 
     const NAT: SimpleType = SimpleType::Classic(ClassicType::i64());
-    const QB: SimpleType = SimpleType::Linear(LinearType::Qubit);
+    const QB: SimpleType = SimpleType::Qubit;
 
     /// Make a module hugr with a fn definition containing an inner dfg node.
     ///

--- a/src/hugr/rewrite/simple_replace.rs
+++ b/src/hugr/rewrite/simple_replace.rs
@@ -266,12 +266,12 @@ mod test {
     use crate::hugr::{Hugr, Node};
     use crate::ops::tag::OpTag;
     use crate::ops::{LeafOp, OpTrait, OpType};
-    use crate::types::{ClassicType, LinearType, Signature, SimpleType};
+    use crate::types::{ClassicType, Signature, SimpleType};
     use crate::{type_row, Port};
 
     use super::SimpleReplacement;
 
-    const QB: SimpleType = SimpleType::Linear(LinearType::Qubit);
+    const QB: SimpleType = SimpleType::Qubit;
 
     /// Creates a hugr like the following:
     /// --   H   --
@@ -511,7 +511,7 @@ mod test {
 
     #[test]
     fn test_replace_cx_cross() {
-        let q_row: Vec<SimpleType> = vec![LinearType::Qubit.into(), LinearType::Qubit.into()];
+        let q_row: Vec<SimpleType> = vec![SimpleType::Qubit, SimpleType::Qubit];
         let mut builder = DFGBuilder::new(q_row.clone(), q_row).unwrap();
         let mut circ = builder.as_circuit(builder.input_wires().collect());
         circ.append(LeafOp::CX, [0, 1]).unwrap();

--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -246,7 +246,7 @@ pub mod test {
             ModuleBuilder,
         },
         ops::{dataflow::IOTrait, Input, LeafOp, Module, Output, DFG},
-        types::{ClassicType, LinearType, Signature, SimpleType},
+        types::{ClassicType, Signature, SimpleType},
         Port,
     };
     use itertools::Itertools;
@@ -255,7 +255,7 @@ pub mod test {
     };
 
     const NAT: SimpleType = SimpleType::Classic(ClassicType::i64());
-    const QB: SimpleType = SimpleType::Linear(LinearType::Qubit);
+    const QB: SimpleType = SimpleType::Qubit;
 
     #[test]
     fn empty_hugr_serialize() {
@@ -425,7 +425,7 @@ pub mod test {
 
     #[test]
     fn hierarchy_order() {
-        let qb: SimpleType = LinearType::Qubit.into();
+        let qb = SimpleType::Qubit;
         let dfg = DFGBuilder::new([qb.clone()].to_vec(), [qb.clone()].to_vec()).unwrap();
         let [old_in, out] = dfg.io();
         let w = dfg.input_wires();

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -740,13 +740,13 @@ mod test {
     use crate::hugr::{HugrError, HugrMut};
     use crate::ops::dataflow::IOTrait;
     use crate::ops::{self, ConstValue, LeafOp, OpType};
-    use crate::types::{ClassicType, LinearType, Signature};
+    use crate::types::{ClassicType, Signature};
     use crate::Direction;
     use crate::{type_row, Node};
 
     const NAT: SimpleType = SimpleType::Classic(ClassicType::i64());
     const B: SimpleType = SimpleType::Classic(ClassicType::bit());
-    const Q: SimpleType = SimpleType::Linear(LinearType::Qubit);
+    const Q: SimpleType = SimpleType::Qubit;
 
     /// Creates a hugr with a single function definition that copies a bit `copies` times.
     ///

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -805,7 +805,7 @@ mod test {
         predicate_size: usize,
     ) -> (Node, Node, Node, Node) {
         let const_op = ops::Const(ConstValue::simple_predicate(0, predicate_size));
-        let tag_type = SimpleType::Classic(ClassicType::new_simple_predicate(predicate_size));
+        let tag_type = SimpleType::new_simple_predicate(predicate_size);
 
         let input = b
             .add_op_with_parent(parent, ops::Input::new(type_row![B]))

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -174,9 +174,11 @@ impl ConstValue {
 
     /// Constant Sum over Tuples, used as predicates.
     pub fn predicate(tag: usize, variant_rows: impl IntoIterator<Item = TypeRow>) -> Self {
+        let variants = TypeRow::predicate_variants_row(variant_rows);
+        assert!(variants.get(tag) == Some(&SimpleType::new_unit()));
         ConstValue::Sum {
             tag,
-            variants: TypeRow::predicate_variants_row(variant_rows),
+            variants,
             val: Box::new(Self::unit()),
         }
     }

--- a/src/ops/handle.rs
+++ b/src/ops/handle.rs
@@ -1,6 +1,6 @@
 //! Handles to nodes in HUGR.
 //!
-use crate::types::{ClassicType, Container, LinearType, SimpleType};
+use crate::types::{ClassicType, Container, SimpleType};
 use crate::Node;
 
 use derive_more::From as DerFrom;
@@ -86,7 +86,7 @@ impl<const DEF: bool> AliasID<DEF> {
     /// Construct new AliasID
     pub fn get_alias_type(&self) -> SimpleType {
         if self.linear {
-            Container::<LinearType>::Alias(self.name.clone()).into()
+            Container::<SimpleType>::Alias(self.name.clone()).into()
         } else {
             Container::<ClassicType>::Alias(self.name.clone()).into()
         }

--- a/src/ops/leaf.rs
+++ b/src/ops/leaf.rs
@@ -7,9 +7,7 @@ use super::{tag::OpTag, OpName, OpTrait};
 use crate::{
     resource::{ResourceId, ResourceSet},
     type_row,
-    types::{
-        ClassicType, EdgeKind, LinearType, Signature, SignatureDescription, SimpleType, TypeRow,
-    },
+    types::{ClassicType, EdgeKind, Signature, SignatureDescription, SimpleType, TypeRow},
 };
 
 /// Dataflow operations with no children.
@@ -85,7 +83,7 @@ pub enum LeafOp {
 impl Default for LeafOp {
     fn default() -> Self {
         Self::Noop {
-            ty: SimpleType::default(),
+            ty: SimpleType::Qubit,
         }
     }
 }
@@ -153,7 +151,7 @@ impl OpTrait for LeafOp {
     fn signature(&self) -> Signature {
         // Static signatures. The `TypeRow`s in the `Signature` use a
         // copy-on-write strategy, so we can avoid unnecessary allocations.
-        const Q: SimpleType = SimpleType::Linear(LinearType::Qubit);
+        const Q: SimpleType = SimpleType::Qubit;
         const B: SimpleType = SimpleType::Classic(ClassicType::bit());
         const F: SimpleType = SimpleType::Classic(ClassicType::F64);
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,7 +11,7 @@ use std::ops::Index;
 use pyo3::prelude::*;
 
 pub use custom::CustomType;
-pub use simple::{ClassicType, Container, LinearType, SimpleType, TypeRow};
+pub use simple::{ClassicType, Container, SimpleType, TypeRow};
 
 use smol_str::SmolStr;
 

--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -154,19 +154,6 @@ impl ClassicType {
     pub const fn bit() -> Self {
         Self::int::<1>()
     }
-
-    /// New Sum of Tuple types, used as predicates in branching.
-    /// Tuple rows are defined in order by input rows.
-    pub fn new_predicate(variant_rows: impl IntoIterator<Item = TypeRow>) -> Self {
-        Self::Container(Container::Sum(Box::new(TypeRow::predicate_variants_row(
-            variant_rows,
-        ))))
-    }
-
-    /// New simple predicate with empty Tuple variants
-    pub fn new_simple_predicate(size: usize) -> Self {
-        Self::new_predicate(std::iter::repeat(type_row![]).take(size))
-    }
 }
 
 impl Default for ClassicType {
@@ -245,12 +232,12 @@ impl SimpleType {
     /// New Sum of Tuple types, used as predicates in branching.
     /// Tuple rows are defined in order by input rows.
     pub fn new_predicate(variant_rows: impl IntoIterator<Item = TypeRow>) -> Self {
-        Self::Classic(ClassicType::new_predicate(variant_rows))
+        Self::new_sum(TypeRow::predicate_variants_row(variant_rows))
     }
 
     /// New simple predicate with empty Tuple variants
     pub fn new_simple_predicate(size: usize) -> Self {
-        Self::Classic(ClassicType::new_simple_predicate(size))
+        Self::new_predicate(std::iter::repeat(type_row![]).take(size))
     }
 }
 
@@ -362,7 +349,7 @@ impl TypeRow {
     pub fn predicate_variants_row(variant_rows: impl IntoIterator<Item = TypeRow>) -> Self {
         variant_rows
             .into_iter()
-            .map(|row| SimpleType::Classic(ClassicType::Container(Container::Tuple(Box::new(row)))))
+            .map(|row| SimpleType::new_tuple(row))
             .collect_vec()
             .into()
     }

--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -254,44 +254,33 @@ impl SimpleType {
     }
 }
 
-/// Implementations of Into and TryFrom for SimpleType and &'a SimpleType.
-macro_rules! impl_from_into_simple_type {
-    ($target:ident, $matcher:pat, $unpack:expr, $new:expr) => {
-        impl From<$target> for SimpleType {
-            fn from(typ: $target) -> Self {
-                $new(typ)
-            }
-        }
-
-        impl TryFrom<SimpleType> for $target {
-            type Error = &'static str;
-
-            fn try_from(op: SimpleType) -> Result<Self, Self::Error> {
-                match op {
-                    $matcher => Ok($unpack),
-                    _ => Err("Invalid type conversion"),
-                }
-            }
-        }
-
-        impl<'a> TryFrom<&'a SimpleType> for &'a $target {
-            type Error = &'static str;
-
-            fn try_from(op: &'a SimpleType) -> Result<Self, Self::Error> {
-                match op {
-                    $matcher => Ok($unpack),
-                    _ => Err("Invalid type conversion"),
-                }
-            }
-        }
-    };
+impl From<ClassicType> for SimpleType {
+    fn from(typ: ClassicType) -> Self {
+        SimpleType::Classic(typ)
+    }
 }
-impl_from_into_simple_type!(
-    ClassicType,
-    SimpleType::Classic(typ),
-    typ,
-    SimpleType::Classic
-);
+
+impl TryFrom<SimpleType> for ClassicType {
+    type Error = &'static str;
+
+    fn try_from(op: SimpleType) -> Result<Self, Self::Error> {
+        match op {
+            SimpleType::Classic(typ) => Ok(typ),
+            _ => Err("Invalid type conversion"),
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a SimpleType> for &'a ClassicType {
+    type Error = &'static str;
+
+    fn try_from(op: &'a SimpleType) -> Result<Self, Self::Error> {
+        match op {
+            SimpleType::Classic(typ) => Ok(typ),
+            _ => Err("Invalid type conversion"),
+        }
+    }
+}
 
 /// List of types, used for function signatures.
 #[derive(Clone, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]

--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -371,17 +371,6 @@ impl TypeRow {
         }
     }
 
-    /// Create a new row from a Cow slice of types.
-    ///
-    /// See [`type_row!`] for a more ergonomic way to create a statically allocated rows.
-    ///
-    /// [`type_row!`]: crate::macros::type_row.
-    pub fn from(types: impl Into<Cow<'static, [SimpleType]>>) -> Self {
-        Self {
-            types: types.into(),
-        }
-    }
-
     /// Iterator over the types in the row.
     pub fn iter(&self) -> impl Iterator<Item = &SimpleType> {
         self.types.iter()
@@ -427,7 +416,9 @@ where
     T: Into<Cow<'static, [SimpleType]>>,
 {
     fn from(types: T) -> Self {
-        Self::from(types.into())
+        Self {
+            types: types.into(),
+        }
     }
 }
 

--- a/src/types/simple/serialize.rs
+++ b/src/types/simple/serialize.rs
@@ -2,7 +2,6 @@ use super::ClassicType;
 
 use super::Container;
 
-use super::LinearType;
 use super::PrimType;
 
 use smol_str::SmolStr;
@@ -116,24 +115,16 @@ impl From<ClassicType> for SerSimpleType {
     }
 }
 
-impl From<LinearType> for SerSimpleType {
-    fn from(value: LinearType) -> Self {
-        match value {
-            LinearType::Qubit => SerSimpleType::Q,
-            LinearType::Container(c) => c.into(),
-            LinearType::Qpaque(inner) => SerSimpleType::Opaque {
-                custom: inner,
-                l: true,
-            },
-        }
-    }
-}
-
 impl From<SimpleType> for SerSimpleType {
     fn from(value: SimpleType) -> Self {
         match value {
-            SimpleType::Linear(l) => l.into(),
             SimpleType::Classic(c) => c.into(),
+            SimpleType::Qubit => SerSimpleType::Q,
+            SimpleType::Qontainer(c) => c.into(),
+            SimpleType::Qpaque(inner) => SerSimpleType::Opaque {
+                custom: inner,
+                l: true,
+            },
         }
     }
 }
@@ -156,7 +147,7 @@ where
 impl From<SerSimpleType> for SimpleType {
     fn from(value: SerSimpleType) -> Self {
         match value {
-            SerSimpleType::Q => LinearType::Qubit.into(),
+            SerSimpleType::Q => SimpleType::Qubit,
             SerSimpleType::I { width } => ClassicType::Int(width).into(),
             SerSimpleType::F => ClassicType::F64.into(),
             SerSimpleType::S => ClassicType::String.into(),
@@ -206,7 +197,7 @@ impl From<SerSimpleType> for SimpleType {
             } => Container::<ClassicType>::Array(box_convert_try(*inner), len).into(),
             SerSimpleType::Alias { name: s, l: true } => Container::<SimpleType>::Alias(s).into(),
             SerSimpleType::Alias { name: s, l: false } => Container::<ClassicType>::Alias(s).into(),
-            SerSimpleType::Opaque { custom: c, l: true } => LinearType::Qpaque(c).into(),
+            SerSimpleType::Opaque { custom: c, l: true } => SimpleType::Qpaque(c),
             SerSimpleType::Opaque {
                 custom: c,
                 l: false,

--- a/src/types/simple/serialize.rs
+++ b/src/types/simple/serialize.rs
@@ -167,7 +167,7 @@ impl From<SerSimpleType> for SimpleType {
             SerSimpleType::Tuple {
                 row: inner,
                 l: true,
-            } => Container::<LinearType>::Tuple(box_convert_try(*inner)).into(),
+            } => Container::<SimpleType>::Tuple(box_convert_try(*inner)).into(),
             SerSimpleType::Tuple {
                 row: inner,
                 l: false,
@@ -175,22 +175,20 @@ impl From<SerSimpleType> for SimpleType {
             SerSimpleType::Sum {
                 row: inner,
                 l: true,
-            } => Container::<LinearType>::Sum(box_convert_try(*inner)).into(),
+            } => Container::<SimpleType>::Sum(box_convert_try(*inner)).into(),
             SerSimpleType::Sum {
                 row: inner,
                 l: false,
             } => Container::<ClassicType>::Sum(box_convert_try(*inner)).into(),
             SerSimpleType::List { inner, l: true } => {
-                Container::<LinearType>::List(box_convert_try(*inner)).into()
+                Container::<SimpleType>::List(box_convert_try(*inner)).into()
             }
             SerSimpleType::List { inner, l: false } => {
                 Container::<ClassicType>::List(box_convert_try(*inner)).into()
             }
-            SerSimpleType::Map { k, v, l: true } => Container::<LinearType>::Map(Box::new((
-                (*k).try_into().unwrap(),
-                (*v).try_into().unwrap(),
-            )))
-            .into(),
+            SerSimpleType::Map { k, v, l: true } => {
+                Container::<SimpleType>::Map(Box::new(((*k).try_into().unwrap(), *v))).into()
+            }
             SerSimpleType::Map { k, v, l: false } => Container::<ClassicType>::Map(Box::new((
                 (*k).try_into().unwrap(),
                 (*v).try_into().unwrap(),
@@ -200,13 +198,13 @@ impl From<SerSimpleType> for SimpleType {
                 inner,
                 len,
                 l: true,
-            } => Container::<LinearType>::Array(box_convert_try(*inner), len).into(),
+            } => Container::<SimpleType>::Array(box_convert_try(*inner), len).into(),
             SerSimpleType::Array {
                 inner,
                 len,
                 l: false,
             } => Container::<ClassicType>::Array(box_convert_try(*inner), len).into(),
-            SerSimpleType::Alias { name: s, l: true } => Container::<LinearType>::Alias(s).into(),
+            SerSimpleType::Alias { name: s, l: true } => Container::<SimpleType>::Alias(s).into(),
             SerSimpleType::Alias { name: s, l: false } => Container::<ClassicType>::Alias(s).into(),
             SerSimpleType::Opaque { custom: c, l: true } => LinearType::Qpaque(c).into(),
             SerSimpleType::Opaque {


### PR DESCRIPTION
This is a followup to #252 and, ok, maybe not as hard as I thought after all. But I'll have more certainty after the parameterization of TypeRow so I'll come back to this then.