### PR TITLE
[refactor] DFGBuilder signature

### DIFF
--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 use crate::hugr::{HugrView, NodeType, ValidationError};
 use crate::ops;
 
-use crate::types::{AbstractSignature, Signature, SimpleRow};
+use crate::types::{AbstractSignature, Signature};
 
 use crate::resource::ResourceSet;
 use crate::Node;
@@ -81,13 +81,7 @@ impl DFGBuilder<Hugr> {
     /// # Errors
     ///
     /// Error in adding DFG child nodes.
-    pub fn new(
-        input: impl Into<SimpleRow>,
-        output: impl Into<SimpleRow>,
-    ) -> Result<DFGBuilder<Hugr>, BuildError> {
-        let input = input.into();
-        let output = output.into();
-        let signature = AbstractSignature::new_df(input, output);
+    pub fn new(signature: AbstractSignature) -> Result<DFGBuilder<Hugr>, BuildError> {
         let dfg_op = ops::DFG {
             signature: signature.clone(),
         };
@@ -403,7 +397,8 @@ mod test {
 
     #[test]
     fn dfg_hugr() -> Result<(), BuildError> {
-        let dfg_builder = DFGBuilder::new(type_row![BIT], type_row![BIT])?;
+        let dfg_builder =
+            DFGBuilder::new(AbstractSignature::new_df(type_row![BIT], type_row![BIT]))?;
 
         let [i1] = dfg_builder.input_wires_arr();
         let hugr = dfg_builder.finish_hugr_with_outputs([i1])?;
@@ -417,7 +412,8 @@ mod test {
     #[test]
     fn insert_hugr() -> Result<(), BuildError> {
         // Create a simple DFG
-        let mut dfg_builder = DFGBuilder::new(type_row![BIT], type_row![BIT])?;
+        let mut dfg_builder =
+            DFGBuilder::new(AbstractSignature::new_df(type_row![BIT], type_row![BIT]))?;
         let [i1] = dfg_builder.input_wires_arr();
         dfg_builder.set_metadata(json!(42));
         let dfg_hugr = dfg_builder.finish_hugr_with_outputs([i1])?;

--- a/src/hugr/rewrite/simple_replace.rs
+++ b/src/hugr/rewrite/simple_replace.rs
@@ -270,7 +270,10 @@ mod test {
     /// ┤ H ├┤ X ├
     /// └───┘└───┘
     fn make_dfg_hugr() -> Result<Hugr, BuildError> {
-        let mut dfg_builder = DFGBuilder::new(type_row![QB, QB], type_row![QB, QB])?;
+        let mut dfg_builder = DFGBuilder::new(AbstractSignature::new_df(
+            type_row![QB, QB],
+            type_row![QB, QB],
+        ))?;
         let [wire0, wire1] = dfg_builder.input_wires_arr();
         let wire2 = dfg_builder.add_dataflow_op(LeafOp::H, vec![wire0])?;
         let wire3 = dfg_builder.add_dataflow_op(LeafOp::H, vec![wire1])?;
@@ -285,7 +288,10 @@ mod test {
     /// ┤ H ├
     /// └───┘
     fn make_dfg_hugr2() -> Result<Hugr, BuildError> {
-        let mut dfg_builder = DFGBuilder::new(type_row![QB, QB], type_row![QB, QB])?;
+        let mut dfg_builder = DFGBuilder::new(AbstractSignature::new_df(
+            type_row![QB, QB],
+            type_row![QB, QB],
+        ))?;
         let [wire0, wire1] = dfg_builder.input_wires_arr();
         let wire2 = dfg_builder.add_dataflow_op(LeafOp::H, vec![wire1])?;
         let wire2out = wire2.outputs().exactly_one().unwrap();
@@ -460,7 +466,7 @@ mod test {
     #[test]
     fn test_replace_cx_cross() {
         let q_row: Vec<SimpleType> = vec![SimpleType::Qubit, SimpleType::Qubit];
-        let mut builder = DFGBuilder::new(q_row.clone(), q_row).unwrap();
+        let mut builder = DFGBuilder::new(AbstractSignature::new_df(q_row.clone(), q_row)).unwrap();
         let mut circ = builder.as_circuit(builder.input_wires().collect());
         circ.append(LeafOp::CX, [0, 1]).unwrap();
         circ.append(LeafOp::CX, [1, 0]).unwrap();
@@ -506,7 +512,8 @@ mod test {
         let one_bit: Vec<SimpleType> = vec![ClassicType::bit().into()];
         let two_bit: Vec<SimpleType> = vec![ClassicType::bit().into(), ClassicType::bit().into()];
 
-        let mut builder = DFGBuilder::new(one_bit.clone(), one_bit.clone()).unwrap();
+        let mut builder =
+            DFGBuilder::new(AbstractSignature::new_df(one_bit.clone(), one_bit.clone())).unwrap();
         let inw = builder.input_wires().exactly_one().unwrap();
         let outw = builder
             .add_dataflow_op(LeafOp::Xor, [inw, inw])
@@ -515,7 +522,7 @@ mod test {
         let [input, _] = builder.io();
         let mut h = builder.finish_hugr_with_outputs(outw).unwrap();
 
-        let mut builder = DFGBuilder::new(two_bit, one_bit).unwrap();
+        let mut builder = DFGBuilder::new(AbstractSignature::new_df(two_bit, one_bit)).unwrap();
         let inw = builder.input_wires();
         let outw = builder.add_dataflow_op(LeafOp::Xor, inw).unwrap().outputs();
         let [repl_input, repl_output] = builder.io();

--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -434,7 +434,7 @@ pub mod test {
     #[test]
     fn dfg_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
         let tp: Vec<SimpleType> = vec![ClassicType::bit().into(); 2];
-        let mut dfg = DFGBuilder::new(tp.clone(), tp)?;
+        let mut dfg = DFGBuilder::new(AbstractSignature::new_df(tp.clone(), tp))?;
         let mut params: [_; 2] = dfg.input_wires_arr();
         for p in params.iter_mut() {
             *p = dfg
@@ -462,7 +462,11 @@ pub mod test {
     #[test]
     fn hierarchy_order() {
         let qb = SimpleType::Qubit;
-        let dfg = DFGBuilder::new([qb.clone()].to_vec(), [qb.clone()].to_vec()).unwrap();
+        let dfg = DFGBuilder::new(AbstractSignature::new_df(
+            vec![qb.clone()],
+            vec![qb.clone()],
+        ))
+        .unwrap();
         let [old_in, out] = dfg.io();
         let w = dfg.input_wires();
         let mut hugr = dfg.finish_hugr_with_outputs(w).unwrap();

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -344,7 +344,10 @@ mod test {
         classic_row, type_row,
         types::simple::Container,
         types::type_param::TypeArg,
-        types::{ClassicType, CustomType, HashableType, SimpleRow, SimpleType, TypeTag},
+        types::{
+            AbstractSignature, ClassicType, CustomType, HashableType, SimpleRow, SimpleType,
+            TypeTag,
+        },
         values::{ConstTypeError, CustomCheckFail, HashableValue, ValueOfType},
     };
 
@@ -357,7 +360,10 @@ mod test {
         ];
         let pred_ty = SimpleType::new_predicate(pred_rows.clone());
 
-        let mut b = DFGBuilder::new(type_row![], SimpleRow::from(vec![pred_ty.clone()]))?;
+        let mut b = DFGBuilder::new(AbstractSignature::new_df(
+            type_row![],
+            SimpleRow::from(vec![pred_ty.clone()]),
+        ))?;
         let c = b.add_constant(Const::predicate(
             0,
             ConstValue::sequence(&[
@@ -369,7 +375,10 @@ mod test {
         let w = b.load_const(&c)?;
         b.finish_hugr_with_outputs([w]).unwrap();
 
-        let mut b = DFGBuilder::new(type_row![], SimpleRow::from(vec![pred_ty]))?;
+        let mut b = DFGBuilder::new(AbstractSignature::new_df(
+            type_row![],
+            SimpleRow::from(vec![pred_ty]),
+        ))?;
         let c = b.add_constant(Const::predicate(1, ConstValue::unit(), pred_rows)?)?;
         let w = b.load_const(&c)?;
         b.finish_hugr_with_outputs([w]).unwrap();


### PR DESCRIPTION
Make DFGBuilder take an AbstractSignature rather than a list of inputs and outputs. This allows us to use the builder to create a DFG which adds resource requirements.