### PR TITLE
[tests] Swap the order of case building in conditional test

### DIFF
--- a/src/builder/conditional.rs
+++ b/src/builder/conditional.rs
@@ -224,8 +224,8 @@ mod test {
         let mut conditional_b =
             ConditionalBuilder::new(predicate_inputs, type_row![NAT], type_row![NAT])?;
 
-        n_identity(conditional_b.case_builder(0)?)?;
         n_identity(conditional_b.case_builder(1)?)?;
+        n_identity(conditional_b.case_builder(0)?)?;
         Ok(())
     }
 


### PR DESCRIPTION
This should cover the code which checks for existing cases and maintains order (Line 124 of this file)