### PR TITLE
Correct field names for op/type args/params

### DIFF
--- a/src/extensions/rotation.rs
+++ b/src/extensions/rotation.rs
@@ -65,7 +65,7 @@ impl Type {
     pub fn type_def(self) -> TypeDef {
         TypeDef {
             name: self.name(),
-            args: vec![],
+            params: vec![],
         }
     }
 }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -169,7 +169,7 @@ impl OpDef {
     pub fn new_with_yaml_types(
         name: SmolStr,
         description: String,
-        args: Vec<TypeParam>,
+        params: Vec<TypeParam>,
         misc: HashMap<String, serde_yaml::Value>,
         inputs: String, // TODO this is likely the wrong type
         outputs: String, // TODO similarly
@@ -179,7 +179,7 @@ impl OpDef {
             resource: Default::default(), // Currently overwritten when OpDef added to Resource
             name,
             description,
-            params: args,
+            params,
             misc,
             signature_func: SignatureFunc::FromYAML { inputs, outputs },
             lower_funcs: Vec::new(),
@@ -190,7 +190,7 @@ impl OpDef {
     pub fn new_with_custom_sig(
         name: SmolStr,
         description: String,
-        args: Vec<TypeParam>,
+        params: Vec<TypeParam>,
         misc: HashMap<String, serde_yaml::Value>,
         sig_func: impl CustomSignatureFunc + 'static,
     ) -> Self {
@@ -198,7 +198,7 @@ impl OpDef {
             resource: Default::default(), // Currently overwritten when OpDef added to Resource
             name,
             description,
-            params: args,
+            params,
             misc,
             signature_func: SignatureFunc::CustomFunc(Box::new(sig_func)),
             lower_funcs: Vec::new(),

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -151,7 +151,7 @@ pub struct OpDef {
     /// Human readable description of the operation.
     pub description: String,
     /// Declared type parameters, values must be provided for each operation node
-    pub args: Vec<TypeParam>,
+    pub params: Vec<TypeParam>,
     /// Miscellaneous data associated with the operation.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub misc: HashMap<String, serde_yaml::Value>,
@@ -179,7 +179,7 @@ impl OpDef {
             resource: Default::default(), // Currently overwritten when OpDef added to Resource
             name,
             description,
-            args,
+            params: args,
             misc,
             signature_func: SignatureFunc::FromYAML { inputs, outputs },
             lower_funcs: Vec::new(),
@@ -198,7 +198,7 @@ impl OpDef {
             resource: Default::default(), // Currently overwritten when OpDef added to Resource
             name,
             description,
-            args,
+            params: args,
             misc,
             signature_func: SignatureFunc::CustomFunc(Box::new(sig_func)),
             lower_funcs: Vec::new(),
@@ -218,15 +218,13 @@ impl OpDef {
         args: &[TypeArg],
         resources_in: &ResourceSet,
     ) -> Result<Signature, SignatureError> {
-        if args.len() != self.args.len() {
+        if args.len() != self.params.len() {
             return Err(SignatureError::TypeArgMismatch(TypeArgError::WrongNumber(
                 args.len(),
-                self.args.len(),
+                self.params.len(),
             )));
         }
-        for (a, p) in args.iter().zip(self.args.iter()) {
-            check_type_arg(a, p).map_err(SignatureError::TypeArgMismatch)?;
-        }
+        self.check_args(args)?;
         let (ins, outs, res) = match &self.signature_func {
             SignatureFunc::FromYAML { .. } => {
                 // Sig should be computed solely from inputs + outputs + args.
@@ -239,6 +237,13 @@ impl OpDef {
         sig.input_resources = resources_in.clone();
         sig.output_resources = res.union(resources_in); // Pass input requirements through
         Ok(sig)
+    }
+
+    fn check_args(&self, args: &[TypeArg]) -> Result<(), SignatureError> {
+        for (a, p) in args.iter().zip(self.params.iter()) {
+            check_type_arg(a, p).map_err(SignatureError::TypeArgMismatch)?;
+        }
+        Ok(())
     }
 
     /// Optional description of the ports in the signature.
@@ -290,7 +295,7 @@ pub struct TypeDef {
     /// with the same number of [`TypeArg`]'s to make an actual type.
     ///
     /// [`TypeArg`]: crate::types::type_param::TypeArg
-    pub args: Vec<TypeParam>,
+    pub params: Vec<TypeParam>,
 }
 
 /// A unique identifier for a resource.

--- a/src/types/custom.rs
+++ b/src/types/custom.rs
@@ -17,7 +17,7 @@ pub struct CustomType {
     /// Arguments that fit the [`TypeParam`]s declared by the typedef
     ///
     /// [`TypeParam`]: super::type_param::TypeParam
-    params: Vec<TypeArg>,
+    args: Vec<TypeArg>,
 }
 
 impl CustomType {
@@ -25,13 +25,13 @@ impl CustomType {
     pub fn new(id: impl Into<SmolStr>, params: impl Into<Vec<TypeArg>>) -> Self {
         Self {
             id: id.into(),
-            params: params.into(),
+            args: params.into(),
         }
     }
 
     /// Creates a new opaque type with no parameters
     pub const fn new_simple(id: SmolStr) -> Self {
-        Self { id, params: vec![] }
+        Self { id, args: vec![] }
     }
 
     /// Returns the unique identifier of the opaque type.
@@ -39,9 +39,9 @@ impl CustomType {
         &self.id
     }
 
-    /// Returns the parameters of the opaque type.
-    pub fn params(&self) -> &[TypeArg] {
-        &self.params
+    /// Returns the arguments of the opaque type.
+    pub fn args(&self) -> &[TypeArg] {
+        &self.args
     }
 
     /// Returns a [`ClassicType`] containing this opaque type.
@@ -52,7 +52,7 @@ impl CustomType {
 
 impl Display for CustomType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}({:?})", self.id, self.params)
+        write!(f, "{}({:?})", self.id, self.args)
     }
 }
 

--- a/src/types/custom.rs
+++ b/src/types/custom.rs
@@ -22,10 +22,10 @@ pub struct CustomType {
 
 impl CustomType {
     /// Creates a new opaque type.
-    pub fn new(id: impl Into<SmolStr>, params: impl Into<Vec<TypeArg>>) -> Self {
+    pub fn new(id: impl Into<SmolStr>, args: impl Into<Vec<TypeArg>>) -> Self {
         Self {
             id: id.into(),
-            args: params.into(),
+            args: args.into(),
         }
     }
 


### PR DESCRIPTION
Fly-by refactor out arg checking for future reuse