### PR TITLE
[WIP] Start on making "Single" be an element of Container, SimpleType=Container<SimpleElem>

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -6,9 +6,9 @@ use thiserror::Error;
 use pyo3::prelude::*;
 
 use crate::hugr::{HugrError, Node, ValidationError, Wire};
+use crate::ops::constant::ConstTypeError;
 use crate::ops::handle::{BasicBlockID, CfgID, ConditionalID, DfgID, FuncID, TailLoopID};
 use crate::types::SimpleType;
-use crate::values::ConstTypeError;
 
 pub mod handle;
 pub use handle::BuildHandle;

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -2,6 +2,7 @@ use crate::hugr::validate::InterGraphEdgeError;
 use crate::hugr::view::HugrView;
 use crate::hugr::{Node, NodeMetadata, Port, ValidationError};
 use crate::ops::{self, LeafOp, OpTrait, OpType};
+use crate::types::simple::Tagged;
 
 use std::iter;
 
@@ -513,7 +514,7 @@ pub trait Dataflow: Container {
         values: impl IntoIterator<Item = Wire>,
     ) -> Result<Wire, BuildError> {
         let tuple = self.make_tuple(values)?;
-        let variants = ClassicRow::predicate_variants_row(predicate_variants).map_into();
+        let variants = ClassicRow::predicate_variants_row(predicate_variants).map_map_into();
         let make_op = self.add_dataflow_op(LeafOp::Tag { tag, variants }, vec![tuple])?;
         Ok(make_op.out_wire(0))
     }

--- a/src/builder/cfg.rs
+++ b/src/builder/cfg.rs
@@ -5,10 +5,10 @@ use super::{
     BasicBlockID, BuildError, CfgID, Container, Dataflow, HugrBuilder, Wire,
 };
 
-use crate::{hugr::view::HugrView, types::ClassicType};
 use crate::ops::handle::NodeHandle;
 use crate::ops::{self, BasicBlock, OpType};
 use crate::types::AbstractSignature;
+use crate::{hugr::view::HugrView, types::ClassicType};
 
 use crate::Node;
 use crate::{

--- a/src/builder/cfg.rs
+++ b/src/builder/cfg.rs
@@ -5,7 +5,7 @@ use super::{
     BasicBlockID, BuildError, CfgID, Container, Dataflow, HugrBuilder, Wire,
 };
 
-use crate::hugr::view::HugrView;
+use crate::{hugr::view::HugrView, types::ClassicType};
 use crate::ops::handle::NodeHandle;
 use crate::ops::{self, BasicBlock, OpType};
 use crate::types::AbstractSignature;
@@ -243,7 +243,7 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> BlockBuilder<B> {
         inputs: SimpleRow,
     ) -> Result<Self, BuildError> {
         // The node outputs a predicate before the data outputs of the block node
-        let predicate_type = SimpleType::new_predicate(predicate_variants);
+        let predicate_type = ClassicType::new_predicate(predicate_variants).map_into();
         let mut node_outputs = vec![predicate_type];
         node_outputs.extend_from_slice(&other_outputs);
         let signature = AbstractSignature::new_df(inputs, SimpleRow::from(node_outputs));

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -182,7 +182,7 @@ impl ValueOfType for ConstLeaf {
             }
             ConstLeaf::Hashable(hv) => {
                 if let ClassicElem::Hashable(ht) = ty {
-                    return hv.check_type(ht).map_err(|e|e.map_into());
+                    return hv.check_type(ht).map_err(|e| e.map_into());
                 }
             }
             ConstLeaf::Opaque((val,)) => {

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -130,7 +130,7 @@ pub(crate) type HugrIntWidthStore = u8;
 pub(crate) const HUGR_MAX_INT_WIDTH: HugrIntWidthStore =
     HugrIntValueStore::BITS as HugrIntWidthStore;
 
-/// Value constants. (This could be "ClassicValue" to parallel [HashableValue])
+/// Value constants. (This could be "ClassicLeaf" to parallel [HashableLeaf])
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[non_exhaustive]
 #[allow(missing_docs)]

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -344,7 +344,7 @@ mod test {
         ];
 
         let res = Const::predicate(0, ConstValue::sequence(&[]), pred_rows);
-        assert_matches!(res, Err(ConstTypeError::TupleWrongLength));
+        assert_matches!(res, Err(ConstTypeError::WrongNumber(_, _, _)));
     }
 
     #[test]
@@ -372,7 +372,7 @@ mod test {
         let tuple_val3 = ConstValue::sequence(&[V_INT, ConstValue::F64(3.3), ConstValue::F64(2.0)]);
         assert_eq!(
             tuple_val3.check_type(&tuple_ty),
-            Err(ConstTypeError::TupleWrongLength)
+            Err(ConstTypeError::WrongNumber(_, _, _))
         );
     }
 

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -11,8 +11,7 @@ use smol_str::SmolStr;
 use thiserror::Error;
 
 use crate::ops::custom::OpaqueOp;
-use crate::types::type_param::{check_type_arg, TypeArgError};
-use crate::types::type_param::{TypeArg, TypeParam};
+use crate::types::type_param::{TypeArg, TypeArgError, TypeParam};
 use crate::types::CustomType;
 
 mod opdef;
@@ -89,7 +88,7 @@ trait TypeParametrised {
             )));
         }
         for (a, p) in args.iter().zip(self.params().iter()) {
-            check_type_arg(a, p).map_err(SignatureError::TypeArgMismatch)?;
+            a.check_type(p).map_err(SignatureError::TypeArgMismatch)?;
         }
         Ok(())
     }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -13,6 +13,7 @@ use thiserror::Error;
 use crate::ops::custom::OpaqueOp;
 use crate::types::type_param::{TypeArg, TypeArgError, TypeParam};
 use crate::types::CustomType;
