### PR TITLE
[RFC] Allow linear Constants

### DIFF
--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -15,7 +15,7 @@ use pyo3::prelude::*;
 use crate::ops::validate::{ChildrenEdgeData, ChildrenValidationError, EdgeValidationError};
 use crate::ops::{OpTag, OpTrait, OpType, ValidateOp};
 use crate::resource::ResourceSet;
-use crate::types::{ClassicType, EdgeKind, SimpleType};
+use crate::types::{EdgeKind, SimpleType};
 use crate::{Direction, Hugr, Node, Port};
 
 use super::hierarchical_views::{HierarchyView, SiblingGraph};
@@ -734,7 +734,7 @@ pub enum InterGraphEdgeError {
     InvalidConstSrc {
         from: Node,
         from_offset: Port,
-        typ: ClassicType,
+        typ: SimpleType,
     },
 }
 
@@ -1149,7 +1149,7 @@ mod test {
         let lcst = h.add_op_with_parent(
             h.root(),
             ops::LoadConstant {
-                datatype: ClassicType::int::<1>(),
+                datatype: SimpleType::int::<1>(),
             },
         )?;
         h.connect(cst, 0, lcst, 0)?;

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -823,12 +823,7 @@ mod test {
             .unwrap();
         let tag_def = b.add_op_with_parent(b.root(), const_op).unwrap();
         let tag = b
-            .add_op_with_parent(
-                parent,
-                ops::LoadConstant {
-                    datatype: tag_type.try_into().unwrap(),
-                },
-            )
+            .add_op_with_parent(parent, ops::LoadConstant { datatype: tag_type })
             .unwrap();
 
         b.connect(tag_def, 0, tag, 0).unwrap();

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -464,7 +464,7 @@ mod test {
             TypeTag::Hashable,
         );
         let t: SimpleType = typ_qb.clone().into();
-        assert_matches!(val.check_type(&t.try_into().unwrap()),
+        assert_matches!(val.check_type(&t),
             Err(ConstTypeError::CustomCheckFail(CustomCheckFail::TypeMismatch(a, b))) => a == typ_int && b == typ_qb);
 
         assert_eq!(val, val);

--- a/src/ops/dataflow.rs
+++ b/src/ops/dataflow.rs
@@ -146,7 +146,7 @@ impl DataflowOpTrait for Call {
 
     fn signature(&self) -> AbstractSignature {
         AbstractSignature {
-            static_input: vec![ClassicType::graph_from_sig(self.signature.clone())].into(),
+            static_input: vec![ClassicType::graph_from_sig(self.signature.clone()).into()].into(),
             ..self.signature.clone()
         }
     }
@@ -181,7 +181,7 @@ impl DataflowOpTrait for CallIndirect {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct LoadConstant {
     /// Constant type
-    pub datatype: ClassicType,
+    pub datatype: SimpleType,
 }
 impl_op_name!(LoadConstant);
 impl DataflowOpTrait for LoadConstant {
@@ -194,7 +194,7 @@ impl DataflowOpTrait for LoadConstant {
     fn signature(&self) -> AbstractSignature {
         AbstractSignature::new(
             SimpleRow::new(),
-            vec![SimpleType::Classic(self.datatype.clone())],
+            vec![self.datatype.clone()],
             vec![self.datatype.clone()],
         )
     }

--- a/src/ops/module.rs
+++ b/src/ops/module.rs
@@ -53,9 +53,9 @@ impl OpTrait for FuncDefn {
     }
 
     fn other_output(&self) -> Option<EdgeKind> {
-        Some(EdgeKind::Static(ClassicType::graph_from_sig(
-            self.signature.clone(),
-        )))
+        Some(EdgeKind::Static(
+            ClassicType::graph_from_sig(self.signature.clone()).into(),
+        ))
     }
 }
 
@@ -82,9 +82,9 @@ impl OpTrait for FuncDecl {
     }
 
     fn other_output(&self) -> Option<EdgeKind> {
-        Some(EdgeKind::Static(ClassicType::graph_from_sig(
-            self.signature.clone(),
-        )))
+        Some(EdgeKind::Static(
+            ClassicType::graph_from_sig(self.signature.clone()).into(),
+        ))
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -34,7 +34,7 @@ pub enum EdgeKind {
     /// Data edges of a DDG region, also known as "wires".
     Value(SimpleType),
     /// A reference to a static value definition.
-    Static(ClassicType),
+    Static(SimpleType),
     /// Explicitly enforce an ordering between nodes in a DDG.
     StateOrder,
 }
@@ -59,7 +59,7 @@ pub struct AbstractSignature {
     /// Value outputs of the function.
     pub output: SimpleRow,
     /// Possible static input (for call / load-constant).
-    pub static_input: ClassicRow,
+    pub static_input: SimpleRow,
     /// The resource requirements which are added by the operation
     pub resource_reqs: ResourceSet,
 }
@@ -78,7 +78,7 @@ impl AbstractSignature {
     pub fn new(
         input: impl Into<SimpleRow>,
         output: impl Into<SimpleRow>,
-        static_input: impl Into<ClassicRow>,
+        static_input: impl Into<SimpleRow>,
     ) -> Self {
         Self {
             input: input.into(),
@@ -241,7 +241,7 @@ impl AbstractSignature {
 
     #[inline]
     /// Returns the row of static inputs
-    pub fn static_input(&self) -> &ClassicRow {
+    pub fn static_input(&self) -> &SimpleRow {
         &self.static_input
     }
 }
@@ -318,7 +318,7 @@ impl Signature {
             /// Outputs of the abstract signature
             pub fn output(&self) -> &SimpleRow;
             /// Static inputs of the abstract signature
-            pub fn static_input(&self) -> &ClassicRow;
+            pub fn static_input(&self) -> &SimpleRow;
         }
     }
 }
@@ -438,7 +438,7 @@ impl SignatureDescription {
     pub fn static_input_zip<'a>(
         &'a self,
         signature: &'a Signature,
-    ) -> impl Iterator<Item = (&SmolStr, &ClassicType)> {
+    ) -> impl Iterator<Item = (&SmolStr, &SimpleType)> {
         Self::row_zip(signature.static_input(), &self.static_input)
     }
 }

--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -367,6 +367,12 @@ impl SimpleType {
     pub fn new_simple_predicate(size: usize) -> Self {
         Self::Classic(ClassicType::new_simple_predicate(size))
     }
+
+    /// Returns a new integer type with the given number of bits.
+    #[inline]
+    pub const fn int<const N: HugrIntWidthStore>() -> Self {
+        Self::Classic(ClassicType::int::<N>())
+    }
 }
 
 impl From<ClassicType> for SimpleType {

--- a/src/values.rs
+++ b/src/values.rs
@@ -6,7 +6,7 @@
 use thiserror::Error;
 
 use crate::ops::constant::{HugrIntWidthStore, HUGR_MAX_INT_WIDTH};
-use crate::types::{ClassicType, Container, CustomType, HashableType, PrimType};
+use crate::types::{Container, CustomType, HashableType, PrimType, SimpleType};
 use crate::{
     ops::constant::{ConstValue, HugrIntValueStore},
     types::TypeRow,
@@ -73,7 +73,7 @@ impl ValueOfType for HashableValue {
             }
         }
         Err(ConstTypeError::ValueCheckFail(
-            ClassicType::Hashable(ty.clone()),
+            ty.clone().into(),
             ConstValue::Hashable(self.clone()),
         ))
     }
@@ -83,7 +83,7 @@ impl ValueOfType for HashableValue {
         vals: ContainerValue<HashableValue>,
     ) -> ConstTypeError {
         ConstTypeError::ValueCheckFail(
-            ClassicType::Hashable(HashableType::Container(typ)),
+            HashableType::Container(typ).into(),
             ConstValue::Hashable(HashableValue::Container(vals)),
         )
     }
@@ -284,7 +284,7 @@ pub enum ConstTypeError {
     InvalidSumTag,
     /// A mismatch between the type expected and the value.
     #[error("Value {1:?} does not match expected type {0}")]
-    ValueCheckFail(ClassicType, ConstValue),
+    ValueCheckFail(SimpleType, ConstValue),
     /// Error when checking a custom value.
     #[error("Error when checking custom type: {0:?}")]
     CustomCheckFail(#[from] CustomCheckFail),


### PR DESCRIPTION
There are two things I dislike about this.

Firstly, that the maze of `SimpleType::Qontainer` of `SimpleType::Classic` of `ClassicType::Container` of .... just got worse. That is what much of #363 is aiming to fix, so we might want to wait for that.

Secondly, I've changed `static_input` from ClassicType to SimpleType too (as required), but wtf happens with EdgeKind::Static now. Do we enforce linearity of linear-typed *static* edges? See discussion #368