### PR TITLE
Tag the regions with their root node handle

### DIFF
--- a/src/algorithm/nest_cfgs.rs
+++ b/src/algorithm/nest_cfgs.rs
@@ -447,7 +447,7 @@ pub(crate) mod test {
         let (split, merge, head, tail) = (split.node(), merge.node(), head.node(), tail.node());
         // There's no need to use a FlatRegionView here but we do so just to check
         // that we *can* (as we'll need to for "real" module Hugr's).
-        let v = SiblingGraph::new(&h, h.root());
+        let v: SiblingGraph = SiblingGraph::new(&h, h.root());
         let edge_classes = EdgeClassifier::get_edge_classes(&SimpleCfgView::new(&v));
         let [&left,&right] = edge_classes.keys().filter(|(s,_)| *s == split).map(|(_,t)|t).collect::<Vec<_>>()[..] else {panic!("Split node should have two successors");};
 

--- a/src/hugr/hierarchical_views.rs
+++ b/src/hugr/hierarchical_views.rs
@@ -23,6 +23,8 @@ use context_iterators::{ContextIterator, IntoContextIterator, MapWithCtx};
 use itertools::{Itertools, MapInto};
 use portgraph::{LinkView, PortIndex, PortView};
 
+use crate::ops::handle::NodeHandle;
+use crate::ops::OpTrait;
 use crate::{hugr::NodeType, hugr::OpType, Direction, Hugr, Node, Port};
 
 use super::view::sealed::HugrInternals;
@@ -36,7 +38,7 @@ type FlatRegionGraph<'g, Base> =
 /// Includes only the root node and its direct children.
 ///
 /// For a view that includes all the descendants of the root, see [`DescendantsGraph`].
-pub struct SiblingGraph<'g, Base = Hugr>
+pub struct SiblingGraph<'g, Root = Node, Base = Hugr>
 where
     Base: HugrInternals,
 {
@@ -48,10 +50,14 @@ where
 
     /// The rest of the HUGR.
     hugr: &'g Base,
+
+    /// The operation type of the root node.
+    _phantom: std::marker::PhantomData<Root>,
 }
 
-impl<'g, Base> Clone for SiblingGraph<'g, Base>
+impl<'g, Root, Base> Clone for SiblingGraph<'g, Root, Base>
 where
+    Root: NodeHandle,
     Base: HugrInternals + HugrView + Clone,
 {
     fn clone(&self) -> Self {
@@ -59,8 +65,9 @@ where
     }
 }
 
-impl<'g, Base> HugrView for SiblingGraph<'g, Base>
+impl<'g, Root, Base> HugrView for SiblingGraph<'g, Root, Base>
 where
+    Root: NodeHandle,
     Base: HugrInternals + HugrView,
 {
     type Nodes<'a> = iter::Chain<iter::Once<Node>, MapInto<portgraph::hierarchy::Children<'a>, Node>>
@@ -200,7 +207,7 @@ type RegionGraph<'g, Base> = portgraph::view::Region<'g, <Base as HugrInternals>
 /// For a view that includes only the direct children of the root, see
 /// [`SiblingGraph`]. Prefer using [`SiblingGraph`] over this type when
 /// possible, as it is more efficient.
-pub struct DescendantsGraph<'g, Base>
+pub struct DescendantsGraph<'g, Root = Node, Base = Hugr>
 where
     Base: HugrInternals,
 {
@@ -212,10 +219,14 @@ where
 
     /// The node hierarchy.
     hugr: &'g Base,
+
+    /// The operation handle of the root node.
+    _phantom: std::marker::PhantomData<Root>,
 }
 
-impl<'g, Base: Clone> Clone for DescendantsGraph<'g, Base>
+impl<'g, Root, Base: Clone> Clone for DescendantsGraph<'g, Root, Base>
 where
+    Root: NodeHandle,
     Base: HugrInternals + HugrView,
 {
     fn clone(&self) -> Self {
@@ -223,8 +234,9 @@ where
     }
 }
 
-impl<'g, Base> HugrView for DescendantsGraph<'g, Base>
+impl<'g, Root, Base> HugrView for DescendantsGraph<'g, Root, Base>
 where
+    Root: NodeHandle,
     Base: HugrInternals + HugrView,
 {
     type Nodes<'a> = MapInto<<RegionGraph<'g, Base> as PortView>::Nodes<'a>, Node>
@@ -366,13 +378,19 @@ where
     fn new(hugr: &'a Self::Base, root: Node) -> Self;
 }
 
-impl<'a, Base> HierarchyView<'a> for SiblingGraph<'a, Base>
+impl<'a, Root, Base> HierarchyView<'a> for SiblingGraph<'a, Root, Base>
 where
+    Root: NodeHandle,
     Base: HugrInternals + HugrView,
 {
     type Base = Base;
 
     fn new(hugr: &'a Base, root: Node) -> Self {
+        let root_tag = hugr.get_optype(root).tag();
+        if !Root::TAG.is_superset(root_tag) {
+            // TODO: Return an error
+            panic!("Root node must have the correct operation type tag.")
+        }
         Self {
             root,
             graph: FlatRegionGraph::<Base>::new_flat_region(
@@ -381,17 +399,24 @@ where
                 root.index,
             ),
             hugr,
+            _phantom: std::marker::PhantomData,
         }
     }
 }
 
-impl<'a, Base> HierarchyView<'a> for DescendantsGraph<'a, Base>
+impl<'a, Root, Base> HierarchyView<'a> for DescendantsGraph<'a, Root, Base>
 where
+    Root: NodeHandle,
     Base: HugrInternals + HugrView,
 {
     type Base = Base;
 
     fn new(hugr: &'a Base, root: Node) -> Self {
+        let root_tag = hugr.get_optype(root).tag();
+        if !Root::TAG.is_superset(root_tag) {
+            // TODO: Return an error
+            panic!("Root node must have the correct operation type tag.")
+        }
         Self {
             root,
             graph: RegionGraph::<Base>::new_region(
@@ -400,12 +425,14 @@ where
                 root.index,
             ),
             hugr,
+            _phantom: std::marker::PhantomData,
         }
     }
 }
 
-impl<'g, Base> super::view::sealed::HugrInternals for SiblingGraph<'g, Base>
+impl<'g, Root, Base> super::view::sealed::HugrInternals for SiblingGraph<'g, Root, Base>
 where
+    Root: NodeHandle,
     Base: HugrInternals,
 {
     type Portgraph = FlatRegionGraph<'g, Base>;
@@ -421,8 +448,9 @@ where
     }
 }
 
-impl<'g, Base> super::view::sealed::HugrInternals for DescendantsGraph<'g, Base>
+impl<'g, Root, Base> super::view::sealed::HugrInternals for DescendantsGraph<'g, Root, Base>
 where
+    Root: NodeHandle,
     Base: HugrInternals,
 {
     type Portgraph = RegionGraph<'g, Base>;
@@ -490,7 +518,7 @@ mod test {
     fn flat_region() -> Result<(), Box<dyn std::error::Error>> {
         let (hugr, def, inner) = make_module_hgr()?;
 
-        let region = SiblingGraph::new(&hugr, def);
+        let region: SiblingGraph = SiblingGraph::new(&hugr, def);
 
         assert_eq!(region.node_count(), 5);
         assert!(region
@@ -505,7 +533,7 @@ mod test {
     fn full_region() -> Result<(), Box<dyn std::error::Error>> {
         let (hugr, def, inner) = make_module_hgr()?;
 
-        let region = DescendantsGraph::new(&hugr, def);
+        let region: DescendantsGraph = DescendantsGraph::new(&hugr, def);
 
         assert_eq!(region.node_count(), 7);
         assert!(region.nodes().all(|n| n == def

--- a/src/hugr/hierarchical_views/petgraph.rs
+++ b/src/hugr/hierarchical_views/petgraph.rs
@@ -3,6 +3,7 @@
 use super::{DescendantsGraph, SiblingGraph};
 use crate::hugr::view::sealed::HugrInternals;
 use crate::hugr::HugrView;
+use crate::ops::handle::NodeHandle;
 use crate::ops::OpType;
 use crate::types::EdgeKind;
 use crate::{Node, Port};
@@ -13,23 +14,26 @@ use portgraph::NodeIndex;
 
 macro_rules! impl_region_petgraph_traits {
     ($hugr:ident) => {
-        impl<'a, Base> pv::GraphBase for $hugr<'a, Base>
+        impl<'a, Root, Base> pv::GraphBase for $hugr<'a, Root, Base>
         where
+            Root: NodeHandle,
             Base: HugrInternals + HugrView,
         {
             type NodeId = Node;
             type EdgeId = ((Node, Port), (Node, Port));
         }
 
-        impl<'a, Base> pv::GraphProp for $hugr<'a, Base>
+        impl<'a, Root, Base> pv::GraphProp for $hugr<'a, Root, Base>
         where
+            Root: NodeHandle,
             Base: HugrInternals + HugrView,
         {
             type EdgeType = petgraph::Directed;
         }
 
-        impl<'a, Base> pv::NodeCount for $hugr<'a, Base>
+        impl<'a, Root, Base> pv::NodeCount for $hugr<'a, Root, Base>
         where
+            Root: NodeHandle,
             Base: HugrInternals + HugrView,
         {
             fn node_count(&self) -> usize {
@@ -37,8 +41,9 @@ macro_rules! impl_region_petgraph_traits {
             }
         }
 
-        impl<'a, Base> pv::NodeIndexable for $hugr<'a, Base>
+        impl<'a, Root, Base> pv::NodeIndexable for $hugr<'a, Root, Base>
         where
+            Root: NodeHandle,
             Base: HugrInternals + HugrView,
         {
             fn node_bound(&self) -> usize {
@@ -54,8 +59,9 @@ macro_rules! impl_region_petgraph_traits {
             }
         }
 
-        impl<'a, Base> pv::EdgeCount for $hugr<'a, Base>
+        impl<'a, Root, Base> pv::EdgeCount for $hugr<'a, Root, Base>
         where
+            Root: NodeHandle,
             Base: HugrInternals + HugrView,
         {
             fn edge_count(&self) -> usize {
@@ -63,33 +69,36 @@ macro_rules! impl_region_petgraph_traits {
             }
         }
 
-        impl<'a, Base> pv::Data for $hugr<'a, Base>
+        impl<'a, Root, Base> pv::Data for $hugr<'a, Root, Base>
         where
+            Root: NodeHandle,
             Base: HugrInternals + HugrView,
         {
             type NodeWeight = OpType;
             type EdgeWeight = EdgeKind;
         }
 
-        impl<'g, 'a, Base> pv::IntoNodeIdentifiers for &'g $hugr<'a, Base>
+        impl<'g, 'a, Root, Base> pv::IntoNodeIdentifiers for &'g $hugr<'a, Root, Base>
         where
+            Root: NodeHandle,
             Base: HugrInternals + HugrView,
         {
-            type NodeIdentifiers = <$hugr<'a, Base> as HugrView>::Nodes<'g>;
+            type NodeIdentifiers = <$hugr<'a, Root, Base> as HugrView>::Nodes<'g>;
 
             fn node_identifiers(self) -> Self::NodeIdentifiers {
                 self.nodes()
             }
         }
 
-        impl<'g, 'a, Base> pv::IntoNodeReferences for &'g $hugr<'a, Base>
+        impl<'g, 'a, Root, Base> pv::IntoNodeReferences for &'g $hugr<'a, Root, Base>
         where
+            Root: NodeHandle,
             'g: 'a,
             Base: HugrInternals + HugrView,
         {
             type NodeRef = HugrNodeRef<'a>;
             type NodeReferences =
-                MapWithCtx<<$hugr<'a, Base> as HugrView>::Nodes<'a>, Self, HugrNodeRef<'a>>;
+                MapWithCtx<<$hugr<'a, Root, Base> as HugrView>::Nodes<'a>, Self, HugrNodeRef<'a>>;
 
             fn node_references(self) -> Self::NodeReferences {
                 self.nodes()
@@ -98,22 +107,24 @@ macro_rules! impl_region_petgraph_traits {
             }
         }
 
-        impl<'g, 'a, Base> pv::IntoNeighbors for &'g $hugr<'a, Base>
+        impl<'g, 'a, Root, Base> pv::IntoNeighbors for &'g $hugr<'a, Root, Base>
         where
+            Root: NodeHandle,
             Base: HugrInternals + HugrView,
         {
-            type Neighbors = <$hugr<'a, Base> as HugrView>::Neighbours<'g>;
+            type Neighbors = <$hugr<'a, Root, Base> as HugrView>::Neighbours<'g>;
 
             fn neighbors(self, n: Self::NodeId) -> Self::Neighbors {
                 self.output_neighbours(n)
             }
         }
 
-        impl<'g, 'a, Base> pv::IntoNeighborsDirected for &'g $hugr<'a, Base>
+        impl<'g, 'a, Root, Base> pv::IntoNeighborsDirected for &'g $hugr<'a, Root, Base>
         where
+            Root: NodeHandle,
             Base: HugrInternals + HugrView,
         {
-            type NeighborsDirected = <$hugr<'a, Base> as HugrView>::Neighbours<'g>;
+            type NeighborsDirected = <$hugr<'a, Root, Base> as HugrView>::Neighbours<'g>;
 
             fn neighbors_directed(
                 self,
@@ -124,8 +135,9 @@ macro_rules! impl_region_petgraph_traits {
             }
         }
 
-        impl<'a, Base> pv::Visitable for $hugr<'a, Base>
+        impl<'a, Root, Base> pv::Visitable for $hugr<'a, Root, Base>
         where
+            Root: NodeHandle,
             Base: HugrInternals + HugrView,
         {
             type Map = std::collections::HashSet<Self::NodeId>;
@@ -139,8 +151,9 @@ macro_rules! impl_region_petgraph_traits {
             }
         }
 
-        impl<'a, Base> pv::GetAdjacencyMatrix for $hugr<'a, Base>
+        impl<'a, Root, Base> pv::GetAdjacencyMatrix for $hugr<'a, Root, Base>
         where
+            Root: NodeHandle,
             Base: HugrInternals + HugrView,
         {
             type AdjMatrix = std::collections::HashSet<(Self::NodeId, Self::NodeId)>;

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -100,7 +100,7 @@ impl<'a> ValidationContext<'a> {
     /// The results of this computation should be cached in `self.dominators`.
     /// We don't do it here to avoid mutable borrows.
     fn compute_dominator(&self, parent: Node) -> Dominators<Node> {
-        let region = SiblingGraph::new(self.hugr, parent);
+        let region: SiblingGraph = SiblingGraph::new(self.hugr, parent);
         let entry_node = self.hugr.children(parent).next().unwrap();
         dominators::simple_fast(&region, entry_node)
     }
@@ -391,7 +391,7 @@ impl<'a> ValidationContext<'a> {
             return Ok(());
         };
 
-        let region = SiblingGraph::new(self.hugr, parent);
+        let region: SiblingGraph = SiblingGraph::new(self.hugr, parent);
         let entry_node = self.hugr.children(parent).next().unwrap();
 
         let postorder = DfsPostOrder::new(&region, entry_node);


### PR DESCRIPTION
Add's a `Root: NodeHandle` parameter to the views to restrict the hugr type. The root tag is dynamically checked at construction time.

The next step would be to tag the `Hugr`s too, and add dynamic casting between handle types.