### PR TITLE
Feat/region trait

### DIFF
--- a/src/algorithm/nest_cfgs.rs
+++ b/src/algorithm/nest_cfgs.rs
@@ -398,7 +398,7 @@ impl<T: Copy + Clone + PartialEq + Eq + Hash> EdgeClassifier<T> {
 pub(crate) mod test {
     use super::*;
     use crate::builder::{BuildError, CFGBuilder, Container, DataflowSubContainer, HugrBuilder};
-    use crate::hugr::region::FlatRegionView;
+    use crate::hugr::region::{FlatRegionView, Region};
     use crate::ops::{
         handle::{BasicBlockID, ConstID, NodeHandle},
         ConstValue,

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -366,7 +366,7 @@ fn insert_hugr_internal(
     root: Node,
     other: &impl HugrView,
 ) -> Result<(Node, HashMap<NodeIndex, NodeIndex>), HugrError> {
-    let node_map = hugr.graph.insert_graph(other.as_portgraph())?;
+    let node_map = hugr.graph.insert_graph(other.portgraph())?;
     let other_root = node_map[&other.root().index];
 
     // Update hierarchy and optypes

--- a/src/hugr/region.rs
+++ b/src/hugr/region.rs
@@ -15,6 +15,7 @@ pub mod petgraph;
 
 use std::iter;
 
+use ::petgraph::visit as pv;
 use context_iterators::{ContextIterator, IntoContextIterator, MapWithCtx};
 use itertools::{Itertools, MapInto};
 use portgraph::{LinkView, PortIndex, PortView};
@@ -317,17 +318,16 @@ where
 /// A common trait for views of a hugr region.
 pub trait Region<'a, Base = Hugr>:
     HugrView
-    + ::petgraph::visit::GraphBase<NodeId = Node>
-    + ::petgraph::visit::GraphProp
-    + ::petgraph::visit::NodeCount
-    + ::petgraph::visit::NodeIndexable
-    + ::petgraph::visit::EdgeCount
-    + ::petgraph::visit::Visitable
-    + ::petgraph::visit::GetAdjacencyMatrix
-    + ::petgraph::visit::Visitable
+    + pv::GraphBase<NodeId = Node>
+    + pv::GraphProp
+    + pv::NodeCount
+    + pv::NodeIndexable
+    + pv::EdgeCount
+    + pv::Visitable
+    + pv::GetAdjacencyMatrix
+    + pv::Visitable
 where
-    for<'g> &'g Self:
-        ::petgraph::visit::IntoNeighborsDirected + ::petgraph::visit::IntoNodeIdentifiers,
+    for<'g> &'g Self: pv::IntoNeighborsDirected + pv::IntoNodeIdentifiers,
 {
     /// Create a region view of a HUGR given a root node.
     fn new(hugr: &'a Base, root: Node) -> Self;

--- a/src/hugr/region.rs
+++ b/src/hugr/region.rs
@@ -317,7 +317,7 @@ where
 }
 
 /// A common trait for views of a hugr region.
-pub trait Region<'a, Base = Hugr>:
+pub trait Region<'a>:
     HugrView
     + pv::GraphBase<NodeId = Node>
     + pv::GraphProp
@@ -330,14 +330,19 @@ pub trait Region<'a, Base = Hugr>:
 where
     for<'g> &'g Self: pv::IntoNeighborsDirected + pv::IntoNodeIdentifiers,
 {
+    /// The base from which the region is derived.
+    type Base;
+
     /// Create a region view of a HUGR given a root node.
-    fn new(hugr: &'a Base, root: Node) -> Self;
+    fn new(hugr: &'a Self::Base, root: Node) -> Self;
 }
 
-impl<'a, Base> Region<'a, Base> for FlatRegionView<'a, Base>
+impl<'a, Base> Region<'a> for FlatRegionView<'a, Base>
 where
     Base: HugrInternals + HugrView,
 {
+    type Base = Base;
+
     fn new(hugr: &'a Base, root: Node) -> Self {
         Self {
             root,
@@ -351,10 +356,12 @@ where
     }
 }
 
-impl<'a, Base> Region<'a, Base> for RegionView<'a, Base>
+impl<'a, Base> Region<'a> for RegionView<'a, Base>
 where
     Base: HugrInternals + HugrView,
 {
+    type Base = Base;
+
     fn new(hugr: &'a Base, root: Node) -> Self {
         Self {
             root,

--- a/src/hugr/region.rs
+++ b/src/hugr/region.rs
@@ -315,7 +315,7 @@ where
 }
 
 /// A common trait for views of a hugr region.
-pub trait Region<'a, Base>:
+pub trait Region<'a, Base = Hugr>:
     HugrView
     + ::petgraph::visit::GraphBase<NodeId = Node>
     + ::petgraph::visit::GraphProp

--- a/src/hugr/region.rs
+++ b/src/hugr/region.rs
@@ -2,7 +2,8 @@
 //!
 //! A region is a subgraph of a HUGR that includes a root node and some of its
 //! descendants. The root node is the only node in the region that has no parent
-//! in the region.
+//! in the region. Non-local edges between nodes inside and outside the region
+//! are ignored.
 //!
 //! [`FlatRegionView`] includes only the root node and its direct children,
 //! while [`RegionView`] includes all the descendants of the root.
@@ -38,14 +39,14 @@ where
     /// The chosen root node.
     root: Node,
 
-    /// The filtered graph encoding the adjacency structure of the HUGR.
+    /// The filtered portgraph encoding the adjacency structure of the HUGR.
     graph: FlatRegionGraph<'g, Base>,
 
     /// The rest of the HUGR.
     hugr: &'g Base,
 }
 
-impl<'g, Base: Clone> Clone for FlatRegionView<'g, Base>
+impl<'g, Base> Clone for FlatRegionView<'g, Base>
 where
     Base: HugrInternals + HugrView + Clone,
 {

--- a/src/hugr/region.rs
+++ b/src/hugr/region.rs
@@ -104,7 +104,7 @@ where
 
     #[inline]
     fn node_count(&self) -> usize {
-        self.hugr.base_hugr().hierarchy.child_count(self.root.index) + 1
+        self.base_hugr().hierarchy.child_count(self.root.index) + 1
     }
 
     #[inline]

--- a/src/hugr/region/petgraph.rs
+++ b/src/hugr/region/petgraph.rs
@@ -1,6 +1,7 @@
 //! Implementations of petgraph's traits for Hugr Region views.
 
 use super::{FlatRegionView, RegionView};
+use crate::hugr::view::sealed::HugrInternals;
 use crate::hugr::HugrView;
 use crate::ops::OpType;
 use crate::types::EdgeKind;
@@ -12,22 +13,34 @@ use portgraph::NodeIndex;
 
 macro_rules! impl_region_petgraph_traits {
     ($hugr:ident) => {
-        impl<'a> petgraph::visit::GraphBase for $hugr<'a> {
+        impl<'a, Base> petgraph::visit::GraphBase for $hugr<'a, Base>
+        where
+            Base: HugrInternals + HugrView,
+        {
             type NodeId = Node;
             type EdgeId = ((Node, Port), (Node, Port));
         }
 
-        impl<'a> petgraph::visit::GraphProp for $hugr<'a> {
+        impl<'a, Base> petgraph::visit::GraphProp for $hugr<'a, Base>
+        where
+            Base: HugrInternals + HugrView,
+        {
             type EdgeType = petgraph::Directed;
         }
 
-        impl<'a> petgraph::visit::NodeCount for $hugr<'a> {
+        impl<'a, Base> petgraph::visit::NodeCount for $hugr<'a, Base>
+        where
+            Base: HugrInternals + HugrView,
+        {
             fn node_count(&self) -> usize {
                 HugrView::node_count(self)
             }
         }
 
-        impl<'a> petgraph::visit::NodeIndexable for $hugr<'a> {
+        impl<'a, Base> petgraph::visit::NodeIndexable for $hugr<'a, Base>
+        where
+            Base: HugrInternals + HugrView,
+        {
             fn node_bound(&self) -> usize {
                 HugrView::node_count(self)
             }
@@ -41,32 +54,42 @@ macro_rules! impl_region_petgraph_traits {
             }
         }
 
-        impl<'a> petgraph::visit::EdgeCount for $hugr<'a> {
+        impl<'a, Base> petgraph::visit::EdgeCount for $hugr<'a, Base>
+        where
+            Base: HugrInternals + HugrView,
+        {
             fn edge_count(&self) -> usize {
                 HugrView::edge_count(self)
             }
         }
 
-        impl<'a> petgraph::visit::Data for $hugr<'a> {
+        impl<'a, Base> petgraph::visit::Data for $hugr<'a, Base>
+        where
+            Base: HugrInternals + HugrView,
+        {
             type NodeWeight = OpType;
             type EdgeWeight = EdgeKind;
         }
 
-        impl<'g, 'a> petgraph::visit::IntoNodeIdentifiers for &'g $hugr<'a> {
-            type NodeIdentifiers = <$hugr<'a> as HugrView>::Nodes<'g>;
+        impl<'g, 'a, Base> petgraph::visit::IntoNodeIdentifiers for &'g $hugr<'a, Base>
+        where
+            Base: HugrInternals + HugrView,
+        {
+            type NodeIdentifiers = <$hugr<'a, Base> as HugrView>::Nodes<'g>;
 
             fn node_identifiers(self) -> Self::NodeIdentifiers {
                 self.nodes()
             }
         }
 
-        impl<'g, 'a> petgraph::visit::IntoNodeReferences for &'g $hugr<'a>
+        impl<'g, 'a, Base> petgraph::visit::IntoNodeReferences for &'g $hugr<'a, Base>
         where
             'g: 'a,
+            Base: HugrInternals + HugrView,
         {
             type NodeRef = HugrNodeRef<'a>;
             type NodeReferences =
-                MapWithCtx<<$hugr<'a> as HugrView>::Nodes<'a>, Self, HugrNodeRef<'a>>;
+                MapWithCtx<<$hugr<'a, Base> as HugrView>::Nodes<'a>, Self, HugrNodeRef<'a>>;
 
             fn node_references(self) -> Self::NodeReferences {
                 self.nodes()
@@ -75,16 +98,22 @@ macro_rules! impl_region_petgraph_traits {
             }
         }
 
-        impl<'g, 'a> petgraph::visit::IntoNeighbors for &'g $hugr<'a> {
-            type Neighbors = <$hugr<'a> as HugrView>::Neighbours<'g>;
+        impl<'g, 'a, Base> petgraph::visit::IntoNeighbors for &'g $hugr<'a, Base>
+        where
+            Base: HugrInternals + HugrView,
+        {
+            type Neighbors = <$hugr<'a, Base> as HugrView>::Neighbours<'g>;
 
             fn neighbors(self, n: Self::NodeId) -> Self::Neighbors {
                 self.output_neighbours(n)
             }
         }
 
-        impl<'g, 'a> petgraph::visit::IntoNeighborsDirected for &'g $hugr<'a> {
-            type NeighborsDirected = <$hugr<'a> as HugrView>::Neighbours<'g>;
+        impl<'g, 'a, Base> petgraph::visit::IntoNeighborsDirected for &'g $hugr<'a, Base>
+        where
+            Base: HugrInternals + HugrView,
+        {
+            type NeighborsDirected = <$hugr<'a, Base> as HugrView>::Neighbours<'g>;
 
             fn neighbors_directed(
                 self,
@@ -95,7 +124,10 @@ macro_rules! impl_region_petgraph_traits {
             }
         }
 
-        impl<'a> petgraph::visit::Visitable for $hugr<'a> {
+        impl<'a, Base> petgraph::visit::Visitable for $hugr<'a, Base>
+        where
+            Base: HugrInternals + HugrView,
+        {
             type Map = std::collections::HashSet<Self::NodeId>;
 
             fn visit_map(&self) -> Self::Map {
@@ -107,7 +139,10 @@ macro_rules! impl_region_petgraph_traits {
             }
         }
 
-        impl<'a> petgraph::visit::GetAdjacencyMatrix for $hugr<'a> {
+        impl<'a, Base> petgraph::visit::GetAdjacencyMatrix for $hugr<'a, Base>
+        where
+            Base: HugrInternals + HugrView,
+        {
             type AdjMatrix = std::collections::HashSet<(Self::NodeId, Self::NodeId)>;
 
             fn adjacency_matrix(&self) -> Self::AdjMatrix {

--- a/src/hugr/region/petgraph.rs
+++ b/src/hugr/region/petgraph.rs
@@ -8,12 +8,12 @@ use crate::types::EdgeKind;
 use crate::{Node, Port};
 
 use context_iterators::{ContextIterator, IntoContextIterator, MapWithCtx};
-use petgraph::visit::NodeRef;
+use petgraph::visit as pv;
 use portgraph::NodeIndex;
 
 macro_rules! impl_region_petgraph_traits {
     ($hugr:ident) => {
-        impl<'a, Base> petgraph::visit::GraphBase for $hugr<'a, Base>
+        impl<'a, Base> pv::GraphBase for $hugr<'a, Base>
         where
             Base: HugrInternals + HugrView,
         {
@@ -21,14 +21,14 @@ macro_rules! impl_region_petgraph_traits {
             type EdgeId = ((Node, Port), (Node, Port));
         }
 
-        impl<'a, Base> petgraph::visit::GraphProp for $hugr<'a, Base>
+        impl<'a, Base> pv::GraphProp for $hugr<'a, Base>
         where
             Base: HugrInternals + HugrView,
         {
             type EdgeType = petgraph::Directed;
         }
 
-        impl<'a, Base> petgraph::visit::NodeCount for $hugr<'a, Base>
+        impl<'a, Base> pv::NodeCount for $hugr<'a, Base>
         where
             Base: HugrInternals + HugrView,
         {
@@ -37,7 +37,7 @@ macro_rules! impl_region_petgraph_traits {
             }
         }
 
-        impl<'a, Base> petgraph::visit::NodeIndexable for $hugr<'a, Base>
+        impl<'a, Base> pv::NodeIndexable for $hugr<'a, Base>
         where
             Base: HugrInternals + HugrView,
         {
@@ -54,7 +54,7 @@ macro_rules! impl_region_petgraph_traits {
             }
         }
 
-        impl<'a, Base> petgraph::visit::EdgeCount for $hugr<'a, Base>
+        impl<'a, Base> pv::EdgeCount for $hugr<'a, Base>
         where
             Base: HugrInternals + HugrView,
         {
@@ -63,7 +63,7 @@ macro_rules! impl_region_petgraph_traits {
             }
         }
 
-        impl<'a, Base> petgraph::visit::Data for $hugr<'a, Base>
+        impl<'a, Base> pv::Data for $hugr<'a, Base>
         where
             Base: HugrInternals + HugrView,
         {
@@ -71,7 +71,7 @@ macro_rules! impl_region_petgraph_traits {
             type EdgeWeight = EdgeKind;
         }
 
-        impl<'g, 'a, Base> petgraph::visit::IntoNodeIdentifiers for &'g $hugr<'a, Base>
+        impl<'g, 'a, Base> pv::IntoNodeIdentifiers for &'g $hugr<'a, Base>
         where
             Base: HugrInternals + HugrView,
         {
@@ -82,7 +82,7 @@ macro_rules! impl_region_petgraph_traits {
             }
         }
 
-        impl<'g, 'a, Base> petgraph::visit::IntoNodeReferences for &'g $hugr<'a, Base>
+        impl<'g, 'a, Base> pv::IntoNodeReferences for &'g $hugr<'a, Base>
         where
             'g: 'a,
             Base: HugrInternals + HugrView,
@@ -98,7 +98,7 @@ macro_rules! impl_region_petgraph_traits {
             }
         }
 
-        impl<'g, 'a, Base> petgraph::visit::IntoNeighbors for &'g $hugr<'a, Base>
+        impl<'g, 'a, Base> pv::IntoNeighbors for &'g $hugr<'a, Base>
         where
             Base: HugrInternals + HugrView,
         {
@@ -109,7 +109,7 @@ macro_rules! impl_region_petgraph_traits {
             }
         }
 
-        impl<'g, 'a, Base> petgraph::visit::IntoNeighborsDirected for &'g $hugr<'a, Base>
+        impl<'g, 'a, Base> pv::IntoNeighborsDirected for &'g $hugr<'a, Base>
         where
             Base: HugrInternals + HugrView,
         {
@@ -124,7 +124,7 @@ macro_rules! impl_region_petgraph_traits {
             }
         }
 
-        impl<'a, Base> petgraph::visit::Visitable for $hugr<'a, Base>
+        impl<'a, Base> pv::Visitable for $hugr<'a, Base>
         where
             Base: HugrInternals + HugrView,
         {
@@ -139,7 +139,7 @@ macro_rules! impl_region_petgraph_traits {
             }
         }
 
-        impl<'a, Base> petgraph::visit::GetAdjacencyMatrix for $hugr<'a, Base>
+        impl<'a, Base> pv::GetAdjacencyMatrix for $hugr<'a, Base>
         where
             Base: HugrInternals + HugrView,
         {
@@ -186,7 +186,7 @@ impl<'a> HugrNodeRef<'a> {
     }
 }
 
-impl NodeRef for HugrNodeRef<'_> {
+impl pv::NodeRef for HugrNodeRef<'_> {
     type NodeId = Node;
 
     type Weight = OpType;

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -18,7 +18,7 @@ use crate::types::ClassicType;
 use crate::types::{EdgeKind, SimpleType};
 use crate::{Direction, Hugr, Node, Port};
 
-use super::region::FlatRegionView;
+use super::region::{FlatRegionView, Region};
 use super::view::HugrView;
 
 /// Structure keeping track of pre-computed information used in the validation

--- a/src/hugr/view.rs
+++ b/src/hugr/view.rs
@@ -251,7 +251,10 @@ pub(crate) mod sealed {
         type Portgraph: LinkView;
 
         /// Returns a reference to the underlying portgraph.
-        fn as_portgraph(&self) -> &Self::Portgraph;
+        fn portgraph(&self) -> &Self::Portgraph;
+
+        /// Returns a the Hugr at the base of a chain of views.
+        fn base_hugr(&self) -> &Hugr;
     }
 
     impl<T> HugrInternals for T
@@ -260,8 +263,14 @@ pub(crate) mod sealed {
     {
         type Portgraph = MultiPortGraph;
 
-        fn as_portgraph(&self) -> &Self::Portgraph {
+        #[inline]
+        fn portgraph(&self) -> &Self::Portgraph {
             &self.as_ref().graph
+        }
+
+        #[inline]
+        fn base_hugr(&self) -> &Hugr {
+            self.as_ref()
         }
     }
 }

--- a/src/hugr/view.rs
+++ b/src/hugr/view.rs
@@ -253,7 +253,7 @@ pub(crate) mod sealed {
         /// Returns a reference to the underlying portgraph.
         fn portgraph(&self) -> &Self::Portgraph;
 
-        /// Returns a the Hugr at the base of a chain of views.
+        /// Returns the Hugr at the base of a chain of views.
         fn base_hugr(&self) -> &Hugr;
     }
 


### PR DESCRIPTION
Adds a `Base` parameter to the views, so we can make a view from any `HugrView`. Most of the noise comes from adding the generic constraints everywhere.

The more useful part of these changes is the new trait
```rust
pub trait Region<'a, Base>:
    HugrView
    + ::petgraph::visit::GraphBase<NodeId = Node>
    + ::petgraph::visit::GraphProp
    + ::petgraph::visit::NodeCount
    + ::petgraph::visit::NodeIndexable
    + ::petgraph::visit::EdgeCount
    + ::petgraph::visit::Visitable
    + ::petgraph::visit::GetAdjacencyMatrix
    + ::petgraph::visit::Visitable
where
    for<'g> &'g Self:
        ::petgraph::visit::IntoNeighborsDirected + ::petgraph::visit::IntoNodeIdentifiers,
```

that allows us to generalize over views where we can run petgraph's algorithms.