### PR TITLE
A few more Eq fixes

### DIFF
--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -450,5 +450,7 @@ mod test {
         let t: SimpleType = typ_float.clone().into();
         assert_matches!(val.check_type(&t.try_into().unwrap()),
             Err(ConstTypeError::CustomCheckFail(CustomCheckFail::TypeMismatch(a, b))) => a == typ_int && b == typ_float);
+
+        assert_eq!(val, val);
     }
 }

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -306,7 +306,9 @@ pub trait CustomConst:
 impl_downcast!(CustomConst);
 impl_box_clone!(CustomConst, CustomConstBoxClone);
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+// Don't derive Eq here - the yaml could contain floats etc.
+// (Perhaps we could derive Eq if-and-only-if "typ.tag() == TypeTag::Hashable"!)
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 struct CustomSerialized {
     typ: CustomType,
     value: serde_yaml::Value,
@@ -324,6 +326,10 @@ impl CustomConst for CustomSerialized {
         } else {
             Err(CustomCheckFail::TypeMismatch(typ.clone(), self.typ.clone()))
         }
+    }
+
+    fn equal_consts(&self, other: &dyn CustomConst) -> bool {
+        Some(self) == other.downcast_ref()
     }
 }
 

--- a/src/values.rs
+++ b/src/values.rs
@@ -16,7 +16,7 @@ use crate::{
 
 /// A constant value/instance of a [HashableType]. Note there is no
 /// equivalent of [HashableType::Variable]; we can't have instances of that.
-#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum HashableValue {
     /// A string, i.e. corresponding to [HashableType::String]
     String(String),
@@ -97,7 +97,7 @@ impl ValueOfType for HashableValue {
 /// resolved to concrete types in order to create instances (values),
 /// nor to [Container::Opaque], which is left to classes for broader
 /// sets of values (see e.g. [ConstValue::Opaque])
-#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum ContainerValue<T> {
     /// A [Container::Array] or [Container::Tuple] or [Container::List]
     Sequence(Vec<T>),


### PR DESCRIPTION
* HashableValue's are Eq, that's the whole point of them ;-)
* ContainerValue's can also be Eq if they contain things that are
* CustomSerialized probably should not be
* But, provide missing impl of `equal_const`