### PR TITLE
Remove f64

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -96,7 +96,6 @@ mod test {
     use super::{DataflowSubContainer, HugrBuilder};
 
     pub(super) const NAT: SimpleType = SimpleType::Classic(ClassicType::i64());
-    pub(super) const F64: SimpleType = SimpleType::Classic(ClassicType::F64);
     pub(super) const BIT: SimpleType = SimpleType::Classic(ClassicType::bit());
     pub(super) const QB: SimpleType = SimpleType::Qubit;
 

--- a/src/builder/circuit.rs
+++ b/src/builder/circuit.rs
@@ -139,7 +139,7 @@ mod test {
             test::{build_main, BIT, F64, QB},
             Dataflow, DataflowSubContainer, Wire,
         },
-        ops::LeafOp,
+        ops::{custom::OpaqueOp, LeafOp},
         type_row,
         types::AbstractSignature,
     };
@@ -173,6 +173,13 @@ mod test {
 
     #[test]
     fn with_nonlinear_and_outputs() {
+        let my_custom_op = LeafOp::CustomOp(crate::ops::custom::ExternalOp::Opaque(OpaqueOp::new(
+            "MissingRsrc".into(),
+            "MyOp",
+            "unknown op".to_string(),
+            vec![],
+            Some(AbstractSignature::new(vec![QB, F64], vec![QB], vec![])),
+        )));
         let build_res = build_main(
             AbstractSignature::new_df(type_row![QB, QB, F64], type_row![QB, QB, BIT]).pure(),
             |mut f_build| {
@@ -183,7 +190,7 @@ mod test {
                 let measure_out = linear
                     .append(LeafOp::CX, [0, 1])?
                     .append_and_consume(
-                        LeafOp::RzF64,
+                        my_custom_op,
                         [CircuitUnit::Linear(0), CircuitUnit::Wire(angle)],
                     )?
                     .append_with_outputs(LeafOp::Measure, [0])?;

--- a/src/builder/circuit.rs
+++ b/src/builder/circuit.rs
@@ -136,7 +136,7 @@ mod test {
 
     use crate::{
         builder::{
-            test::{build_main, BIT, F64, QB},
+            test::{build_main, BIT, NAT, QB},
             Dataflow, DataflowSubContainer, Wire,
         },
         ops::{custom::OpaqueOp, LeafOp},
@@ -178,10 +178,10 @@ mod test {
             "MyOp",
             "unknown op".to_string(),
             vec![],
-            Some(AbstractSignature::new(vec![QB, F64], vec![QB], vec![])),
+            Some(AbstractSignature::new(vec![QB, NAT], vec![QB], vec![])),
         )));
         let build_res = build_main(
-            AbstractSignature::new_df(type_row![QB, QB, F64], type_row![QB, QB, BIT]).pure(),
+            AbstractSignature::new_df(type_row![QB, QB, NAT], type_row![QB, QB, BIT]).pure(),
             |mut f_build| {
                 let [q0, q1, angle]: [Wire; 3] = f_build.input_wires_arr();
 

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -748,7 +748,7 @@ mod test {
     use crate::hugr::{HugrError, HugrMut, NodeType};
     use crate::ops::dataflow::IOTrait;
     use crate::ops::{self, LeafOp, OpType};
-    use crate::types::{AbstractSignature, ClassicType};
+    use crate::types::{AbstractSignature, ClassicType, HashableType};
     use crate::Direction;
     use crate::{type_row, Node};
 
@@ -876,7 +876,7 @@ mod test {
     #[test]
     fn leaf_root() {
         let leaf_op: OpType = LeafOp::Noop {
-            ty: ClassicType::F64.into(),
+            ty: HashableType::Int(32).into(),
         }
         .into();
 

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -379,10 +379,7 @@ mod test {
 
     #[test]
     fn test_bad_predicate() {
-        let pred_rows = vec![
-            classic_row![ClassicType::i64(), ClassicType::F64],
-            type_row![],
-        ];
+        let pred_rows = vec![classic_row![ClassicType::i64(), CLASSIC_T], type_row![]];
 
         let res = Const::predicate(0, ConstValue::sequence(&[]), pred_rows);
         assert_matches!(res, Err(ConstTypeError::TupleWrongLength));
@@ -399,8 +396,8 @@ mod test {
         );
         custom_value(17.4).check_type(&CLASSIC_T).unwrap();
         assert_matches!(
-            V_INT.check_type(&ClassicType::F64),
-            Err(ConstTypeError::ValueCheckFail(ClassicType::F64, v)) => v == V_INT
+            V_INT.check_type(&CLASSIC_T),
+            Err(ConstTypeError::ValueCheckFail(t, v)) => t == CLASSIC_T && v == V_INT
         );
         let tuple_ty = ClassicType::new_tuple(classic_row![T_INT, CLASSIC_T]);
         let tuple_val = ConstValue::sequence(&[V_INT, custom_value(5.1)]);

--- a/src/ops/leaf.rs
+++ b/src/ops/leaf.rs
@@ -49,8 +49,6 @@ pub enum LeafOp {
     },
     /// A qubit measurement operation.
     Measure,
-    /// A rotation of a qubit about the Pauli Z axis by an input float angle.
-    RzF64,
     /// A bitwise XOR operation.
     Xor,
     /// An operation that packs all its inputs into a tuple.
@@ -109,7 +107,6 @@ impl OpName for LeafOp {
             LeafOp::MakeTuple { tys: _ } => "MakeTuple",
             LeafOp::UnpackTuple { tys: _ } => "UnpackTuple",
             LeafOp::Tag { .. } => "Tag",
-            LeafOp::RzF64 => "RzF64",
             LeafOp::Lift { .. } => "Lift",
         }
         .into()
@@ -142,7 +139,6 @@ impl OpTrait for LeafOp {
             LeafOp::MakeTuple { tys: _ } => "MakeTuple operation",
             LeafOp::UnpackTuple { tys: _ } => "UnpackTuple operation",
             LeafOp::Tag { .. } => "Tag Sum operation",
-            LeafOp::RzF64 => "Rz rotation.",
             LeafOp::Lift { .. } => "Add a resource requirement to an edge",
         }
     }
@@ -157,7 +153,6 @@ impl OpTrait for LeafOp {
         // copy-on-write strategy, so we can avoid unnecessary allocations.
         const Q: SimpleType = SimpleType::Qubit;
         const B: SimpleType = SimpleType::Classic(ClassicType::bit());
-        const F: SimpleType = SimpleType::Classic(ClassicType::F64);
 
         match self {
             LeafOp::Noop { ty: typ } => {
@@ -186,7 +181,6 @@ impl OpTrait for LeafOp {
                 vec![variants.get(*tag).expect("Not a valid tag").clone()],
                 vec![SimpleType::new_sum(variants.clone())],
             ),
-            LeafOp::RzF64 => AbstractSignature::new_df(type_row![Q, F], type_row![Q]),
             LeafOp::Lift {
                 type_row,
                 new_resource,

--- a/src/resource/type_def.rs
+++ b/src/resource/type_def.rs
@@ -149,6 +149,7 @@ impl Resource {
 #[cfg(test)]
 mod test {
     use crate::resource::SignatureError;
+    use crate::types::custom::test::CLASSIC_T;
     use crate::types::type_param::{TypeArg, TypeArgError, TypeParam};
     use crate::types::{
         AbstractSignature, ClassicType, HashableType, PrimType, SimpleType, TypeTag,
@@ -194,8 +195,8 @@ mod test {
         // Too many arguments:
         assert_eq!(
             def.instantiate_concrete([
-                TypeArg::Type(ClassicType::F64.into()),
-                TypeArg::Type(ClassicType::F64.into()),
+                TypeArg::Type(CLASSIC_T.into()),
+                TypeArg::Type(CLASSIC_T.into()),
             ])
             .unwrap_err(),
             SignatureError::TypeArgMismatch(TypeArgError::WrongNumberArgs(2, 1))

--- a/src/types/custom.rs
+++ b/src/types/custom.rs
@@ -80,3 +80,21 @@ impl From<CustomType> for SimpleType {
         }
     }
 }
+
+#[cfg(test)]
+pub(crate) mod test {
+    use smol_str::SmolStr;
+
+    use super::CustomType;
+    use crate::types::{ClassicType, Container, TypeTag};
+
+    pub(crate) const CLASSIC_T: ClassicType =
+        ClassicType::Container(Container::Opaque(CLASSIC_CUST));
+
+    pub(crate) const CLASSIC_CUST: CustomType = CustomType {
+        resource: SmolStr::new_inline("MyRsrc"),
+        id: SmolStr::new_inline("MyType"),
+        args: vec![],
+        tag: TypeTag::Classic,
+    };
+}

--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -178,8 +178,6 @@ impl From<Container<SimpleType>> for SimpleType {
 #[serde(try_from = "SimpleType", into = "SimpleType")]
 #[non_exhaustive]
 pub enum ClassicType {
-    /// A 64-bit floating point number.
-    F64,
     /// A graph encoded as a value. It contains a concrete signature and a set of required resources.
     /// TODO this can be moved out into an extension/resource
     Graph(Box<AbstractSignature>),
@@ -284,7 +282,6 @@ impl ClassicType {
 impl Display for ClassicType {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
-            ClassicType::F64 => f.write_str("F64"),
             ClassicType::Graph(data) => {
                 let sig = data.as_ref();
                 write!(f, "[{:?}]", sig.resource_reqs)?;
@@ -481,18 +478,30 @@ impl<T: PrimType> TypeRow<T> {
 
 #[cfg(test)]
 mod test {
+
     use super::*;
     use cool_asserts::assert_matches;
 
+    /// Alternatively we could use [CLASSIC_T]
+    ///
+    /// [CLASSIC_T]: crate::types::custom::test::CLASSIC_T
+    fn graph_type() -> ClassicType {
+        ClassicType::Graph(Box::new(AbstractSignature::new(
+            vec![HashableType::Int(64).into()],
+            vec![HashableType::Int(64).into()],
+            vec![],
+        )))
+    }
+
     #[test]
     fn new_tuple() {
-        let simp = vec![SimpleType::Qubit, SimpleType::Classic(ClassicType::F64)];
+        let simp = vec![SimpleType::Qubit, SimpleType::Classic(graph_type())];
         let ty = SimpleType::new_tuple(simp);
         assert_matches!(ty, SimpleType::Qontainer(Container::Tuple(_)));
 
         let clas: ClassicRow = vec![
-            ClassicType::F64,
-            ClassicType::Container(Container::List(Box::new(ClassicType::F64))),
+            graph_type(),
+            ClassicType::Container(Container::List(Box::new(graph_type()))),
         ]
         .into();
         let ty = SimpleType::new_tuple(clas.map_into());
@@ -517,10 +526,8 @@ mod test {
     #[test]
     fn new_sum() {
         let clas = vec![
-            SimpleType::Classic(ClassicType::F64),
-            SimpleType::Classic(ClassicType::Container(Container::List(Box::new(
-                ClassicType::F64,
-            )))),
+            SimpleType::Classic(graph_type()),
+            Container::<ClassicType>::List(Box::new(graph_type())).into(),
         ];
         let ty = SimpleType::new_sum(clas);
         assert_matches!(

--- a/src/types/simple/serialize.rs
+++ b/src/types/simple/serialize.rs
@@ -25,7 +25,7 @@ pub(crate) enum SerSimpleType {
     I {
         width: HugrIntWidthStore,
     },
-    F,
+    //F, // Or preserve??
     S,
     G {
         signature: Box<AbstractSignature>,
@@ -130,7 +130,6 @@ impl From<HashableType> for SerSimpleType {
 impl From<ClassicType> for SerSimpleType {
     fn from(value: ClassicType) -> Self {
         match value {
-            ClassicType::F64 => SerSimpleType::F,
             ClassicType::Graph(inner) => SerSimpleType::G {
                 signature: Box::new(*inner),
             },
@@ -180,7 +179,6 @@ impl From<SerSimpleType> for SimpleType {
         match value {
             SerSimpleType::Q => SimpleType::Qubit,
             SerSimpleType::I { width } => HashableType::Int(width).into(),
-            SerSimpleType::F => ClassicType::F64.into(),
             SerSimpleType::S => HashableType::String.into(),
             SerSimpleType::G { signature } => ClassicType::Graph(Box::new(*signature)).into(),
             SerSimpleType::Tuple { row: inner, c } => {
@@ -237,6 +235,7 @@ impl TryFrom<SerSimpleType> for HashableType {
 #[cfg(test)]
 mod test {
     use crate::hugr::serialize::test::ser_roundtrip;
+    use crate::types::custom::test::CLASSIC_T;
     use crate::types::{ClassicType, Container, HashableType, SimpleType};
 
     #[test]
@@ -244,14 +243,14 @@ mod test {
         // A Simple tuple
         let t = SimpleType::new_tuple(vec![
             SimpleType::Qubit,
-            SimpleType::Classic(ClassicType::F64),
+            SimpleType::from(HashableType::Int(64)),
         ]);
         assert_eq!(ser_roundtrip(&t), t);
 
         // A Classic sum
         let t = SimpleType::new_sum(vec![
             SimpleType::Classic(ClassicType::Hashable(HashableType::Int(4))),
-            SimpleType::Classic(ClassicType::F64),
+            SimpleType::Classic(CLASSIC_T),
         ]);
         assert_eq!(ser_roundtrip(&t), t);
 

--- a/src/types/simple/serialize.rs
+++ b/src/types/simple/serialize.rs
@@ -25,7 +25,6 @@ pub(crate) enum SerSimpleType {
     I {
         width: HugrIntWidthStore,
     },
-    //F, // Or preserve??
     S,
     G {
         signature: Box<AbstractSignature>,


### PR DESCRIPTION
Spec was updated already in #358. I took out `LeafOp::Rzf64` too (the only LeafOp that actually used it), also `SerSimpleType::F`. Added a couple of other ClassicType instances for use in tests because we need some (specifically, `ClassicType::Graph`s are a pain to construct, cannot be `const` as they contain Boxes, and do not yet have ConstValue instances)