### PR TITLE
[Refactor] Derive PartialEq for ConstValue

### DIFF
--- a/src/hugr/typecheck.rs
+++ b/src/hugr/typecheck.rs
@@ -155,7 +155,7 @@ pub fn typecheck_const(typ: &ClassicType, val: &ConstValue) -> Result<(), ConstT
             (Container::Sum(_), _) => {
                 Err(ConstTypeError::TypeMismatch(ty.clone(), tm.const_type()))
             }
-            (Container::Opaque(ty), ConstValue::Opaque(ty_act, _val)) => {
+            (Container::Opaque(ty), ConstValue::Opaque((ty_act, _val))) => {
                 if ty_act != ty {
                     return Err(ConstTypeError::TypeMismatch(
                         ty.clone().into(),

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -48,7 +48,7 @@ pub(crate) const HUGR_MAX_INT_WIDTH: HugrIntWidthStore =
 ///
 /// TODO: Add more constants
 /// TODO: bigger/smaller integers.
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[non_exhaustive]
 #[allow(missing_docs)]
 pub enum ConstValue {
@@ -69,38 +69,14 @@ pub enum ConstValue {
     },
     /// A tuple of constant values.
     Tuple(Vec<ConstValue>),
-    /// An opaque constant value, with cached type.
-    Opaque(CustomType, Box<dyn CustomConst>),
+    /// An opaque constant value, with cached type
+    // Note: the extra level of tupling is to avoid https://github.com/rust-lang/rust/issues/78808
+    Opaque((CustomType, Box<dyn CustomConst>)),
 }
 
-impl PartialEq for ConstValue {
+impl PartialEq for dyn CustomConst {
     fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (
-                Self::Int {
-                    value: l0,
-                    width: l_width,
-                },
-                Self::Int {
-                    value: r0,
-                    width: r_width,
-                },
-            ) => l0 == r0 && l_width == r_width,
-            (Self::Opaque(l0, l1), Self::Opaque(r0, r1)) => l0 == r0 && l1.eq(&**r1),
-            (
-                Self::Sum { tag, variants, val },
-                Self::Sum {
-                    tag: t1,
-                    variants: type1,
-                    val: v1,
-                },
-            ) => tag == t1 && variants == type1 && val == v1,
-
-            (Self::Tuple(v1), Self::Tuple(v2)) => v1.eq(v2),
-            (Self::F64(f1), Self::F64(f2)) => f1 == f2,
-
-            _ => false,
-        }
+        (*self).equal_consts(other)
     }
 }
 
@@ -118,7 +94,7 @@ impl ConstValue {
     pub fn const_type(&self) -> ClassicType {
         match self {
             Self::Int { value: _, width } => HashableType::Int(*width).into(),
-            Self::Opaque(_, b) => Container::Opaque((*b).custom_type()).into(),
+            Self::Opaque((_, b)) => Container::Opaque((*b).custom_type()).into(),
             Self::Sum { variants, .. } => ClassicType::new_sum(variants.clone()),
             Self::Tuple(vals) => {
                 let row: Vec<_> = vals.iter().map(|val| val.const_type()).collect();
@@ -132,7 +108,7 @@ impl ConstValue {
         match self {
             Self::Int { value, width } => format!("const:int<{width}>:{value}"),
             Self::F64(f) => format!("const:float:{f}"),
-            Self::Opaque(_, v) => format!("const:{}", v.name()),
+            Self::Opaque((_, v)) => format!("const:{}", v.name()),
             Self::Sum { tag, val, .. } => {
                 format!("const:sum:{{tag:{tag}, val:{}}}", val.name())
             }
@@ -203,7 +179,7 @@ impl ConstValue {
 
 impl<T: CustomConst> From<T> for ConstValue {
     fn from(v: T) -> Self {
-        Self::Opaque(v.custom_type(), Box::new(v))
+        Self::Opaque((v.custom_type(), Box::new(v)))
     }
 }
 
@@ -223,7 +199,7 @@ pub trait CustomConst:
     fn custom_type(&self) -> CustomType;
 
     /// Compare two constants for equality, using downcasting and comparing the definitions.
-    fn eq(&self, other: &dyn CustomConst) -> bool {
+    fn equal_consts(&self, other: &dyn CustomConst) -> bool {
         let _ = other;
         false
     }


### PR DESCRIPTION
AFAICT our manual implementation does exactly what the derive one would, except for one case - ConstValue::Opaque. But with a bit of "wizardry" (?!) we can get provide that ourselves and get Rust to derive the rest.

The extra level of tupling inside `ConstValue::Opaque` was because without that the `derive(serde::Serialize)` on ConstValue produced a complex error about moving out of a Box<dyn CustomConst>. A `struct OpaqueValue(CustomType, Box<dyn CustomConst>)` is one way to do that but just the tuple works too.