### PR TITLE
OutlineCfg use insert_hugr; remove CfgBuilder::from_existing

### DIFF
--- a/src/builder/cfg.rs
+++ b/src/builder/cfg.rs
@@ -257,8 +257,7 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> BlockBuilder<B> {
         let db = DFGBuilder::create_with_io(base, block_n, signature)?;
         Ok(BlockBuilder::from_dfg_builder(db))
     }
-}
-impl<B: AsMut<Hugr> + AsRef<Hugr>> BlockBuilder<B> {
+
     /// [Set outputs](BlockBuilder::set_outputs) and [finish](`BlockBuilder::finish_sub_container`).
     pub fn finish_with_outputs(
         mut self,
@@ -292,6 +291,16 @@ impl BlockBuilder<Hugr> {
         let base = Hugr::new(op);
         let root = base.root();
         Self::create(base, root, predicate_variants, other_outputs, inputs)
+    }
+
+    /// [Set outputs](BlockBuilder::set_outputs) and [finish_hugr](`BlockBuilder::finish_hugr`).
+    pub fn finish_hugr_with_outputs(
+        mut self,
+        branch_wire: Wire,
+        outputs: impl IntoIterator<Item = Wire>,
+    ) -> Result<Hugr, BuildError> {
+        self.set_outputs(branch_wire, outputs)?;
+        self.finish_hugr().map_err(BuildError::InvalidHUGR)
     }
 }
 

--- a/src/hugr/rewrite/outline_cfg.rs
+++ b/src/hugr/rewrite/outline_cfg.rs
@@ -102,9 +102,7 @@ impl Rewrite for OutlineCfg {
         // 2. new_block contains input node, sub-cfg, exit node all connected
         let new_block = {
             let mut new_block_bldr =
-                BlockBuilder::new//existing_cfg.block_builder
-                (inputs.clone(), vec![type_row![]], outputs.clone())
-                .unwrap();
+                BlockBuilder::new(inputs.clone(), vec![type_row![]], outputs.clone()).unwrap();
             let wires_in = inputs.iter().cloned().zip(new_block_bldr.input_wires());
             let cfg = new_block_bldr.cfg_builder(wires_in, outputs).unwrap();
             cfg.exit_block(); // Makes inner exit block (but no entry block)

--- a/src/hugr/rewrite/outline_cfg.rs
+++ b/src/hugr/rewrite/outline_cfg.rs
@@ -125,7 +125,7 @@ impl Rewrite for OutlineCfg {
             .filter(|n| h.get_optype(*n).tag() == OpTag::Cfg)
             .exactly_one()
             .unwrap();
-        let inner_exit = h.children(cfg_node).next().unwrap();
+        let inner_exit = h.children(cfg_node).exactly_one().unwrap();
 
         // 4. Entry edges. Change any edges into entry_block from outside, to target new_block
         let preds: Vec<_> = h


### PR DESCRIPTION
This requires copying the created nodes, but there are, like, 6 of them, and means we can drop CfgBuilder::from_existing, easing the path to #282.

Also merge identical-signature impl Blocks and add `BlockBuilder::finish_hugr_with_outputs`, but no other Builder refactoring was required :)