+use crate::values::ValueOfType;
 
 mod opdef;
 pub use opdef::{CustomSignatureFunc, OpDef};
@@ -21,7 +22,7 @@ pub use type_def::{TypeDef, TypeDefTag};
 
 /// An error that can occur in computing the signature of a node.
 /// TODO: decide on failure modes
-#[derive(Debug, Clone, Error, PartialEq, Eq)]
+#[derive(Debug, Clone, Error, PartialEq)]
 pub enum SignatureError {
     /// Name mismatch
     #[error("Definition name ({0}) and instantiation name ({1}) do not match.")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -21,6 +21,7 @@ use delegate::delegate;
 use smol_str::SmolStr;
 
 use crate::hugr::{Direction, Port};
+use crate::types::simple::Tagged;
 use crate::utils::display_list;
 use crate::{resource::ResourceSet, type_row};
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -24,6 +24,8 @@ use crate::hugr::{Direction, Port};
 use crate::utils::display_list;
 use crate::{resource::ResourceSet, type_row};
 
+use self::type_row::TypeRowElem;
+
 /// The kinds of edges in a HUGR, excluding Hierarchy.
 //#[cfg_attr(feature = "pyo3", pyclass)] # TODO: Manually derive pyclass with non-unit variants
 #[derive(Clone, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
@@ -402,7 +404,7 @@ impl SignatureDescription {
         }
     }
 
-    fn row_zip<'a, T: PrimType>(
+    fn row_zip<'a, T: TypeRowElem>(
         type_row: &'a TypeRow<T>,
         name_row: &'a [SmolStr],
     ) -> impl Iterator<Item = (&'a SmolStr, &'a T)> {

--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -31,8 +31,8 @@ mod serialize;
 impl Display for SimpleElem {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            SimpleType::Classic(ty) => ty.fmt(f),
-            SimpleType::Qubit => f.write_str("Qubit"),
+            SimpleElem::Classic(ty) => ty.fmt(f),
+            SimpleElem::Qubit => f.write_str("Qubit"),
         }
     }
 }
@@ -186,6 +186,12 @@ pub enum ClassicElem {
     Graph(Box<AbstractSignature>),
     /// A type which can be hashed
     Hashable(HashableElem),
+}
+
+impl From<HashableElem> for ClassicElem {
+    fn from(value: HashableElem) -> Self {
+        Self::Hashable(value)
+    }
 }
 
 /// A type that represents concrete classical data that supports hashing

--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -102,19 +102,6 @@ pub enum Container<T: PrimType> {
 impl<T: PrimType> TypeRowElem for Container<T> {}
 
 impl<T: PrimType> Container<T> {
-    fn all(&self, f: impl Fn(&T) -> bool) -> bool {
-        match self {
-            Container::Single(e) => f(&*e),
-            Container::List(e) => e.all(f),
-            Container::Map(kv) => kv.1.all(f),
-            Container::Tuple(r) => (*r).iter().all(|c| c.all(f)),
-            Container::Sum(r) => (*r).iter().all(|c| c.all(f)),
-            Container::Array(e, _) => e.all(f),
-            Container::Alias(_) => todo!(),
-            Container::Opaque(_) => todo!(),
-        }
-    }
-
     // TODO there must be a good way to publish this. 'impl From` seems conflicting :-(
     pub(crate) fn map_into<T2: PrimType>(self) -> Container<T2>
     where
@@ -234,7 +221,7 @@ impl Display for ClassicElem {
                 write!(f, "[{:?}]", sig.resource_reqs)?;
                 sig.fmt(f)
             }
-            ClassicElem::Hashable(h) => h.fmt(f)
+            ClassicElem::Hashable(h) => h.fmt(f),
         }
     }
 }
