### PR TITLE
Add a blanket implementation for CustomSigFn

### DIFF
--- a/src/extensions/rotation.rs
+++ b/src/extensions/rotation.rs
@@ -12,8 +12,9 @@ use std::collections::HashMap;
 use pyo3::prelude::*;
 
 use crate::ops::constant::CustomConst;
-use crate::resource::{CustomSignatureFunc, OpDef, ResourceSet, SignatureError, TypeDef};
-use crate::types::{type_param::TypeArg, ClassicType, CustomType, SimpleType, TypeRow};
+use crate::resource::{OpDef, ResourceSet, TypeDef};
+use crate::types::type_param::TypeArg;
+use crate::types::{ClassicType, CustomType, SimpleType, TypeRow};
 use crate::Resource;
 
 pub const fn resource_id() -> SmolStr {
@@ -27,15 +28,18 @@ pub fn resource() -> Resource {
     resource.add_type(Type::Angle.type_def());
     resource.add_type(Type::Quaternion.type_def());
 
-    resource
-        .add_op(OpDef::new_with_custom_sig(
-            "AngleAdd".into(),
-            "".into(),
-            vec![],
-            HashMap::default(),
-            AngleAdd,
-        ))
-        .unwrap();
+    let op = OpDef::new_with_custom_sig(
+        "AngleAdd".into(),
+        "".into(),
+        vec![],
+        HashMap::default(),
+        |_arg_values: &[TypeArg]| {
+            let t: TypeRow = vec![SimpleType::Classic(Type::Angle.custom_type().into())].into();
+            Ok((t.clone(), t, ResourceSet::default()))
+        },
+    );
+
+    resource.add_op(op).unwrap();
     resource
 }
 
@@ -95,24 +99,6 @@ impl CustomConst for Constant {
             Constant::Quaternion(_) => Type::Quaternion,
         };
         t.custom_type().into()
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct AngleAdd;
-
-/// When we have a YAML type-scheme interpreter, we'll be able to use that;
-/// there is no need for a binary compute_signature for a case this simple.
-impl CustomSignatureFunc for AngleAdd {
-    fn compute_signature(
-        &self,
-        _args_values: &[TypeArg],
-    ) -> Result<(TypeRow, TypeRow, ResourceSet), SignatureError> {
-        let t: TypeRow = vec![SimpleType::Classic(
-            Into::<CustomType>::into(Type::Angle).into(),
-        )]
-        .into();
-        Ok((t.clone(), t, ResourceSet::default()))
     }
 }
 

--- a/src/extensions/rotation.rs
+++ b/src/extensions/rotation.rs
@@ -106,9 +106,7 @@ pub struct AngleAdd;
 impl CustomSignatureFunc for AngleAdd {
     fn compute_signature(
         &self,
-        _name: &SmolStr,
-        _arg_values: &[TypeArg],
-        _misc: &HashMap<String, serde_yaml::Value>,
+        _args_values: &[TypeArg],
     ) -> Result<(TypeRow, TypeRow, ResourceSet), SignatureError> {
         let t: TypeRow = vec![SimpleType::Classic(
             Into::<CustomType>::into(Type::Angle).into(),

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -26,7 +26,9 @@ pub trait CustomSignatureFunc: Send + Sync {
     /// and 'misc' data from the resource definition YAML
     fn compute_signature(
         &self,
+        name: &SmolStr,
         arg_values: &[TypeArg],
+        misc: &HashMap<String, serde_yaml::Value>,
     ) -> Result<(TypeRow, TypeRow, ResourceSet), SignatureError>;
 
     /// Describe the signature of a node, given the operation name,
@@ -48,7 +50,9 @@ where
 {
     fn compute_signature(
         &self,
+        _name: &SmolStr,
         arg_values: &[TypeArg],
+        _misc: &HashMap<String, serde_yaml::Value>,
     ) -> Result<(TypeRow, TypeRow, ResourceSet), SignatureError> {
         self(arg_values)
     }
@@ -229,7 +233,7 @@ impl OpDef {
                 // Sig should be computed solely from inputs + outputs + args.
                 todo!()
             }
-            SignatureFunc::CustomFunc(bf) => bf.compute_signature(args)?,
+            SignatureFunc::CustomFunc(bf) => bf.compute_signature(&self.name, args, &self.misc)?,
         };
         assert!(res.contains(&self.resource));
         let mut sig = Signature::new_df(ins, outs);


### PR DESCRIPTION
- Adds a blanket `CustomSignatureFunction` implementation for closures, for we don't want to add a description.
- Drops the `name` and `misc` parameters, since they can be taken directly when creating the function along with the OpDef.

So we can just do:

```rust
let name = "MyOp".into();
let description = "".into();
let args = vec![];
let mut misc = HashMap::new();

let sig: Signature = todo!(); // Some complex computation
let signature = move |_args: &[TypeArg]| {
    Ok((sig.input.clone(), sig.output.clone(), ResourceSet::new()))
};

OpDef::new_with_custom_sig(name, description, args, misc, signature)
```