### PR TITLE
keep rust on nixpkgs version in devenv

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -22,7 +22,6 @@
   # https://devenv.sh/languages/
   # https://devenv.sh/reference/options/#languagesrustversion
   languages.rust = {
-    channel = "stable";
     enable = true;
     components = [ "rustc" "cargo" "clippy" "rustfmt" "rust-analyzer" ];
   };


### PR DESCRIPTION
otherwise clippy has a different version and pre-commit fails