### PR TITLE
Add HashableType as subset of ClassicType

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ serde = { version = "1.0", features = [
     "derive", "rc",
 ] }
 serde_yaml = "0.9.19"
+serde_repr = "0.1"
 typetag = "0.2.7"
 smol_str = { version = "0.2.0", features = ["serde"] }
 derive_more = "0.99.17"

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -614,7 +614,7 @@ fn wire_up<T: Dataflow + ?Sized>(
     if let EdgeKind::Value(typ) = base.get_optype(src).port_kind(src_offset).unwrap() {
         if !local_source {
             // Non-local value sources require a state edge to an ancestor of dst
-            if !typ.class().is_classical() {
+            if !typ.tag().is_classical() {
                 let val_err: ValidationError = InterGraphEdgeError::NonClassicalData {
                     from: src,
                     from_offset: Port::new_outgoing(src_port),
@@ -646,8 +646,7 @@ fn wire_up<T: Dataflow + ?Sized>(
             // TODO: Avoid adding duplicate edges
             // This should be easy with https://github.com/CQCL-DEV/hugr/issues/130
             base.add_other_edge(src, src_sibling)?;
-        } else if !typ.class().is_classical() && base.linked_ports(src, src_offset).next().is_some()
-        {
+        } else if !typ.tag().is_classical() && base.linked_ports(src, src_offset).next().is_some() {
             // Don't copy linear edges.
             return Err(BuildError::NoCopyLinear(typ));
         }

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -16,7 +16,7 @@ use crate::{
     types::EdgeKind,
 };
 
-use crate::types::{ClassicRow, ClassicType, Signature, SimpleRow, SimpleType};
+use crate::types::{ClassicRow, ClassicType, PrimType, Signature, SimpleRow, SimpleType};
 
 use itertools::Itertools;
 
@@ -614,7 +614,7 @@ fn wire_up<T: Dataflow + ?Sized>(
     if let EdgeKind::Value(typ) = base.get_optype(src).port_kind(src_offset).unwrap() {
         if !local_source {
             // Non-local value sources require a state edge to an ancestor of dst
-            if !typ.is_classical() {
+            if !typ.class().is_classical() {
                 let val_err: ValidationError = InterGraphEdgeError::NonClassicalData {
                     from: src,
                     from_offset: Port::new_outgoing(src_port),
@@ -646,7 +646,8 @@ fn wire_up<T: Dataflow + ?Sized>(
             // TODO: Avoid adding duplicate edges
             // This should be easy with https://github.com/CQCL-DEV/hugr/issues/130
             base.add_other_edge(src, src_sibling)?;
-        } else if !typ.is_classical() && base.linked_ports(src, src_offset).next().is_some() {
+        } else if !typ.class().is_classical() && base.linked_ports(src, src_offset).next().is_some()
+        {
             // Don't copy linear edges.
             return Err(BuildError::NoCopyLinear(typ));
         }

--- a/src/builder/module.rs
+++ b/src/builder/module.rs
@@ -196,7 +196,8 @@ mod test {
         let build_result = {
             let mut module_builder = ModuleBuilder::new();
 
-            let qubit_state_type = module_builder.add_alias_declare("qubit_state", TypeTag::Any)?;
+            let qubit_state_type =
+                module_builder.add_alias_declare("qubit_state", TypeTag::Simple)?;
 
             let f_build = module_builder.define_function(
                 "main",

--- a/src/builder/module.rs
+++ b/src/builder/module.rs
@@ -7,7 +7,7 @@ use super::{
 use crate::{
     hugr::{view::HugrView, ValidationError},
     ops,
-    types::{simple::TypeClass, PrimType, SimpleType},
+    types::{simple::TypeTag, PrimType, SimpleType},
 };
 
 use crate::ops::handle::{AliasID, FuncID, NodeHandle};
@@ -132,13 +132,13 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
         // Could be fixed by removing single-entry requirement and sorting from
         // every 0-input node.
         let name: SmolStr = name.into();
-        let class = typ.class();
+        let tag = typ.tag();
         let node = self.add_child_op(ops::AliasDefn {
             name: name.clone(),
             definition: typ,
         })?;
 
-        Ok(AliasID::new(node, name, class))
+        Ok(AliasID::new(node, name, tag))
     }
 
     /// Add a [`OpType::AliasDecl`] node and return a handle to the Alias.
@@ -148,15 +148,15 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
     pub fn add_alias_declare(
         &mut self,
         name: impl Into<SmolStr>,
-        class: TypeClass,
+        tag: TypeTag,
     ) -> Result<AliasID<false>, BuildError> {
         let name: SmolStr = name.into();
         let node = self.add_child_op(ops::AliasDecl {
             name: name.clone(),
-            class,
+            tag,
         })?;
 
-        Ok(AliasID::new(node, name, class))
+        Ok(AliasID::new(node, name, tag))
     }
 }
 
@@ -196,8 +196,7 @@ mod test {
         let build_result = {
             let mut module_builder = ModuleBuilder::new();
 
-            let qubit_state_type =
-                module_builder.add_alias_declare("qubit_state", TypeClass::Any)?;
+            let qubit_state_type = module_builder.add_alias_declare("qubit_state", TypeTag::Any)?;
 
             let f_build = module_builder.define_function(
                 "main",

--- a/src/builder/module.rs
+++ b/src/builder/module.rs
@@ -7,7 +7,7 @@ use super::{
 use crate::{
     hugr::{view::HugrView, ValidationError},
     ops,
-    types::SimpleType,
+    types::{simple::TypeClass, PrimType, SimpleType},
 };
 
 use crate::ops::handle::{AliasID, FuncID, NodeHandle};
@@ -132,13 +132,13 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
         // Could be fixed by removing single-entry requirement and sorting from
         // every 0-input node.
         let name: SmolStr = name.into();
-        let classical = typ.is_classical();
+        let class = typ.class();
         let node = self.add_child_op(ops::AliasDefn {
             name: name.clone(),
             definition: typ,
         })?;
 
-        Ok(AliasID::new(node, name, classical))
+        Ok(AliasID::new(node, name, class))
     }
 
     /// Add a [`OpType::AliasDecl`] node and return a handle to the Alias.
@@ -148,15 +148,15 @@ impl<T: AsMut<Hugr> + AsRef<Hugr>> ModuleBuilder<T> {
     pub fn add_alias_declare(
         &mut self,
         name: impl Into<SmolStr>,
-        classical: bool,
+        class: TypeClass,
     ) -> Result<AliasID<false>, BuildError> {
         let name: SmolStr = name.into();
         let node = self.add_child_op(ops::AliasDecl {
             name: name.clone(),
-            classical,
+            class,
         })?;
 
-        Ok(AliasID::new(node, name, classical))
+        Ok(AliasID::new(node, name, class))
     }
 }
 
@@ -196,7 +196,8 @@ mod test {
         let build_result = {
             let mut module_builder = ModuleBuilder::new();
 
-            let qubit_state_type = module_builder.add_alias_declare("qubit_state", false)?;
+            let qubit_state_type =
+                module_builder.add_alias_declare("qubit_state", TypeClass::Any)?;
 
             let f_build = module_builder.define_function(
                 "main",

--- a/src/hugr/typecheck.rs
+++ b/src/hugr/typecheck.rs
@@ -125,19 +125,14 @@ pub fn typecheck_const(typ: &ClassicType, val: &ConstValue) -> Result<(), ConstT
             (Container::Sum(_), _) => Err(ConstTypeError::Failed(ty.clone())),
             _ => Err(ConstTypeError::Unimplemented(ty.clone())),
         },
-        (ty @ ClassicType::Hashable(HashableType::Container(c)), tm) => match c {
+        (ClassicType::Hashable(HashableType::Container(c)), tm) => {
             // Here we deliberately build malformed Container-of-Hashable types
             // (rather than Hashable-of-Container) in order to reuse logic above
-            Container::Tuple(row) => typecheck_const(
-                &ClassicType::Container(Container::Tuple(Box::new(row.clone().map_into()))),
+            typecheck_const(
+                &ClassicType::Container(c.clone().map_vals(&ClassicType::Hashable)),
                 tm,
-            ),
-            Container::Sum(row) => typecheck_const(
-                &ClassicType::Container(Container::Sum(Box::new(row.clone().map_into()))),
-                tm,
-            ),
-            _ => Err(ConstTypeError::Unimplemented(ty.clone())),
-        },
+            )
+        }
         (ty @ ClassicType::Graph(_), _) => Err(ConstTypeError::Unimplemented(ty.clone())),
         (ty @ ClassicType::Hashable(HashableType::String), _) => {
             Err(ConstTypeError::Unimplemented(ty.clone()))

--- a/src/hugr/typecheck.rs
+++ b/src/hugr/typecheck.rs
@@ -168,10 +168,7 @@ mod test {
             typecheck_const(&ClassicType::F64, &ConstValue::i64(5)),
             Err(ConstTypeError::Failed(ClassicType::F64))
         );
-        let tuple_ty = ClassicType::Container(Container::Tuple(Box::new(classic_row![
-            INT,
-            ClassicType::F64,
-        ])));
+        let tuple_ty = ClassicType::new_tuple(classic_row![INT, ClassicType::F64,]);
         typecheck_const(
             &tuple_ty,
             &ConstValue::Tuple(vec![ConstValue::i64(7), ConstValue::F64(5.1)]),

--- a/src/hugr/typecheck.rs
+++ b/src/hugr/typecheck.rs
@@ -9,8 +9,7 @@ use crate::hugr::*;
 
 // For static typechecking
 use crate::ops::ConstValue;
-use crate::types::simple::{ClassicRow, HashableType};
-use crate::types::{ClassicType, Container};
+use crate::types::{ClassicRow, ClassicType, Container, HashableType};
 
 use crate::ops::constant::{HugrIntValueStore, HugrIntWidthStore, HUGR_MAX_INT_WIDTH};
 

--- a/src/hugr/typecheck.rs
+++ b/src/hugr/typecheck.rs
@@ -125,6 +125,19 @@ pub fn typecheck_const(typ: &ClassicType, val: &ConstValue) -> Result<(), ConstT
             (Container::Sum(_), _) => Err(ConstTypeError::Failed(ty.clone())),
             _ => Err(ConstTypeError::Unimplemented(ty.clone())),
         },
+        (ty @ ClassicType::Hashable(HashableType::Container(c)), tm) => match c {
+            // Here we deliberately build malformed Container-of-Hashable types
+            // (rather than Hashable-of-Container) in order to reuse logic above
+            Container::Tuple(row) => typecheck_const(
+                &ClassicType::Container(Container::Tuple(Box::new(row.clone().map_into()))),
+                tm,
+            ),
+            Container::Sum(row) => typecheck_const(
+                &ClassicType::Container(Container::Sum(Box::new(row.clone().map_into()))),
+                tm,
+            ),
+            _ => Err(ConstTypeError::Unimplemented(ty.clone())),
+        },
         (ty @ ClassicType::Graph(_), _) => Err(ConstTypeError::Unimplemented(ty.clone())),
         (ty @ ClassicType::Hashable(HashableType::String), _) => {
             Err(ConstTypeError::Unimplemented(ty.clone()))

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -1141,7 +1141,7 @@ mod test {
         let lcst = h.add_op_with_parent(
             h.root(),
             ops::LoadConstant {
-                datatype: ClassicType::Int(1),
+                datatype: ClassicType::int::<1>(),
             },
         )?;
         h.connect(cst, 0, lcst, 0)?;

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -5,7 +5,7 @@ use std::any::Any;
 use crate::{
     classic_row,
     macros::impl_box_clone,
-    types::{simple::HashableType, ClassicRow, ClassicType, Container, CustomType, EdgeKind},
+    types::{simple::HashableType, ClassicRow, ClassicType, CustomType, EdgeKind},
 };
 
 use downcast_rs::{impl_downcast, Downcast};
@@ -121,12 +121,10 @@ impl ConstValue {
         match self {
             Self::Int { value: _, width } => HashableType::Int(*width).into(),
             Self::Opaque(_, b) => ClassicType::Opaque((*b).custom_type()),
-            Self::Sum { variants, .. } => {
-                ClassicType::Container(Container::Sum(Box::new(variants.clone())))
-            }
+            Self::Sum { variants, .. } => ClassicType::new_sum(variants.clone()),
             Self::Tuple(vals) => {
                 let row: Vec<_> = vals.iter().map(|val| val.const_type()).collect();
-                ClassicType::Container(Container::Tuple(Box::new(row.into())))
+                ClassicType::new_tuple(row)
             }
             Self::F64(_) => ClassicType::F64,
         }

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -5,7 +5,7 @@ use std::any::Any;
 use crate::{
     classic_row,
     macros::impl_box_clone,
-    types::{ClassicRow, ClassicType, Container, CustomType, EdgeKind},
+    types::{simple::HashableType, ClassicRow, ClassicType, Container, CustomType, EdgeKind},
 };
 
 use downcast_rs::{impl_downcast, Downcast};
@@ -119,7 +119,7 @@ impl ConstValue {
     /// Returns the datatype of the constant.
     pub fn const_type(&self) -> ClassicType {
         match self {
-            Self::Int { value: _, width } => ClassicType::Int(*width),
+            Self::Int { value: _, width } => HashableType::Int(*width).into(),
             Self::Opaque(_, b) => ClassicType::Opaque((*b).custom_type()),
             Self::Sum { variants, .. } => {
                 ClassicType::Container(Container::Sum(Box::new(variants.clone())))

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -5,7 +5,7 @@ use std::any::Any;
 use crate::{
     classic_row,
     macros::impl_box_clone,
-    types::{simple::HashableType, ClassicRow, ClassicType, CustomType, EdgeKind},
+    types::{ClassicRow, ClassicType, CustomType, EdgeKind, HashableType},
 };
 
 use downcast_rs::{impl_downcast, Downcast};

--- a/src/ops/handle.rs
+++ b/src/ops/handle.rs
@@ -1,7 +1,6 @@
 //! Handles to nodes in HUGR.
 //!
-use crate::types::simple::{HashableType, TypeTag};
-use crate::types::{ClassicType, Container, SimpleType};
+use crate::types::{ClassicType, Container, HashableType, SimpleType, TypeTag};
 use crate::Node;
 
 use derive_more::From as DerFrom;

--- a/src/ops/handle.rs
+++ b/src/ops/handle.rs
@@ -89,7 +89,7 @@ impl<const DEF: bool> AliasID<DEF> {
         match self.tag {
             TypeTag::Hashable => Container::<HashableType>::Alias(self.name.clone()).into(),
             TypeTag::Classic => Container::<ClassicType>::Alias(self.name.clone()).into(),
-            TypeTag::Any => Container::<SimpleType>::Alias(self.name.clone()).into(),
+            TypeTag::Simple => Container::<SimpleType>::Alias(self.name.clone()).into(),
         }
     }
     /// Retrieve the underlying core type

--- a/src/ops/handle.rs
+++ b/src/ops/handle.rs
@@ -1,5 +1,6 @@
 //! Handles to nodes in HUGR.
 //!
+use crate::types::simple::{HashableType, TypeClass};
 use crate::types::{ClassicType, Container, SimpleType};
 use crate::Node;
 
@@ -74,25 +75,21 @@ pub struct FuncID<const DEF: bool>(Node);
 pub struct AliasID<const DEF: bool> {
     node: Node,
     name: SmolStr,
-    classical: bool,
+    class: TypeClass,
 }
 
 impl<const DEF: bool> AliasID<DEF> {
     /// Construct new AliasID
-    pub fn new(node: Node, name: SmolStr, classical: bool) -> Self {
-        Self {
-            node,
-            name,
-            classical,
-        }
+    pub fn new(node: Node, name: SmolStr, class: TypeClass) -> Self {
+        Self { node, name, class }
     }
 
     /// Construct new AliasID
     pub fn get_alias_type(&self) -> SimpleType {
-        if self.classical {
-            Container::<ClassicType>::Alias(self.name.clone()).into()
-        } else {
-            Container::<SimpleType>::Alias(self.name.clone()).into()
+        match self.class {
+            TypeClass::Hashable => Container::<HashableType>::Alias(self.name.clone()).into(),
+            TypeClass::Classic => Container::<ClassicType>::Alias(self.name.clone()).into(),
+            TypeClass::Any => Container::<SimpleType>::Alias(self.name.clone()).into(),
         }
     }
     /// Retrieve the underlying core type

--- a/src/ops/handle.rs
+++ b/src/ops/handle.rs
@@ -1,6 +1,6 @@
 //! Handles to nodes in HUGR.
 //!
-use crate::types::simple::{HashableType, TypeClass};
+use crate::types::simple::{HashableType, TypeTag};
 use crate::types::{ClassicType, Container, SimpleType};
 use crate::Node;
 
@@ -75,21 +75,21 @@ pub struct FuncID<const DEF: bool>(Node);
 pub struct AliasID<const DEF: bool> {
     node: Node,
     name: SmolStr,
-    class: TypeClass,
+    tag: TypeTag,
 }
 
 impl<const DEF: bool> AliasID<DEF> {
     /// Construct new AliasID
-    pub fn new(node: Node, name: SmolStr, class: TypeClass) -> Self {
-        Self { node, name, class }
+    pub fn new(node: Node, name: SmolStr, tag: TypeTag) -> Self {
+        Self { node, name, tag }
     }
 
     /// Construct new AliasID
     pub fn get_alias_type(&self) -> SimpleType {
-        match self.class {
-            TypeClass::Hashable => Container::<HashableType>::Alias(self.name.clone()).into(),
-            TypeClass::Classic => Container::<ClassicType>::Alias(self.name.clone()).into(),
-            TypeClass::Any => Container::<SimpleType>::Alias(self.name.clone()).into(),
+        match self.tag {
+            TypeTag::Hashable => Container::<HashableType>::Alias(self.name.clone()).into(),
+            TypeTag::Classic => Container::<ClassicType>::Alias(self.name.clone()).into(),
+            TypeTag::Any => Container::<SimpleType>::Alias(self.name.clone()).into(),
         }
     }
     /// Retrieve the underlying core type

--- a/src/ops/leaf.rs
+++ b/src/ops/leaf.rs
@@ -215,10 +215,3 @@ impl OpTrait for LeafOp {
         Some(EdgeKind::StateOrder)
     }
 }
-
-impl LeafOp {
-    /// Returns true if the operation has only classical inputs and outputs.
-    pub fn is_pure_classical(&self) -> bool {
-        self.signature().purely_classical()
-    }
-}

--- a/src/ops/module.rs
+++ b/src/ops/module.rs
@@ -2,6 +2,7 @@
 
 use smol_str::SmolStr;
 
+use crate::types::simple::TypeClass;
 use crate::types::{ClassicType, EdgeKind, Signature, SimpleType};
 
 use super::StaticTag;
@@ -115,7 +116,7 @@ pub struct AliasDecl {
     /// Alias name
     pub name: SmolStr,
     /// Flag to signify type is classical
-    pub classical: bool,
+    pub class: TypeClass,
 }
 
 impl_op_name!(AliasDecl);

--- a/src/ops/module.rs
+++ b/src/ops/module.rs
@@ -2,7 +2,7 @@
 
 use smol_str::SmolStr;
 
-use crate::types::simple::TypeClass;
+use crate::types::simple::TypeTag;
 use crate::types::{ClassicType, EdgeKind, Signature, SimpleType};
 
 use super::StaticTag;
@@ -116,7 +116,7 @@ pub struct AliasDecl {
     /// Alias name
     pub name: SmolStr,
     /// Flag to signify type is classical
-    pub class: TypeClass,
+    pub tag: TypeTag,
 }
 
 impl_op_name!(AliasDecl);

--- a/src/types.rs
+++ b/src/types.rs
@@ -68,13 +68,8 @@ impl Signature {
     pub fn is_empty(&self) -> bool {
         self.static_input.is_empty() && self.input.is_empty() && self.output.is_empty()
     }
-
-    /// Returns whether the data wires in the signature are purely classical.
-    #[inline(always)]
-    pub fn purely_classical(&self) -> bool {
-        self.input.purely_classical() && self.output.purely_classical()
-    }
 }
+
 impl Signature {
     /// Returns the type of a [`Port`]. Returns `None` if the port is out of bounds.
     pub fn get(&self, port: Port) -> Option<EdgeKind> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -38,7 +38,7 @@ impl EdgeKind {
     /// Returns whether the type might contain linear data.
     pub fn is_linear(&self) -> bool {
         match self {
-            EdgeKind::Value(t) => !t.class().is_classical(),
+            EdgeKind::Value(t) => !t.tag().is_classical(),
             _ => false,
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -38,7 +38,7 @@ impl EdgeKind {
     /// Returns whether the type might contain linear data.
     pub fn is_linear(&self) -> bool {
         match self {
-            EdgeKind::Value(t) => !t.is_classical(),
+            EdgeKind::Value(t) => !t.class().is_classical(),
             _ => false,
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,7 +11,10 @@ use std::ops::Index;
 use pyo3::prelude::*;
 
 pub use custom::CustomType;
-pub use simple::{ClassicRow, ClassicType, Container, PrimType, SimpleRow, SimpleType, TypeRow};
+pub use simple::{
+    ClassicRow, ClassicType, Container, HashableType, PrimType, SimpleRow, SimpleType, TypeRow,
+    TypeTag,
+};
 
 use smol_str::SmolStr;
 

--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -541,7 +541,7 @@ impl<T: PrimType> TypeRow<T> {
     }
 
     /// Returns the smallest [TypeTag] that contains all elements of the row
-    pub fn common_class(&self) -> TypeTag {
+    pub fn containing_tag(&self) -> TypeTag {
         self.types
             .iter()
             .map(PrimType::tag)

--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -171,12 +171,6 @@ impl ClassicType {
     }
 }
 
-impl Default for ClassicType {
-    fn default() -> Self {
-        Self::int::<1>()
-    }
-}
-
 impl Display for ClassicType {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {

--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -495,7 +495,6 @@ impl TypeRow<SimpleType> {
 impl TypeRow<ClassicType> {
     /// Return the type row of variants required to define a Sum of Tuples type
     /// given the rows of each tuple
-    #[inline]
     pub fn predicate_variants_row(variant_rows: impl IntoIterator<Item = ClassicRow>) -> Self {
         variant_rows
             .into_iter()

--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -54,10 +54,10 @@ impl Display for SimpleType {
 )]
 #[repr(u8)]
 pub enum TypeTag {
-    /// Any value, including linear and quantum values;
-    /// cannot necessarily be copied or discarded. See [SimpleType]
-    Any = 0,
-    /// Subset of [TypeTag::Any]; types that can be copied and discarded. See [ClassicType]
+    /// Any [SimpleType], including linear and quantum types;
+    /// cannot necessarily be copied or discarded.
+    Simple = 0,
+    /// Subset of [TypeTag::Simple]; types that can be copied and discarded. See [ClassicType]
     Classic = 1,
     /// Subset of [TypeTag::Classic]: types that can also be hashed and support
     /// a strong notion of equality. See [HashableType]
@@ -68,8 +68,8 @@ impl TypeTag {
     /// Returns the smallest TypeTag containing both the receiver and argument.
     /// (This will be one of the receiver or the argument.)
     fn union(self, other: Self) -> Self {
-        if self == Self::Any || other == Self::Any {
-            Self::Any
+        if self == Self::Simple || other == Self::Simple {
+            Self::Simple
         } else if self == Self::Classic || other == Self::Classic {
             Self::Classic
         } else {
@@ -80,7 +80,7 @@ impl TypeTag {
     /// Do types in this tag contain only classic data
     /// (which can be copied and discarded, i.e. [ClassicType]s)
     pub fn is_classical(self) -> bool {
-        self != Self::Any
+        self != Self::Simple
     }
 
     /// Do types in this tag contain only hashable classic data
@@ -343,7 +343,7 @@ impl PrimType for SimpleType {
     fn tag(&self) -> TypeTag {
         match self {
             Self::Classic(c) => c.tag(),
-            _ => TypeTag::Any,
+            _ => TypeTag::Simple,
         }
     }
 }

--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -65,6 +65,18 @@ pub enum TypeClass {
 }
 
 impl TypeClass {
+    /// Returns the smallest TypeClass containing both the receiver and argument.
+    /// (This will be one of the receiver or the argument.)
+    fn union(self, other: Self) -> Self {
+        if self == Self::Any || other == Self::Any {
+            Self::Any
+        } else if self == Self::Classic || other == Self::Classic {
+            Self::Classic
+        } else {
+            Self::Hashable
+        }
+    }
+
     /// Do types in this class contain only classic data
     /// (which can be copied and discarded, i.e. [ClassicType]s)
     pub fn is_classical(self) -> bool {
@@ -527,6 +539,14 @@ impl<T: PrimType> TypeRow<T> {
             .iter()
             .map(PrimType::class)
             .all(TypeClass::is_hashable)
+    }
+
+    /// Returns the smallest [TypeClass] that contains all elements of the row
+    pub fn common_class(&self) -> TypeClass {
+        self.types
+            .iter()
+            .map(PrimType::class)
+            .fold(TypeClass::Hashable, TypeClass::union)
     }
 
     /// Mutable iterator over the types in the row.

--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -108,7 +108,7 @@ pub enum Container<T: PrimType> {
     /// Variable sized list of T.
     List(Box<T>),
     /// Hash map from hashable key type to value T.
-    Map(Box<(ClassicType, T)>),
+    Map(Box<(HashableType, T)>),
     /// Product type, known-size tuple over elements of type row.
     Tuple(Box<TypeRow<T>>),
     /// Product type, variants are tagged by their position in the type row.

--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -245,12 +245,12 @@ impl From<ClassicType> for SimpleType {
 }
 
 impl TryFrom<SimpleType> for ClassicType {
-    type Error = &'static str;
+    type Error = String;
 
     fn try_from(op: SimpleType) -> Result<Self, Self::Error> {
         match op {
             SimpleType::Classic(typ) => Ok(typ),
-            _ => Err("Invalid type conversion"),
+            _ => Err(format!("Invalid type conversion, {:?} is not classic", op)),
         }
     }
 }

--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -9,6 +9,7 @@ use std::{
 use itertools::Itertools;
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
+use serde_repr::{Deserialize_repr, Serialize_repr};
 use smol_str::SmolStr;
 
 use super::{custom::CustomType, Signature};
@@ -49,26 +50,18 @@ impl Display for SimpleType {
 
 /// Categorizes types into three classes according to basic operations supported.
 #[derive(
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    Debug,
-    derive_more::Display,
-    serde::Serialize,
-    serde::Deserialize,
+    Copy, Clone, PartialEq, Eq, Hash, Debug, derive_more::Display, Serialize_repr, Deserialize_repr,
 )]
-// TODO: make serde serialize as C-style enum
+#[repr(u8)]
 pub enum TypeClass {
     /// Any value, including linear and quantum values;
     /// cannot necessarily be copied or discarded. See [SimpleType]
-    Any,
+    Any = 0,
     /// Subset of [TypeClass::Any]; types that can be copied and discarded. See [ClassicType]
-    Classic,
+    Classic = 1,
     /// Subset of [TypeClass::Classic]: types that can also be hashed and support
     /// a strong notion of equality. See [HashableType]
-    Hashable,
+    Hashable = 2,
 }
 
 impl TypeClass {

--- a/src/types/simple/serialize.rs
+++ b/src/types/simple/serialize.rs
@@ -98,7 +98,7 @@ where
         match value {
             Container::Sum(inner) => SerSimpleType::Sum {
                 row: Box::new(inner.map_into()),
-                c: T::TAG, // We could inspect inner.common_class(), but this should have been done already
+                c: T::TAG, // We could inspect inner.containing_tag(), but this should have been done already
             },
             Container::List(inner) => SerSimpleType::List {
                 inner: Box::new((*inner).into()),

--- a/src/types/simple/serialize.rs
+++ b/src/types/simple/serialize.rs
@@ -86,8 +86,6 @@ impl SerializableType for SimpleType {
 }
 
 impl SerializableType for HashableType {
-    // TODO: Consider, do we want a const HASHABLE:bool (and appropriate flags
-    // in SerSimpleType enum members) - or a single enum {Simple, Classic, Hashable} ?
     const CLASS: TypeClass = TypeClass::Hashable;
 }
 

--- a/src/types/simple/serialize.rs
+++ b/src/types/simple/serialize.rs
@@ -82,7 +82,7 @@ impl SerializableType for ClassicType {
 }
 
 impl SerializableType for SimpleType {
-    const TAG: TypeTag = TypeTag::Any;
+    const TAG: TypeTag = TypeTag::Simple;
 }
 
 impl SerializableType for HashableType {
@@ -164,7 +164,7 @@ impl From<SimpleType> for SerSimpleType {
             SimpleType::Qontainer(c) => c.into(),
             SimpleType::Qpaque(inner) => SerSimpleType::Opaque {
                 custom: inner,
-                c: TypeTag::Any,
+                c: TypeTag::Simple,
             },
         }
     }
@@ -188,7 +188,7 @@ where
 macro_rules! handle_container {
    ($tag:ident, $variant:ident($($r:expr),*)) => {
         match $tag {
-            TypeTag::Any => (Container::<SimpleType>::$variant($($r),*)).into(),
+            TypeTag::Simple => (Container::<SimpleType>::$variant($($r),*)).into(),
             TypeTag::Classic => (Container::<ClassicType>::$variant($($r),*)).into(),
             TypeTag::Hashable => (Container::<HashableType>::$variant($($r),*)).into()
         }
@@ -225,7 +225,7 @@ impl From<SerSimpleType> for SimpleType {
             }
             SerSimpleType::Alias { name: s, c } => handle_container!(c, Alias(s)),
             SerSimpleType::Opaque { custom, c } => match c {
-                TypeTag::Any => SimpleType::Qpaque(custom),
+                TypeTag::Simple => SimpleType::Qpaque(custom),
                 TypeTag::Classic => ClassicType::Opaque(custom).into(),
                 TypeTag::Hashable => HashableType::Opaque(custom).into(),
             },

--- a/src/types/simple/serialize.rs
+++ b/src/types/simple/serialize.rs
@@ -100,7 +100,7 @@ where
         match value {
             Container::Sum(inner) => SerSimpleType::Sum {
                 row: Box::new(inner.map_into()),
-                c: T::CLASS,
+                c: T::CLASS, // We could inspect inner.common_class(), but this should have been done already
             },
             Container::List(inner) => SerSimpleType::List {
                 inner: Box::new((*inner).into()),

--- a/src/types/simple/serialize.rs
+++ b/src/types/simple/serialize.rs
@@ -199,7 +199,9 @@ impl From<SerSimpleType> for SimpleType {
             SerSimpleType::Tuple {
                 row: inner,
                 c: TypeTag::Any,
-            } => Container::<SimpleType>::Tuple(Box::new(inner.map_into())).into(),
+            } => {
+                Container::<SimpleType>::Tuple(Box::new(inner.try_convert_elems().unwrap())).into()
+            }
             SerSimpleType::Tuple {
                 row: inner,
                 c: TypeTag::Classic,
@@ -214,7 +216,7 @@ impl From<SerSimpleType> for SimpleType {
             SerSimpleType::Sum {
                 row: inner,
                 c: TypeTag::Any,
-            } => Container::<SimpleType>::Sum(Box::new(inner.map_into())).into(),
+            } => Container::<SimpleType>::Sum(Box::new(inner.try_convert_elems().unwrap())).into(),
             SerSimpleType::Sum {
                 row: inner,
                 c: TypeTag::Classic,
@@ -241,8 +243,11 @@ impl From<SerSimpleType> for SimpleType {
                 k,
                 v,
                 c: TypeTag::Any,
-            } => Container::<SimpleType>::Map(Box::new(((*k).try_into().unwrap(), (*v).into())))
-                .into(),
+            } => Container::<SimpleType>::Map(Box::new((
+                (*k).try_into().unwrap(),
+                (*v).try_into().unwrap(),
+            )))
+            .into(),
             SerSimpleType::Map {
                 k,
                 v,

--- a/src/types/simple/serialize.rs
+++ b/src/types/simple/serialize.rs
@@ -74,19 +74,19 @@ impl PrimType for SerSimpleType {
 }
 
 trait SerializableType: PrimType {
-    const CLASS: TypeTag;
+    const TAG: TypeTag;
 }
 
 impl SerializableType for ClassicType {
-    const CLASS: TypeTag = TypeTag::Classic;
+    const TAG: TypeTag = TypeTag::Classic;
 }
 
 impl SerializableType for SimpleType {
-    const CLASS: TypeTag = TypeTag::Any;
+    const TAG: TypeTag = TypeTag::Any;
 }
 
 impl SerializableType for HashableType {
-    const CLASS: TypeTag = TypeTag::Hashable;
+    const TAG: TypeTag = TypeTag::Hashable;
 }
 
 impl<T: SerializableType> From<Container<T>> for SerSimpleType
@@ -98,27 +98,27 @@ where
         match value {
             Container::Sum(inner) => SerSimpleType::Sum {
                 row: Box::new(inner.map_into()),
-                c: T::CLASS, // We could inspect inner.common_class(), but this should have been done already
+                c: T::TAG, // We could inspect inner.common_class(), but this should have been done already
             },
             Container::List(inner) => SerSimpleType::List {
                 inner: Box::new((*inner).into()),
-                c: T::CLASS, // We could inspect inner.tag(), but this should have been done already
+                c: T::TAG, // We could inspect inner.tag(), but this should have been done already
             },
             Container::Tuple(inner) => SerSimpleType::Tuple {
                 row: Box::new(inner.map_into()),
-                c: T::CLASS,
+                c: T::TAG,
             },
             Container::Map(inner) => SerSimpleType::Map {
                 k: Box::new(inner.0.into()),
                 v: Box::new(inner.1.into()),
-                c: T::CLASS,
+                c: T::TAG,
             },
             Container::Array(inner, len) => SerSimpleType::Array {
                 inner: box_convert(*inner),
                 len,
-                c: T::CLASS,
+                c: T::TAG,
             },
-            Container::Alias(name) => SerSimpleType::Alias { name, c: T::CLASS },
+            Container::Alias(name) => SerSimpleType::Alias { name, c: T::TAG },
         }
     }
 }

--- a/src/types/simple/serialize.rs
+++ b/src/types/simple/serialize.rs
@@ -286,4 +286,15 @@ mod test {
         )));
         assert_eq!(ser_roundtrip(&t), t);
     }
+
+    #[test]
+    fn serialize_types_current_behaviour() {
+        // This list should be represented as a HashableType::Container.
+        let malformed = SimpleType::Qontainer(Container::List(Box::new(SimpleType::Classic(
+            ClassicType::Hashable(HashableType::Int(8)),
+        ))));
+        // If this behaviour changes, i.e. to return the well-formed version, that'd be fine.
+        // Just to document current serialization behaviour that we leave it untouched.
+        assert_eq!(ser_roundtrip(&malformed), malformed);
+    }
 }

--- a/src/types/simple/serialize.rs
+++ b/src/types/simple/serialize.rs
@@ -258,3 +258,32 @@ impl TryFrom<SerSimpleType> for HashableType {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::hugr::serialize::test::ser_roundtrip;
+    use crate::types::{ClassicType, Container, HashableType, SimpleType};
+
+    #[test]
+    fn serialize_types_roundtrip() {
+        // A Simple tuple
+        let t = SimpleType::new_tuple(vec![
+            SimpleType::Qubit,
+            SimpleType::Classic(ClassicType::F64),
+        ]);
+        assert_eq!(ser_roundtrip(&t), t);
+
+        // A Classic sum
+        let t = SimpleType::new_sum(vec![
+            SimpleType::Classic(ClassicType::Hashable(HashableType::Int(4))),
+            SimpleType::Classic(ClassicType::F64),
+        ]);
+        assert_eq!(ser_roundtrip(&t), t);
+
+        // A Hashable list
+        let t = SimpleType::Classic(ClassicType::Hashable(HashableType::Container(
+            Container::List(Box::new(HashableType::Int(8))),
+        )));
+        assert_eq!(ser_roundtrip(&t), t);
+    }
+}


### PR DESCRIPTION
[Note there are a few small/preliminary commits here before the bulk starts.]

This was surprisingly painless...
* Add a new TypeTag enum, replacing `is_classical()` bool with a ternary; `is_classical` and `is_hashable` move here.
* Keep `purely_classical` and `purely_hashable` on TypeRow - it's silly to fall back to having to handle TypeTag::Any when you have a row of types already known to be Classic.
* PrimType: add a `.tag()` method. However, keep SerializableType with its `const CLASS` as for well-formed instances we do not need to check the runtime value.
* There is some fun with `new_sum` and `new_tuple` requiring adding these methods to ClassicType *as well as* SimpleType

Unresolved issues:
* What about type variables. These are not really sorted before, specifically that a type variable is always considered classic (!). But I'm leaving this here. _(However, note: I guess the thorough thing would be to have variables that are simple; variables that are only classic; variables that are only hashable. But really any discussion of variables has to mention_
   * _where do variables occur? I think "in YAML type schemes" is the primary place, which doesn't need to even appear in the SimpleType hierarchy, but also probably in graphs. Note that Graphs are opaque and will be defined only in the Tierkreis resource, if that helps...._ 
   * _where are they bound? In Graph types (which will be an opaque type), and const values thereof.)_
   * _**What about function declarations?** Do these have to be monomorphic?_

The next step will be to remove parts of TypeParam and incorporate Hashable there, that can be another PR.

A final note is this leaves us with a lot of different containers: `SimpleType::Qontainer`, and `SimpleType::Classic(ClassicType::Container)`, as before, but now also `SimpleType::Classic(ClassicType::Hashable(HashableType::Container))`. And there will soon be `TypeParam::Container` too! I do have an idea here, as hinted in [this comment](https://github.com/CQCL-DEV/hugr/pull/283#discussion_r1272247479), but I think that can be another PR.