### PR TITLE
Add so minimal pyo3 impls

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2,6 +2,9 @@
 //!
 use thiserror::Error;
 
+#[cfg(feature = "pyo3")]
+use pyo3::prelude::*;
+
 use crate::hugr::{HugrError, Node, ValidationError, Wire};
 use crate::ops::handle::{BasicBlockID, CfgID, ConditionalID, DfgID, FuncID, TailLoopID};
 use crate::types::SimpleType;
@@ -67,6 +70,14 @@ pub enum BuildError {
     /// Error in CircuitBuilder
     #[error("Error in CircuitBuilder: {0}.")]
     CircuitError(#[from] circuit::CircuitBuildError),
+}
+
+#[cfg(feature = "pyo3")]
+impl From<BuildError> for PyErr {
+    fn from(err: BuildError) -> Self {
+        // We may want to define more specific python-level errors at some point.
+        PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(err.to_string())
+    }
 }
 
 #[cfg(test)]

--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -5,6 +5,9 @@ use serde_json::json;
 use std::collections::HashMap;
 use thiserror::Error;
 
+#[cfg(feature = "pyo3")]
+use pyo3::prelude::*;
+
 use crate::hugr::{Hugr, HugrMut};
 use crate::ops::OpTrait;
 use crate::ops::OpType;
@@ -82,6 +85,13 @@ pub enum HUGRSerializationError {
     /// First node in node list must be the HUGR root.
     #[error("The first node in the node list has parent {0:?}, should be itself (index 0)")]
     FirstNodeNotRoot(Node),
+}
+
+#[cfg(feature = "pyo3")]
+impl From<HUGRSerializationError> for PyErr {
+    fn from(err: HUGRSerializationError) -> Self {
+        PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(err.to_string())
+    }
 }
 
 impl Serialize for Hugr {

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -9,6 +9,9 @@ use petgraph::visit::{DfsPostOrder, Walker};
 use portgraph::{LinkView, PortView};
 use thiserror::Error;
 
+#[cfg(feature = "pyo3")]
+use pyo3::prelude::*;
+
 use crate::hugr::typecheck::{typecheck_const, ConstTypeError};
 use crate::ops::validate::{ChildrenEdgeData, ChildrenValidationError, EdgeValidationError};
 use crate::ops::OpTag;
@@ -671,6 +674,14 @@ pub enum ValidationError {
         to_offset: Port,
         to_resources: ResourceSet,
     },
+}
+
+#[cfg(feature = "pyo3")]
+impl From<ValidationError> for PyErr {
+    fn from(err: ValidationError) -> Self {
+        // We may want to define more specific python-level errors at some point.
+        PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(err.to_string())
+    }
 }
 
 /// Errors related to the inter-graph edge validations.

--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -7,8 +7,6 @@ use std::{
 };
 
 use itertools::Itertools;
-#[cfg(feature = "pyo3")]
-use pyo3::prelude::*;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use smol_str::SmolStr;
 


### PR DESCRIPTION
- Expose Hugr and some other structs as opaque python objects.
  - Does not implement any pymethods. We'll leave that for later.
- Implement `Into<PyErr>` for some custom errors