@@ -347,7 +334,7 @@ impl SimpleElem {
 impl SimpleType {
     /// Returns whether the type contains only classic data.
     pub fn is_classical(&self) -> bool {
-        self.all(|e| e.is_classical())
+        self.tag().is_classical()
     }
 }
 

--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -53,7 +53,7 @@ impl TypeTag {
     }
 }
 
-trait Tagged {
+pub trait Tagged {
     /// Tells us the [TypeTag] of the type represented by the receiver.
     fn tag(&self) -> TypeTag;
 }
@@ -115,7 +115,8 @@ impl<T: PrimType> Container<T> {
         }
     }
 
-    fn map_into<T2: PrimType>(self) -> Container<T2>
+    // TODO there must be a good way to publish this. 'impl From` seems conflicting :-(
+    pub(crate) fn map_into<T2: PrimType>(self) -> Container<T2>
     where
         T2: From<T>,
     {

--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -124,11 +124,11 @@ impl<T: PrimType> Container<T> {
         }
     }
 
-    fn new_tuple(elems: impl Into<TypeRow<Container<T>>>) -> Self {
+    pub fn new_tuple(elems: impl Into<TypeRow<Container<T>>>) -> Self {
         Self::Tuple(Box::new(elems.into()))
     }
 
-    fn new_sum(elems: impl Into<TypeRow<Container<T>>>) -> Self {
+    pub fn new_sum(elems: impl Into<TypeRow<Container<T>>>) -> Self {
         Self::Sum(Box::new(elems.into()))
     }
 }

--- a/src/types/type_param.rs
+++ b/src/types/type_param.rs
@@ -4,13 +4,11 @@
 //!
 //! [`TypeDef`]: crate::resource::TypeDef
 
-use crate::ops::constant::typecheck::check_int_fits_in_width;
-use crate::ops::constant::HugrIntValueStore;
 use crate::values::{HashableLeaf, ValueError, ValueOfType};
 
-use super::CustomType;
 use super::simple::{HashableElem, Tagged};
-use super::{simple::Container, ClassicType, HashableType, PrimType, SimpleType, TypeTag};
+use super::CustomType;
+use super::{ClassicType, HashableType, SimpleType, TypeTag};
 
 /// A parameter declared by an OpDef. Specifies a value
 /// that must be provided by each operation node.
@@ -28,6 +26,7 @@ pub enum TypeParam {
     /// Node must provide a [TypeArg::List] (of whatever length)
     /// TODO it'd be better to use [`Container`] here, or a variant thereof
     /// (plus List minus Array).
+    ///
     /// [`Container`]: crate::types::simple::Container
     List(Box<TypeParam>),
     /// Equivalent to [Container::Custom] (since we are not using [Container] here)

--- a/src/types/type_param.rs
+++ b/src/types/type_param.rs
@@ -103,7 +103,9 @@ impl ValueOfType for TypeArg {
                 Ok(())
             }
             (TypeArg::CustomValue(v), TypeParam::CustomValue(ct)) => Ok(()), // TODO more checks here, e.g. storing CustomType in the value
-            (TypeArg::Value(h_v), TypeParam::Value(h_t)) => h_v.check_type(h_t).map_err(|e|e.map_into()),
+            (TypeArg::Value(h_v), TypeParam::Value(h_t)) => {
+                h_v.check_type(h_t).map_err(|e| e.map_into())
+            }
             (_, _) => Err(TypeArgError::ValueCheckFail(param.clone(), self.clone())),
         }
     }

