### PR TITLE
Check Const's are well-formed using a constructor

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 
+use crate::hugr::typecheck::ConstTypeError;
 use crate::hugr::{HugrError, Node, ValidationError, Wire};
 use crate::ops::handle::{BasicBlockID, CfgID, ConditionalID, DfgID, FuncID, TailLoopID};
 use crate::types::SimpleType;
@@ -41,6 +42,11 @@ pub enum BuildError {
     /// The constructed HUGR is invalid.
     #[error("The constructed HUGR is invalid: {0}.")]
     InvalidHUGR(#[from] ValidationError),
+    /// Tried to add a malformed [ConstValue]
+    ///
+    /// [ConstValue]: crate::ops::constant::ConstValue
+    #[error("Constant failed typechecking: {0}")]
+    BadConstant(#[from] ConstTypeError),
     /// HUGR construction error.
     #[error("Error when mutating HUGR: {0}.")]
     ConstructError(#[from] HugrError),

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -63,7 +63,7 @@ pub trait Container {
     /// [`OpType::Const`] node.
     fn add_constant(&mut self, val: ConstValue) -> Result<ConstID, BuildError> {
         let typ = val.const_type();
-        let const_n = self.add_child_op(ops::Const(val))?;
+        let const_n = self.add_child_op(ops::Const::new(val).map_err(BuildError::BadConstant)?)?;
 
         Ok((const_n, typ).into())
     }

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -12,10 +12,9 @@ use thiserror::Error;
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 
-use crate::hugr::typecheck::{typecheck_const, ConstTypeError};
 use crate::ops::validate::{ChildrenEdgeData, ChildrenValidationError, EdgeValidationError};
 use crate::ops::OpTag;
-use crate::ops::{self, OpTrait, OpType, ValidateOp};
+use crate::ops::{OpTrait, OpType, ValidateOp};
 use crate::resource::ResourceSet;
 use crate::types::ClassicType;
 use crate::types::{EdgeKind, SimpleType};
@@ -434,21 +433,16 @@ impl<'a> ValidationContext<'a> {
         let local = Some(from_parent) == to_parent;
 
         let is_static = match from_optype.port_kind(from_offset).unwrap() {
-            // Inter-graph constant wires do not have restrictions
             EdgeKind::Static(typ) => {
-                if let OpType::Const(ops::Const(val)) = from_optype {
-                    typecheck_const(&typ, val).map_err(ValidationError::from)?;
-                } else {
-                    // If const edges aren't coming from const nodes, they're graph
-                    // edges coming from FuncDecl or FuncDefn
-                    if !OpTag::Function.is_superset(from_optype.tag()) {
-                        return Err(InterGraphEdgeError::InvalidConstSrc {
-                            from,
-                            from_offset,
-                            typ,
-                        }
-                        .into());
-                    };
+                if !(OpTag::Const.is_superset(from_optype.tag())
+                    || OpTag::Function.is_superset(from_optype.tag()))
+                {
+                    return Err(InterGraphEdgeError::InvalidConstSrc {
+                        from,
+                        from_offset,
+                        typ,
+                    }
+                    .into());
                 };
                 true
             }
@@ -651,9 +645,6 @@ pub enum ValidationError {
     /// There are invalid inter-graph edges.
     #[error(transparent)]
     InterGraphEdgeError(#[from] InterGraphEdgeError),
-    /// Type error for constant values
-    #[error("Type error for constant value: {0}.")]
-    ConstTypeError(#[from] ConstTypeError),
     /// Missing lift node
     #[error("Resources at target node {to:?} ({to_offset:?}) ({to_resources}) exceed those at source {from:?} ({from_offset:?}) ({from_resources})")]
     TgtExceedsSrcResources {
@@ -817,7 +808,7 @@ mod test {
         parent: Node,
         predicate_size: usize,
     ) -> (Node, Node, Node, Node) {
-        let const_op = ops::Const(ConstValue::simple_predicate(0, predicate_size));
+        let const_op = ops::Const::new(ConstValue::simple_predicate(0, predicate_size)).unwrap();
         let tag_type = SimpleType::Classic(ClassicType::new_simple_predicate(predicate_size));
 
         let input = b
@@ -1147,8 +1138,10 @@ mod test {
             })
         );
         // Second input of Xor from a constant
-        let cst =
-            h.add_op_with_parent(h.root(), ops::Const(ConstValue::Int { width: 1, value: 1 }))?;
+        let cst = h.add_op_with_parent(
+            h.root(),
+            ops::Const::new(ConstValue::Int { width: 1, value: 1 }).unwrap(),
+        )?;
         let lcst = h.add_op_with_parent(
             h.root(),
             ops::LoadConstant {


### PR DESCRIPTION
`typecheck_const` is currently called from `validate_edge` - that is, once per outgoing edge. This is (a) repetitive, (b) doesn't complain about malformed constants with no edges, (c) confusing and hard to find ;-).

Instead, make Const constructible only via a new `new()` method (returning a Result), and validate only there.