### PR TITLE
Cleanup ConstValue::predicate and some ConstTypeErrors

### DIFF
--- a/src/hugr/typecheck.rs
+++ b/src/hugr/typecheck.rs
@@ -166,7 +166,7 @@ mod test {
             typecheck_const(&ClassicType::Int(32), &ConstValue::i64(3)),
             Err(ConstTypeError::IntWidthMismatch(32, 64))
         );
-        typecheck_const(&ClassicType::F64, &ConstValue::F64(3.14)).unwrap();
+        typecheck_const(&ClassicType::F64, &ConstValue::F64(17.4)).unwrap();
         assert_eq!(
             typecheck_const(&ClassicType::F64, &ConstValue::i64(5)),
             Err(ConstTypeError::Failed(ClassicType::F64))

--- a/src/hugr/typecheck.rs
+++ b/src/hugr/typecheck.rs
@@ -19,7 +19,7 @@ use crate::ops::constant::{HugrIntValueStore, HugrIntWidthStore, HUGR_MAX_INT_WI
 pub enum ConstTypeError {
     /// This case hasn't been implemented. Possibly because we don't have value
     /// constructors to check against it
-    #[error("Const type checking unimplemented for {0}")]
+    #[error("Unimplemented: there are no constants of type {0}")]
     Unimplemented(ClassicType),
     /// The given type and term are incompatible
     #[error("Invalid const value for type {0}")]
@@ -100,7 +100,7 @@ pub fn typecheck_const(typ: &ClassicType, val: &ConstValue) -> Result<(), ConstT
                 Err(ConstTypeError::IntWidthMismatch(*exp_width, *width))
             }
         }
-        (ty @ ClassicType::F64, _) => Err(ConstTypeError::Unimplemented(ty.clone())),
+        (ClassicType::F64, ConstValue::F64(_)) => Ok(()),
         (ty @ ClassicType::Container(c), tm) => match (c, tm) {
             (Container::Tuple(row), ConstValue::Tuple(xs)) => {
                 if row.len() != xs.len() {
@@ -114,6 +114,7 @@ pub fn typecheck_const(typ: &ClassicType, val: &ConstValue) -> Result<(), ConstT
                 }
                 Ok(())
             }
+            (Container::Tuple(_), _) => Err(ConstTypeError::Failed(ty.clone())),
             (Container::Sum(row), ConstValue::Sum { tag, variants, val }) => {
                 if tag > &row.len() {
                     return Err(ConstTypeError::InvalidSumTag);
@@ -130,6 +131,7 @@ pub fn typecheck_const(typ: &ClassicType, val: &ConstValue) -> Result<(), ConstT
                     _ => Err(ConstTypeError::LinearTypeDisallowed),
                 }
             }
+            (Container::Sum(_), _) => Err(ConstTypeError::Failed(ty.clone())),
             _ => Err(ConstTypeError::Unimplemented(ty.clone())),
         },
         (ty @ ClassicType::Graph(_), _) => Err(ConstTypeError::Unimplemented(ty.clone())),

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -169,21 +169,23 @@ impl ConstValue {
 
     /// Constant Sum over units, used as predicates.
     pub fn simple_predicate(tag: usize, size: usize) -> Self {
-        Self::predicate(tag, std::iter::repeat(type_row![]).take(size))
+        Self::predicate(tag, Self::unit(), std::iter::repeat(type_row![]).take(size))
     }
 
     /// Constant Sum over Tuples, used as predicates.
-    pub fn predicate(tag: usize, variant_rows: impl IntoIterator<Item = TypeRow>) -> Self {
+    pub fn predicate(
+        tag: usize,
+        val: ConstValue,
+        variant_rows: impl IntoIterator<Item = TypeRow>,
+    ) -> Self {
+        let variants = TypeRow::predicate_variants_row(variant_rows);
+        let const_type = SimpleType::Classic(val.const_type());
+        assert!(Some(&const_type) == variants.get(tag));
         ConstValue::Sum {
             tag,
-            variants: TypeRow::predicate_variants_row(variant_rows),
-            val: Box::new(Self::unit()),
+            variants,
+            val: Box::new(val),
         }
-    }
-
-    /// Constant Sum over Tuples with just one variant
-    pub fn unary_predicate(row: impl Into<TypeRow>) -> Self {
-        Self::predicate(0, [row.into()])
     }
 
     /// Constant Sum over Tuples with just one variant of unit type

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -241,6 +241,7 @@ mod test {
     use super::ConstValue;
     use crate::{
         builder::{BuildError, Container, DFGBuilder, Dataflow, DataflowHugr},
+        hugr::{typecheck::ConstTypeError, ValidationError},
         type_row,
         types::{ClassicType, SimpleType, TypeRow},
     };
@@ -299,7 +300,11 @@ mod test {
             ))
             .unwrap();
         let w = b.load_const(&c).unwrap();
-        // When #231 is fixed, there should be a validation error here instead
-        b.finish_hugr_with_outputs([w]).unwrap_err();
+        assert_eq!(
+            b.finish_hugr_with_outputs([w]),
+            Err(BuildError::InvalidHUGR(ValidationError::ConstTypeError(
+                ConstTypeError::TupleWrongLength
+            )))
+        );
     }
 }

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -259,17 +259,17 @@ mod test {
         let mut b = DFGBuilder::new(type_row![], TypeRow::from(vec![pred_ty.clone()]))?;
         let c = b.add_constant(ConstValue::predicate(
             0,
-            ConstValue::Tuple(vec![ConstValue::i64(3), ConstValue::F64(3.14)]),
+            ConstValue::Tuple(vec![ConstValue::i64(3), ConstValue::F64(3.15)]),
             pred_rows.clone(),
         ))?;
         let w = b.load_const(&c)?;
         b.finish_hugr_with_outputs([w]).unwrap();
 
-        let mut b = DFGBuilder::new(type_row![], TypeRow::from(vec![pred_ty.clone()]))?;
+        let mut b = DFGBuilder::new(type_row![], TypeRow::from(vec![pred_ty]))?;
         let c = b.add_constant(ConstValue::predicate(
             1,
             ConstValue::Tuple(vec![]),
-            pred_rows.clone(),
+            pred_rows,
         ))?;
         let w = b.load_const(&c)?;
         b.finish_hugr_with_outputs([w]).unwrap();

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -180,6 +180,10 @@ impl ConstValue {
     ) -> Self {
         let variants = TypeRow::predicate_variants_row(variant_rows);
         let const_type = SimpleType::Classic(val.const_type());
+        // TODO This assert is not appropriate for a public API and if the specified `val`
+        // is not of tuple type matching the `tag`th element of `variant_rows` then
+        // really the Hugr will fail in validate. However it doesn't at the moment
+        // (https://github.com/CQCL-DEV/hugr/issues/231).
         assert!(Some(&const_type) == variants.get(tag));
         ConstValue::Sum {
             tag,

--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -256,9 +256,7 @@ impl SimpleType {
 
     /// New unit type, defined as an empty Tuple.
     pub fn new_unit() -> Self {
-        Self::Classic(ClassicType::Container(Container::Tuple(Box::new(
-            TypeRow::new(),
-        ))))
+        Self::new_tuple(vec![])
     }
 
     /// New Sum of Tuple types, used as predicates in branching.

--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -254,11 +254,6 @@ impl SimpleType {
         }
     }
 
-    /// New unit type, defined as an empty Tuple.
-    pub fn new_unit() -> Self {
-        Self::new_tuple(vec![])
-    }
-
     /// New Sum of Tuple types, used as predicates in branching.
     /// Tuple rows are defined in order by input rows.
     pub fn new_predicate(variant_rows: impl IntoIterator<Item = TypeRow>) -> Self {


### PR DESCRIPTION
* Wrong signature
* Add assert that the value is of the type we'll claim. Such errors should be caught by `Hugr::validate()` but are not, so this is a temporary measure/sanity check, mostly while I'm playing around with types, but until #231 is fixed
   * Improve `typecheck_const` errors, and test some of the cases
   * Also add a test of a "bad" constant, but this is `should_panic` for now (i.e. the assert fails)
* Also remove `SimpleType::new_unit`. If it was going to be used anywhere, `ConstValue::simple_predicate` seems the most likely place, and...it isn't. (But, if we want to keep it, I can revert the last commit but let's go for the form in 76b47232dc4cfd47ec8c9b5b2872dcec14e65c83)

Links from code to issues may not be the right way, depending on how much we are thinking about the code being forked perhaps. I will add links from the issue to the code but of course tracking these over time may not be so clear.