### PR TITLE
Make ConstValue checkable not synethesisable

### DIFF
--- a/src/algorithm/nest_cfgs.rs
+++ b/src/algorithm/nest_cfgs.rs
@@ -428,8 +428,14 @@ pub(crate) mod test {
         //               \-> right -/             \-<--<-/
         let mut cfg_builder = CFGBuilder::new(type_row![NAT], type_row![NAT])?;
 
-        let pred_const = cfg_builder.add_constant(ConstValue::simple_predicate(0, 2))?; // Nothing here cares which
-        let const_unit = cfg_builder.add_constant(ConstValue::simple_unary_predicate())?;
+        let pred_const = cfg_builder.add_constant(
+            ConstValue::simple_predicate(0, 2),
+            ClassicType::new_simple_predicate(2),
+        )?; // Nothing here cares which
+        let const_unit = cfg_builder.add_constant(
+            ConstValue::simple_unary_predicate(),
+            ClassicType::new_simple_predicate(1),
+        )?;
 
         let entry = n_identity(
             cfg_builder.simple_entry_builder(type_row![NAT], 1)?,
@@ -647,8 +653,14 @@ pub(crate) mod test {
         separate: bool,
     ) -> Result<(Hugr, BasicBlockID, BasicBlockID), BuildError> {
         let mut cfg_builder = CFGBuilder::new(type_row![NAT], type_row![NAT])?;
-        let pred_const = cfg_builder.add_constant(ConstValue::simple_predicate(0, 2))?; // Nothing here cares which
-        let const_unit = cfg_builder.add_constant(ConstValue::simple_unary_predicate())?;
+        let pred_const = cfg_builder.add_constant(
+            ConstValue::simple_predicate(0, 2),
+            ClassicType::new_simple_predicate(2),
+        )?; // Nothing here cares which
+        let const_unit = cfg_builder.add_constant(
+            ConstValue::simple_unary_predicate(),
+            ClassicType::new_simple_predicate(1),
+        )?;
 
         let entry = n_identity(
             cfg_builder.simple_entry_builder(type_row![NAT], 2)?,
@@ -682,8 +694,14 @@ pub(crate) mod test {
 
         let mut cfg_builder = CFGBuilder::new(type_row![NAT], type_row![NAT])?;
 
-        let pred_const = cfg_builder.add_constant(ConstValue::simple_predicate(0, 2))?; // Nothing here cares which
-        let const_unit = cfg_builder.add_constant(ConstValue::simple_unary_predicate())?;
+        let pred_const = cfg_builder.add_constant(
+            ConstValue::simple_predicate(0, 2),
+            ClassicType::new_simple_predicate(2),
+        )?; // Nothing here cares which
+        let const_unit = cfg_builder.add_constant(
+            ConstValue::simple_unary_predicate(),
+            ClassicType::new_simple_predicate(1),
+        )?;
 
         let entry = n_identity(
             cfg_builder.simple_entry_builder(type_row![NAT], 1)?,

--- a/src/algorithm/nest_cfgs.rs
+++ b/src/algorithm/nest_cfgs.rs
@@ -399,10 +399,8 @@ pub(crate) mod test {
     use super::*;
     use crate::builder::{BuildError, CFGBuilder, Container, DataflowSubContainer, HugrBuilder};
     use crate::hugr::region::{FlatRegionView, Region};
-    use crate::ops::{
-        handle::{BasicBlockID, ConstID, NodeHandle},
-        ConstValue,
-    };
+    use crate::ops::handle::{BasicBlockID, ConstID, NodeHandle};
+    use crate::ops::Const;
     use crate::types::{ClassicType, SimpleType};
     use crate::{type_row, Hugr};
     const NAT: SimpleType = SimpleType::Classic(ClassicType::i64());
@@ -428,14 +426,8 @@ pub(crate) mod test {
         //               \-> right -/             \-<--<-/
         let mut cfg_builder = CFGBuilder::new(type_row![NAT], type_row![NAT])?;
 
-        let pred_const = cfg_builder.add_constant(
-            ConstValue::simple_predicate(0, 2),
-            ClassicType::new_simple_predicate(2),
-        )?; // Nothing here cares which
-        let const_unit = cfg_builder.add_constant(
-            ConstValue::simple_unary_predicate(),
-            ClassicType::new_simple_predicate(1),
-        )?;
+        let pred_const = cfg_builder.add_constant(Const::simple_predicate(0, 2))?; // Nothing here cares which
+        let const_unit = cfg_builder.add_constant(Const::simple_unary_predicate())?;
 
         let entry = n_identity(
             cfg_builder.simple_entry_builder(type_row![NAT], 1)?,
@@ -653,14 +645,8 @@ pub(crate) mod test {
         separate: bool,
     ) -> Result<(Hugr, BasicBlockID, BasicBlockID), BuildError> {
         let mut cfg_builder = CFGBuilder::new(type_row![NAT], type_row![NAT])?;
-        let pred_const = cfg_builder.add_constant(
-            ConstValue::simple_predicate(0, 2),
-            ClassicType::new_simple_predicate(2),
-        )?; // Nothing here cares which
-        let const_unit = cfg_builder.add_constant(
-            ConstValue::simple_unary_predicate(),
-            ClassicType::new_simple_predicate(1),
-        )?;
+        let pred_const = cfg_builder.add_constant(Const::simple_predicate(0, 2))?; // Nothing here cares which
+        let const_unit = cfg_builder.add_constant(Const::simple_unary_predicate())?;
 
         let entry = n_identity(
             cfg_builder.simple_entry_builder(type_row![NAT], 2)?,
@@ -694,14 +680,8 @@ pub(crate) mod test {
 
         let mut cfg_builder = CFGBuilder::new(type_row![NAT], type_row![NAT])?;
 
-        let pred_const = cfg_builder.add_constant(
-            ConstValue::simple_predicate(0, 2),
-            ClassicType::new_simple_predicate(2),
-        )?; // Nothing here cares which
-        let const_unit = cfg_builder.add_constant(
-            ConstValue::simple_unary_predicate(),
-            ClassicType::new_simple_predicate(1),
-        )?;
+        let pred_const = cfg_builder.add_constant(Const::simple_predicate(0, 2))?; // Nothing here cares which
+        let const_unit = cfg_builder.add_constant(Const::simple_unary_predicate())?;
 
         let entry = n_identity(
             cfg_builder.simple_entry_builder(type_row![NAT], 1)?,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -5,8 +5,8 @@ use thiserror::Error;
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 
-use crate::hugr::typecheck::ConstTypeError;
 use crate::hugr::{HugrError, Node, ValidationError, Wire};
+use crate::ops::constant::typecheck::ConstTypeError;
 use crate::ops::handle::{BasicBlockID, CfgID, ConditionalID, DfgID, FuncID, TailLoopID};
 use crate::types::SimpleType;
 

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -300,7 +300,7 @@ pub trait Dataflow: Container {
     /// This function will return an error if there is an error when adding the node.
     fn load_const(&mut self, cid: &ConstID) -> Result<Wire, BuildError> {
         let const_node = cid.node();
-        let op @ ops::Const { .. } = self
+        let op: ops::Const = self
             .hugr()
             .get_optype(const_node)
             .clone()
@@ -309,7 +309,7 @@ pub trait Dataflow: Container {
 
         let load_n = self.add_dataflow_op(
             ops::LoadConstant {
-                datatype: op.get_type().clone(),
+                datatype: op.const_type().clone(),
             },
             // Constant wire from the constant value node
             vec![Wire::new(const_node, Port::new_outgoing(0))],

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -1,7 +1,7 @@
 use crate::hugr::validate::InterGraphEdgeError;
 use crate::hugr::view::HugrView;
 use crate::hugr::{Node, NodeMetadata, Port, ValidationError};
-use crate::ops::{self, ConstValue, LeafOp, OpTrait, OpType};
+use crate::ops::{self, LeafOp, OpTrait, OpType};
 
 use std::iter;
 
@@ -61,8 +61,8 @@ pub trait Container {
     ///
     /// This function will return an error if there is an error in adding the
     /// [`OpType::Const`] node.
-    fn add_constant(&mut self, value: ConstValue, typ: ClassicType) -> Result<ConstID, BuildError> {
-        let const_n = self.add_child_op(ops::Const::new(value, typ)?)?;
+    fn add_constant(&mut self, constant: ops::Const) -> Result<ConstID, BuildError> {
+        let const_n = self.add_child_op(constant)?;
 
         Ok(const_n.into())
     }
@@ -323,8 +323,8 @@ pub trait Dataflow: Container {
     /// # Errors
     ///
     /// This function will return an error if there is an error when adding the node.
-    fn add_load_const(&mut self, val: ConstValue, typ: ClassicType) -> Result<Wire, BuildError> {
-        let cid = self.add_constant(val, typ)?;
+    fn add_load_const(&mut self, constant: ops::Const) -> Result<Wire, BuildError> {
+        let cid = self.add_constant(constant)?;
         self.load_const(&cid)
     }
 

--- a/src/builder/cfg.rs
+++ b/src/builder/cfg.rs
@@ -348,7 +348,10 @@ mod test {
         };
         let mut middle_b = cfg_builder.simple_block_builder(type_row![NAT], type_row![NAT], 1)?;
         let middle = {
-            let c = middle_b.add_load_const(ConstValue::simple_unary_predicate())?;
+            let c = middle_b.add_load_const(
+                ConstValue::simple_unary_predicate(),
+                ClassicType::new_simple_predicate(1),
+            )?;
             let [inw] = middle_b.input_wires_arr();
             middle_b.finish_with_outputs(c, [inw])?
         };

--- a/src/builder/cfg.rs
+++ b/src/builder/cfg.rs
@@ -293,7 +293,7 @@ mod test {
     use crate::builder::{DataflowSubContainer, ModuleBuilder};
     use crate::macros::classic_row;
     use crate::types::ClassicType;
-    use crate::{builder::test::NAT, ops::ConstValue, type_row, types::Signature};
+    use crate::{builder::test::NAT, type_row, types::Signature};
     use cool_asserts::assert_matches;
 
     use super::*;
@@ -348,10 +348,7 @@ mod test {
         };
         let mut middle_b = cfg_builder.simple_block_builder(type_row![NAT], type_row![NAT], 1)?;
         let middle = {
-            let c = middle_b.add_load_const(
-                ConstValue::simple_unary_predicate(),
-                ClassicType::new_simple_predicate(1),
-            )?;
+            let c = middle_b.add_load_const(ops::Const::simple_unary_predicate())?;
             let [inw] = middle_b.input_wires_arr();
             middle_b.finish_with_outputs(c, [inw])?
         };

--- a/src/builder/conditional.rs
+++ b/src/builder/conditional.rs
@@ -198,6 +198,7 @@ mod test {
     use cool_asserts::assert_matches;
 
     use crate::builder::{DataflowSubContainer, HugrBuilder, ModuleBuilder};
+    use crate::types::ClassicType;
     use crate::{
         builder::{
             test::{n_identity, NAT},
@@ -227,7 +228,8 @@ mod test {
             let mut module_builder = ModuleBuilder::new();
             let mut fbuild = module_builder
                 .define_function("main", Signature::new_df(type_row![NAT], type_row![NAT]))?;
-            let tru_const = fbuild.add_constant(ConstValue::true_val())?;
+            let tru_const = fbuild
+                .add_constant(ConstValue::true_val(), ClassicType::new_simple_predicate(2))?;
             let _fdef = {
                 let const_wire = fbuild.load_const(&tru_const)?;
                 let [int] = fbuild.input_wires_arr();

--- a/src/builder/conditional.rs
+++ b/src/builder/conditional.rs
@@ -198,13 +198,13 @@ mod test {
     use cool_asserts::assert_matches;
 
     use crate::builder::{DataflowSubContainer, HugrBuilder, ModuleBuilder};
-    use crate::types::ClassicType;
+
     use crate::{
         builder::{
             test::{n_identity, NAT},
             Dataflow,
         },
-        ops::ConstValue,
+        ops::Const,
         type_row,
     };
 
@@ -218,7 +218,6 @@ mod test {
 
         n_identity(conditional_b.case_builder(0)?)?;
         n_identity(conditional_b.case_builder(1)?)?;
-
         Ok(())
     }
 
@@ -228,8 +227,7 @@ mod test {
             let mut module_builder = ModuleBuilder::new();
             let mut fbuild = module_builder
                 .define_function("main", Signature::new_df(type_row![NAT], type_row![NAT]))?;
-            let tru_const = fbuild
-                .add_constant(ConstValue::true_val(), ClassicType::new_simple_predicate(2))?;
+            let tru_const = fbuild.add_constant(Const::true_val())?;
             let _fdef = {
                 let const_wire = fbuild.load_const(&tru_const)?;
                 let [int] = fbuild.input_wires_arr();

--- a/src/builder/tail_loop.rs
+++ b/src/builder/tail_loop.rs
@@ -110,7 +110,7 @@ mod test {
         let build_result: Result<Hugr, ValidationError> = {
             let mut loop_b = TailLoopBuilder::new(vec![], vec![BIT], vec![ClassicType::i64()])?;
             let [i1] = loop_b.input_wires_arr();
-            let const_wire = loop_b.add_load_const(ConstValue::i64(1))?;
+            let const_wire = loop_b.add_load_const(ConstValue::i64(1), ClassicType::i64())?;
 
             let break_wire = loop_b.make_break(loop_b.loop_signature()?.clone(), [const_wire])?;
             loop_b.set_outputs(break_wire, [i1])?;
@@ -136,7 +136,10 @@ mod test {
                         classic_row![ClassicType::i64()],
                     )?;
                     let signature = loop_b.loop_signature()?.clone();
-                    let const_wire = loop_b.add_load_const(ConstValue::true_val())?;
+                    let const_wire = loop_b.add_load_const(
+                        ConstValue::true_val(),
+                        ClassicType::new_simple_predicate(2),
+                    )?;
                     let [b1] = loop_b.input_wires_arr();
                     let conditional_id = {
                         let predicate_inputs = vec![type_row![]; 2];
@@ -156,7 +159,8 @@ mod test {
                         let mut branch_1 = conditional_b.case_builder(1)?;
                         let [_b1] = branch_1.input_wires_arr();
 
-                        let wire = branch_1.add_load_const(ConstValue::i64(2))?;
+                        let wire =
+                            branch_1.add_load_const(ConstValue::i64(2), ClassicType::i64())?;
                         let break_wire = branch_1.make_break(signature, [wire])?;
                         branch_1.finish_with_outputs([break_wire])?;
 

--- a/src/builder/tail_loop.rs
+++ b/src/builder/tail_loop.rs
@@ -98,7 +98,7 @@ mod test {
         },
         classic_row,
         hugr::ValidationError,
-        ops::ConstValue,
+        ops::Const,
         type_row,
         types::{ClassicType, Signature},
         Hugr,
@@ -110,7 +110,7 @@ mod test {
         let build_result: Result<Hugr, ValidationError> = {
             let mut loop_b = TailLoopBuilder::new(vec![], vec![BIT], vec![ClassicType::i64()])?;
             let [i1] = loop_b.input_wires_arr();
-            let const_wire = loop_b.add_load_const(ConstValue::i64(1), ClassicType::i64())?;
+            let const_wire = loop_b.add_load_const(Const::i64(1)?)?;
 
             let break_wire = loop_b.make_break(loop_b.loop_signature()?.clone(), [const_wire])?;
             loop_b.set_outputs(break_wire, [i1])?;
@@ -136,10 +136,7 @@ mod test {
                         classic_row![ClassicType::i64()],
                     )?;
                     let signature = loop_b.loop_signature()?.clone();
-                    let const_wire = loop_b.add_load_const(
-                        ConstValue::true_val(),
-                        ClassicType::new_simple_predicate(2),
-                    )?;
+                    let const_wire = loop_b.add_load_const(Const::true_val())?;
                     let [b1] = loop_b.input_wires_arr();
                     let conditional_id = {
                         let predicate_inputs = vec![type_row![]; 2];
@@ -159,8 +156,7 @@ mod test {
                         let mut branch_1 = conditional_b.case_builder(1)?;
                         let [_b1] = branch_1.input_wires_arr();
 
-                        let wire =
-                            branch_1.add_load_const(ConstValue::i64(2), ClassicType::i64())?;
+                        let wire = branch_1.add_load_const(Const::i64(2)?)?;
                         let break_wire = branch_1.make_break(signature, [wire])?;
                         branch_1.finish_with_outputs([break_wire])?;
 

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -5,7 +5,6 @@ mod hugrmut;
 pub mod region;
 pub mod rewrite;
 pub mod serialize;
-pub mod typecheck;
 pub mod validate;
 pub mod view;
 

--- a/src/hugr/rewrite/outline_cfg.rs
+++ b/src/hugr/rewrite/outline_cfg.rs
@@ -8,6 +8,7 @@ use crate::builder::{BlockBuilder, Container, Dataflow, SubContainer};
 use crate::hugr::rewrite::Rewrite;
 use crate::hugr::{HugrMut, HugrView};
 use crate::ops::{BasicBlock, ConstValue, OpTag, OpTrait, OpType};
+use crate::types::ClassicType;
 use crate::{type_row, Hugr, Node};
 
 /// Moves part of a Control-flow Sibling Graph into a new CFG-node
@@ -108,7 +109,10 @@ impl Rewrite for OutlineCfg {
             cfg.exit_block(); // Makes inner exit block (but no entry block)
             let cfg_outputs = cfg.finish_sub_container().unwrap().outputs();
             let predicate = new_block_bldr
-                .add_constant(ConstValue::simple_predicate(0, 1))
+                .add_constant(
+                    ConstValue::simple_unary_predicate(),
+                    ClassicType::new_simple_predicate(1),
+                )
                 .unwrap();
             let pred_wire = new_block_bldr.load_const(&predicate).unwrap();
             let new_block_hugr = new_block_bldr

--- a/src/hugr/rewrite/outline_cfg.rs
+++ b/src/hugr/rewrite/outline_cfg.rs
@@ -7,8 +7,8 @@ use thiserror::Error;
 use crate::builder::{BlockBuilder, Container, Dataflow, SubContainer};
 use crate::hugr::rewrite::Rewrite;
 use crate::hugr::{HugrMut, HugrView};
-use crate::ops::{BasicBlock, ConstValue, OpTag, OpTrait, OpType};
-use crate::types::ClassicType;
+use crate::ops;
+use crate::ops::{BasicBlock, OpTag, OpTrait, OpType};
 use crate::{type_row, Hugr, Node};
 
 /// Moves part of a Control-flow Sibling Graph into a new CFG-node
@@ -109,10 +109,7 @@ impl Rewrite for OutlineCfg {
             cfg.exit_block(); // Makes inner exit block (but no entry block)
             let cfg_outputs = cfg.finish_sub_container().unwrap().outputs();
             let predicate = new_block_bldr
-                .add_constant(
-                    ConstValue::simple_unary_predicate(),
-                    ClassicType::new_simple_predicate(1),
-                )
+                .add_constant(ops::Const::simple_unary_predicate())
                 .unwrap();
             let pred_wire = new_block_bldr.load_const(&predicate).unwrap();
             let new_block_hugr = new_block_bldr

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -1144,11 +1144,7 @@ mod test {
         // Second input of Xor from a constant
         let cst = h.add_op_with_parent(
             h.root(),
-            ops::Const::new(
-                ConstValue::Int { width: 1, value: 1 },
-                ClassicType::int::<1>(),
-            )
-            .unwrap(),
+            ops::Const::new(ConstValue::Int(1), ClassicType::int::<1>()).unwrap(),
         )?;
         let lcst = h.add_op_with_parent(
             h.root(),

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -808,7 +808,11 @@ mod test {
         parent: Node,
         predicate_size: usize,
     ) -> (Node, Node, Node, Node) {
-        let const_op = ops::Const::new(ConstValue::simple_predicate(0, predicate_size)).unwrap();
+        let const_op = ops::Const::new(
+            ConstValue::simple_predicate(0, predicate_size),
+            ClassicType::new_simple_predicate(predicate_size),
+        )
+        .unwrap();
         let tag_type = SimpleType::Classic(ClassicType::new_simple_predicate(predicate_size));
 
         let input = b
@@ -1140,7 +1144,11 @@ mod test {
         // Second input of Xor from a constant
         let cst = h.add_op_with_parent(
             h.root(),
-            ops::Const::new(ConstValue::Int { width: 1, value: 1 }).unwrap(),
+            ops::Const::new(
+                ConstValue::Int { width: 1, value: 1 },
+                ClassicType::int::<1>(),
+            )
+            .unwrap(),
         )?;
         let lcst = h.add_op_with_parent(
             h.root(),

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -808,11 +808,7 @@ mod test {
         parent: Node,
         predicate_size: usize,
     ) -> (Node, Node, Node, Node) {
-        let const_op = ops::Const::new(
-            ConstValue::simple_predicate(0, predicate_size),
-            ClassicType::new_simple_predicate(predicate_size),
-        )
-        .unwrap();
+        let const_op = ops::Const::simple_predicate(0, predicate_size);
         let tag_type = SimpleType::Classic(ClassicType::new_simple_predicate(predicate_size));
 
         let input = b

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -4,7 +4,6 @@ use std::any::Any;
 
 use crate::{
     classic_row,
-    hugr::typecheck::{typecheck_const, ConstTypeError},
     macros::impl_box_clone,
     types::{ClassicRow, ClassicType, Container, CustomType, EdgeKind, HashableType},
 };
@@ -15,6 +14,8 @@ use smol_str::SmolStr;
 use super::OpTag;
 use super::{OpName, OpTrait, StaticTag};
 
+pub mod typecheck;
+use typecheck::{typecheck_const, ConstTypeError};
 /// A constant value definition.
 #[derive(Debug, Clone, PartialEq, Default, serde::Serialize, serde::Deserialize)]
 pub struct Const(ConstValue);
@@ -220,12 +221,11 @@ impl_box_clone!(CustomConst, CustomConstBoxClone);
 
 #[cfg(test)]
 mod test {
+    use super::typecheck::ConstTypeError;
     use super::ConstValue;
     use crate::{
         builder::{BuildError, Container, DFGBuilder, Dataflow, DataflowHugr},
-        classic_row,
-        hugr::typecheck::ConstTypeError,
-        type_row,
+        classic_row, type_row,
         types::{ClassicType, SimpleRow, SimpleType},
     };
 

--- a/src/ops/constant/typecheck.rs
+++ b/src/ops/constant/typecheck.rs
@@ -117,12 +117,8 @@ fn map_vals<T: PrimType, T2: PrimType>(
 /// Typecheck a constant value
 pub(super) fn typecheck_const(typ: &ClassicType, val: &ConstValue) -> Result<(), ConstTypeError> {
     match (typ, val) {
-        (ClassicType::Hashable(HashableType::Int(exp_width)), ConstValue::Int { value, width }) => {
-            if exp_width == width {
-                check_int_fits_in_width(*value, *width).map_err(ConstTypeError::Int)
-            } else {
-                Err(ConstTypeError::IntWidthMismatch(*exp_width, *width))
-            }
+        (ClassicType::Hashable(HashableType::Int(exp_width)), ConstValue::Int(value)) => {
+            check_int_fits_in_width(*value, *exp_width).map_err(ConstTypeError::Int)
         }
         (ClassicType::F64, ConstValue::F64(_)) => Ok(()),
         (ty @ ClassicType::Container(c), tm) => match (c, tm) {
@@ -187,10 +183,6 @@ mod test {
     fn test_typecheck_const() {
         const INT: ClassicType = ClassicType::int::<64>();
         typecheck_const(&INT, &ConstValue::i64(3)).unwrap();
-        assert_eq!(
-            typecheck_const(&HashableType::Int(32).into(), &ConstValue::i64(3)),
-            Err(ConstTypeError::IntWidthMismatch(32, 64))
-        );
         typecheck_const(&ClassicType::F64, &ConstValue::F64(17.4)).unwrap();
         assert_eq!(
             typecheck_const(&ClassicType::F64, &ConstValue::i64(5)),

--- a/src/ops/constant/typecheck.rs
+++ b/src/ops/constant/typecheck.rs
@@ -5,7 +5,7 @@ use lazy_static::lazy_static;
 
 use std::collections::HashSet;
 
-use crate::hugr::*;
+use thiserror::Error;
 
 // For static typechecking
 use crate::ops::ConstValue;

--- a/src/ops/handle.rs
+++ b/src/ops/handle.rs
@@ -99,14 +99,7 @@ impl<const DEF: bool> AliasID<DEF> {
 
 #[derive(DerFrom, Debug, Clone, PartialEq, Eq)]
 /// Handle to a [Const](crate::ops::OpType::Const) node.
-pub struct ConstID(Node, ClassicType);
-
-impl ConstID {
-    /// Return the type of the constant.
-    pub fn const_type(&self) -> ClassicType {
-        self.1.clone()
-    }
-}
+pub struct ConstID(Node);
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, DerFrom, Debug)]
 /// Handle to a [BasicBlock](crate::ops::BasicBlock) node.

--- a/src/types/type_param.rs
+++ b/src/types/type_param.rs
@@ -6,7 +6,7 @@
 
 use thiserror::Error;
 
-use crate::hugr::typecheck::{check_int_fits_in_width, ConstIntError};
+use crate::ops::constant::typecheck::{check_int_fits_in_width, ConstIntError};
 use crate::ops::constant::HugrIntValueStore;
 
 use super::{simple::Container, ClassicType, HashableType, PrimType, SimpleType, TypeTag};


### PR DESCRIPTION
Partially addresses #318 , still need to add `CustomConst` checking

* new error variant where value doesn't check
* new constructor for Const
* specify const type when building

