### PR TITLE
[Refactor] struct CustomSerialized contains Yaml (+ CustomType)

### DIFF
--- a/src/extensions/rotation.rs
+++ b/src/extensions/rotation.rs
@@ -119,7 +119,7 @@ impl CustomConst for Constant {
         if &self_typ.custom_type() == typ {
             Ok(())
         } else {
-            Err(CustomCheckFail::new(
+            Err(CustomCheckFail::Message(
                 "Rotation constant type mismatch.".into(),
             ))
         }

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -139,7 +139,10 @@ pub enum ConstValue {
     Container(ContainerValue<ConstValue>),
     /// Double precision float
     F64(f64),
-    /// An opaque constant value, with cached type. TODO put this into ContainerValue.
+    /// An opaque constant value, that can check it is of a given [CustomType].
+    /// This may include values that are [hashable]
+    ///
+    /// [hashable]: crate::types::simple::TypeTag::Hashable
     // Note: the extra level of tupling is to avoid https://github.com/rust-lang/rust/issues/78808
     Opaque((Box<dyn CustomConst>,)),
 }

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -176,8 +176,6 @@ impl ValueOfType for ConstValue {
                         // A "hashable" value might be an instance of a non-hashable type:
                         // e.g. an empty list is hashable, yet can be checked against a classic element type!
                         if let HashableValue::Container(ctr) = hv {
-                            // Note if ctr is a ContainerValue<HashableValue>::Opaque, this means we can check that
-                            // against a Container<ClassicType>::Opaque, which is perhaps unnecessary, but harmless.
                             return ctr.map_vals(&ConstValue::Hashable).check_container(cty);
                         }
                     }

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -305,6 +305,27 @@ pub trait CustomConst:
 impl_downcast!(CustomConst);
 impl_box_clone!(CustomConst, CustomConstBoxClone);
 
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+struct CustomSerialized {
+    typ: CustomType,
+    value: serde_yaml::Value,
+}
+
+#[typetag::serde]
+impl CustomConst for CustomSerialized {
+    fn name(&self) -> SmolStr {
+        format!("yaml:{:?}", self.value).into()
+    }
+
+    fn check_custom_type(&self, typ: &CustomType) -> Result<(), CustomCheckFail> {
+        if &self.typ == typ {
+            Ok(())
+        } else {
+            Err(CustomCheckFail::TypeMismatch(typ.clone(), self.typ.clone()))
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use cool_asserts::assert_matches;

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -400,8 +400,7 @@ mod test {
             tuple_val2.check_type(&tuple_ty),
             Err(ConstTypeError::ValueCheckFail(ty, tv2)) => ty == tuple_ty && tv2 == tuple_val2
         );
-        let tuple_val3 =
-            ConstValue::sequence(&vec![V_INT, ConstValue::F64(3.3), ConstValue::F64(2.0)]);
+        let tuple_val3 = ConstValue::sequence(&[V_INT, ConstValue::F64(3.3), ConstValue::F64(2.0)]);
         assert_eq!(
             tuple_val3.check_type(&tuple_ty),
             Err(ConstTypeError::TupleWrongLength)

--- a/src/values.rs
+++ b/src/values.rs
@@ -94,7 +94,9 @@ impl ValueOfType for HashableValue {
 /// A value that is a container of other values, e.g. a tuple or sum;
 /// thus, corresponding to [Container]. Note there is no member
 /// corresponding to [Container::Alias]; such types must have been
-/// resolved to concrete types in order to create instances (values).
+/// resolved to concrete types in order to create instances (values),
+/// nor to [Container::Opaque], which is left to classes for broader
+/// sets of values (see e.g. [ConstValue::Opaque])
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum ContainerValue<T> {
     /// A [Container::Array] or [Container::Tuple] or [Container::List]
@@ -104,11 +106,6 @@ pub enum ContainerValue<T> {
     /// A [Container::Sum] - for any Sum type where this value meets
     /// the type of the variant indicated by the tag
     Sum(usize, Box<T>), // Tag and value
-    /// A value of a custom type defined by an extension/[Resource].
-    ///
-    /// [Resource]: crate::resource::Resource
-    // TODO replace this with CustomConst
-    Opaque(serde_yaml::Value),
 }
 
 impl<Elem: ValueOfType> ContainerValue<Elem> {
@@ -120,7 +117,6 @@ impl<Elem: ValueOfType> ContainerValue<Elem> {
             }
             ContainerValue::Map(_) => "a map".to_string(),
             ContainerValue::Sum(tag, val) => format!("const:sum:{{tag:{tag}, val:{}}}", val.name()),
-            ContainerValue::Opaque(c) => format!("const:yaml:{:?}", c),
         }
     }
     pub(crate) fn check_container(&self, ty: &Container<Elem::T>) -> Result<(), ConstTypeError> {
@@ -160,7 +156,6 @@ impl<Elem: ValueOfType> ContainerValue<Elem> {
             (ContainerValue::Sum(tag, value), Container::Sum(variants)) => {
                 value.check_type(variants.get(*tag).ok_or(ConstTypeError::InvalidSumTag)?)
             }
-            (ContainerValue::Opaque(_), Container::Opaque(_)) => Ok(()), // TODO
             (_, Container::Alias(s)) => Err(ConstTypeError::NoAliases(s.to_string())),
             (_, _) => Err(ValueOfType::container_error(ty.clone(), self.clone())),
         }
@@ -175,7 +170,6 @@ impl<Elem: ValueOfType> ContainerValue<Elem> {
             ContainerValue::Sum(tag, value) => {
                 ContainerValue::Sum(*tag, Box::new(f((**value).clone())))
             }
-            ContainerValue::Opaque(v) => ContainerValue::Opaque(v.clone()),
         }
     }
 }

--- a/src/values.rs
+++ b/src/values.rs
@@ -5,7 +5,7 @@
 
 use thiserror::Error;
 
-use crate::types::{ClassicType, Container, HashableType, PrimType};
+use crate::types::{ClassicType, Container, CustomType, HashableType, PrimType};
 use crate::{
     ops::constant::{
         typecheck::{check_int_fits_in_width, ConstIntError},
@@ -213,14 +213,13 @@ pub(crate) fn map_container_type<T: PrimType, T2: PrimType>(
 
 /// Struct for custom type check fails.
 #[derive(Clone, Debug, PartialEq, Error)]
-#[error("Error when checking custom type.")]
-pub struct CustomCheckFail(String);
-
-impl CustomCheckFail {
-    /// Creates a new [`CustomCheckFail`].
-    pub fn new(message: String) -> Self {
-        Self(message)
-    }
+pub enum CustomCheckFail {
+    /// The value had a specific type that was not what was expected
+    #[error("Expected type: {0} but value was of type: {1}")]
+    TypeMismatch(CustomType, CustomType),
+    /// Any other message
+    #[error("{0}")]
+    Message(String),
 }
 
 /// Errors that arise from typechecking constants
@@ -246,6 +245,6 @@ pub enum ConstTypeError {
     #[error("Value {1:?} does not match expected type {0}")]
     ValueCheckFail(ClassicType, ConstValue),
     /// Error when checking a custom value.
-    #[error("Custom value type check error: {0:?}")]
+    #[error("Error when checking custom type: {0:?}")]
     CustomCheckFail(#[from] CustomCheckFail),
 }


### PR DESCRIPTION
Tests in progress but see if this agrees with what you were thinking.

* Remove ContainerValue::Opaque (which previously contained YAML)
* Do not move ConstValue::Opaque into ContainerValue (rather, remove the TODO saying that). ContainerValue will be shared with TypeArg, so keep `dyn CustomConst` well away from that.