### PR TITLE
[new] Validate IO nodes have resources matching parent signatures

### DIFF
--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -709,7 +709,7 @@ pub enum ValidationError {
     },
     #[error("Missing input resources for node {0:?}")]
     MissingInputResources(Node),
-    #[error("IO nodes don't match parent signature")]
+    #[error("Resources of I/O node ({child:?}) {child_resources:?} don't match those expected by parent node ({parent:?}): {parent_resources:?}")]
     ParentIOResourceMismatch {
         parent: Node,
         parent_resources: ResourceSet,

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -70,9 +70,6 @@ impl<'a> ValidationContext<'a> {
             self.validate_node(node)?;
         }
 
-        // Check that io nodes match their parents' signatures
-        self.validate_io_resources(self.hugr, self.hugr.root())?;
-
         Ok(())
     }
 
@@ -109,9 +106,6 @@ impl<'a> ValidationContext<'a> {
                 };
             }
         };
-        for node in hugr.children(parent) {
-            self.validate_io_resources(hugr, node)?;
-        }
         Ok(())
     }
 
@@ -202,6 +196,10 @@ impl<'a> ValidationContext<'a> {
 
         // Check operation-specific constraints
         self.validate_operation(node, op_type)?;
+
+        // If this is a DataflowParent, check that the I/O nodes
+        // match the parent's signature
+        self.validate_io_resources(&self.hugr, node)?;
 
         Ok(())
     }


### PR DESCRIPTION
Add a validation check that dataflow graph's input and output nodes have the same resource requirements as the incoming/outgoing wires of the parent.