--- a/src/types/type_param.rs
+++ b/src/types/type_param.rs
@@ -103,7 +103,7 @@ impl ValueOfType for TypeArg {
             }
             (TypeArg::List(items), TypeParam::Value(Container::Array(elem, sz))) => {
                 if items.len() != *sz {
-                    return Err(ValueError::WrongNumber(items.len(), *sz));
+                    return Err(ValueError::WrongNumber("array elements", items.len(), *sz));
                 }
                 let elem_ty = TypeParam::Value((**elem));
                 for item in items {
@@ -113,7 +113,11 @@ impl ValueOfType for TypeArg {
             }
             (TypeArg::List(items), TypeParam::Value(Container::Tuple(tys))) => {
                 if items.len() != tys.len() {
-                    return Err(ValueError::WrongNumber(items.len(), tys.len()));
+                    return Err(ValueError::WrongNumber(
+                        "tuple elements",
+                        items.len(),
+                        tys.len(),
+                    ));
                 }
                 for (i, t) in items.iter().zip(tys) {
                     i.check_type(&TypeParam::Value(t))?;

--- a/src/types/type_param.rs
+++ b/src/types/type_param.rs
@@ -9,7 +9,7 @@ use crate::ops::constant::HugrIntValueStore;
 use crate::values::{ValueError, ValueOfType};
 
 use super::simple::{HashableElem, Tagged};
-use super::{simple::Container, ClassicType, HashableType, PrimType, SimpleType, TypeTag};
+use super::{simple::Container, ClassicType, HashableType, SimpleType, TypeTag};
 
 /// A parameter declared by an OpDef. Specifies a value
 /// that must be provided by each operation node.
@@ -105,7 +105,7 @@ impl ValueOfType for TypeArg {
                 if items.len() != *sz {
                     return Err(ValueError::WrongNumber("array elements", items.len(), *sz));
                 }
-                let elem_ty = TypeParam::Value((**elem));
+                let elem_ty = TypeParam::Value(**elem);
                 for item in items {
                     item.check_type(&elem_ty)?;
                 }
@@ -119,8 +119,8 @@ impl ValueOfType for TypeArg {
                         tys.len(),
                     ));
                 }
-                for (i, t) in items.iter().zip(tys) {
-                    i.check_type(&TypeParam::Value(t))?;
+                for (i, t) in items.iter().zip(tys.iter()) {
+                    i.check_type(&TypeParam::Value(*t))?;
                 }
                 Ok(())
             }

--- a/src/types/type_param.rs
+++ b/src/types/type_param.rs
@@ -25,9 +25,8 @@ pub enum TypeParam {
     /// Argument is a [TypeArg::HashableType]
     HashableType,
     /// Node must provide a [TypeArg::List] (of whatever length)
-    /// TODO it'd be better to use [`Container`] here.
-    ///
-    /// [`Container`]: crate::types::simple::Container
+    /// TODO add missing [Container]-equivalents: Tuple+Sum (no Array,
+    /// but keep List even when that's dropped from Container)
     List(Box<TypeParam>),
     /// Argument is a value of the specified type.
     /// TODO It'd be better to use HashableLeaf with a better notion of Container.

--- a/src/types/type_row.rs
+++ b/src/types/type_row.rs
@@ -12,8 +12,6 @@ use crate::utils::display_list;
 /// Base trait for anything that can be put in a [TypeRow]
 pub trait TypeRowElem: Clone + 'static {}
 
-impl<T: Clone + 'static> TypeRowElem for T {}
-
 /// List of types, used for function signatures.
 #[derive(Clone, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
 //#[cfg_attr(feature = "pyo3", pyclass)] // TODO: expose unparameterized versions


### PR DESCRIPTION
* Think I've got the biggest five files compiling (simple, constant, values, type_param, serialize - i.e. the implementation). The rest should mostly just be clients, which might be best solved by adding utility methods like `SimpleType::int` (=> `Container::Single(SimpleElem::Classic(ClassicElem::Hashable(HashableElem::Int(w))))`)
* Not at all sure about deserialization, nor about the TAG's written out in serialization - see comments
* Need to standardize naming, I'm using "Elem" for things implementing PrimType (they should probably be "Prim"s) and "Leaf" for corresponding Values (they might want to be "Elem"!)
* Not sharing much code between type_param and simple, but type_param is currently using HashableType, it should probably only use HashableLeaf (which will be, what, "Int" ?)
* Parameterized ConstTypeError and TypeArgError as aliases of combined ValueError, this works well
* `map_vals` etc. preserved but used only for mapping error types (!). I've generally tried to make these as `map_into` and I'd like to just have `impl<T, T2: Into<T>> From<Container<T2>> for Container<T>` but every type is `Into` of itself (a blanket impl in the standard library), so that allows instantiation with `T` == `T2` which is therefore the identity `From` which conflicts with said blanket impl! I don't know how to turn this off, maybe you / @aborgna-q can see a better way
* I took a slightly different approach to `TypeRowElem` vs `PrimType` - rather than a blanket impl of `TypeRowElem` for anything `Clone + 'static` I've explicitly implemented it only for things I want to put in a TypeRow, i.e. `SerSimpleType` and `Container<T>` (where `T: PrimType` - but `PrimType` no longer requires `TypeRowElem`). That is, `PrimType` is sealed and just `ClassicElem`, `SimpleElem` and `HashableElem`; whereas `TypeRowElem` *could* be implemented by everything but I'm using it as a marker for the things that I actually want to make rows of. (This spotted a few erroneous `TypeRow<ClassicElem>` etc. that I had missed.)