### PR TITLE
[bugfix] Check #TypeArgs == #TypeParams for TypeDefs as well as OpDefs

### DIFF
--- a/src/resource.rs
+++ b/src/resource.rs
@@ -194,6 +194,12 @@ trait TypeParametrised {
     fn resource(&self) -> Option<&ResourceId>;
     /// Check provided type arguments are valid against parameters.
     fn check_args_impl(&self, args: &[TypeArg]) -> Result<(), SignatureError> {
+        if args.len() != self.params().len() {
+            return Err(SignatureError::TypeArgMismatch(TypeArgError::WrongNumber(
+                args.len(),
+                self.params().len(),
+            )));
+        }
         for (a, p) in args.iter().zip(self.params().iter()) {
             check_type_arg(a, p).map_err(SignatureError::TypeArgMismatch)?;
         }
@@ -358,12 +364,6 @@ impl OpDef {
     /// Computes the signature of a node, i.e. an instantiation of this
     /// OpDef with statically-provided [TypeArg]s.
     pub fn compute_signature(&self, args: &[TypeArg]) -> Result<AbstractSignature, SignatureError> {
-        if args.len() != self.params.len() {
-            return Err(SignatureError::TypeArgMismatch(TypeArgError::WrongNumber(
-                args.len(),
-                self.params.len(),
-            )));
-        }
         self.check_args(args)?;
         let (ins, outs, res) = match &self.signature_func {
             SignatureFunc::FromYAML { .. } => {

--- a/src/types/type_param.rs
+++ b/src/types/type_param.rs
@@ -119,8 +119,8 @@ pub enum TypeArgError {
     // TODO It may become possible to combine this with ConstTypeError.
     #[error("Type argument {0:?} does not fit declared parameter {1:?}")]
     TypeMismatch(TypeArg, TypeParam),
-    /// Wrong number of type arguments.
-    // For now this only happens at the top level (TypeArgs of Op vs TypeParams of OpDef).
+    /// Wrong number of type arguments (actual vs expected).
+    // For now this only happens at the top level (TypeArgs of op/type vs TypeParams of Op/TypeDef).
     // However in the future it may be applicable to e.g. contents of Tuples too.
     #[error("Wrong number of type arguments: {0} vs expected {1} declared type parameters")]
     WrongNumber(usize, usize),


### PR DESCRIPTION
The code was in there, but seemingly in the wrong place. Not sure if my comment on `TypeArgError::WrongNumber` had mislead so I've corrected that ;)