### PR TITLE
Allow all Containers in TypeParam

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -23,6 +23,8 @@ use crate::hugr::{Direction, Port};
 use crate::utils::display_list;
 use crate::{resource::ResourceSet, type_row};
 
+mod serialize;
+
 /// The kinds of edges in a HUGR, excluding Hierarchy.
 //#[cfg_attr(feature = "pyo3", pyclass)] # TODO: Manually derive pyclass with non-unit variants
 #[derive(Clone, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]

--- a/src/types/type_param.rs
+++ b/src/types/type_param.rs
@@ -6,7 +6,7 @@
 
 use thiserror::Error;
 
-use crate::ops::constant::typecheck::{check_int_fits_in_width, ConstIntError};
+use crate::ops::constant::typecheck::ConstIntError;
 use crate::ops::constant::HugrIntValueStore;
 
 use super::{
@@ -76,6 +76,10 @@ impl TypeArg {
 
 /// Checks a [TypeArg] is as expected for a [TypeParam]
 pub fn check_type_arg(arg: &TypeArg, param: &TypeParam) -> Result<(), TypeArgError> {
+    let _ = arg;
+    let _ = param;
+    todo!();
+    /* Reinstate following checkable consts etc.
     match (arg, param) {
         (TypeArg::Type(_), TypeParam::Type) => Ok(()),
         (TypeArg::ClassicType(_), TypeParam::ClassicType) => Ok(()),
@@ -115,7 +119,7 @@ pub fn check_type_arg(arg: &TypeArg, param: &TypeParam) -> Result<(), TypeArgErr
             Container::Alias(n) => Err(TypeArgError::NoAliases(n.to_string())),
         },
         _ => Err(TypeArgError::TypeMismatch(arg.clone(), param.clone())),
-    }
+    }*/
 }
 
 /// Errors that can occur fitting a [TypeArg] into a [TypeParam]


### PR DESCRIPTION
This'll follow #322 (which itself will follow #321), as until that I've had to comment out the check_arg_fits_param method, but you can see the changes.

Serialization is now better separated from other concerns (it no longer uses/requires `PrimType` :-)). Is my `Deserialized` what you meant or is there a way to take that further still, e.g. were you thinking
```
enum SerContainer {
   Simple(Container<SimpleType>),
   Classic(Container<ClassicType>),
   Hashable(Container<HashableType>),
   TypeParam(Container<TypeParam>)
}

enum SerSimpleType {
   Ctr(SerContainer),
   // remove SerSimpleType::List,Array,Tuple,...
}
```
? (I'm not convinced this'll work with the `Container`->`Type` change but there may be something I'm missing)