### PR TITLE
SerSimpleType: use Vec not TypeRow

### DIFF
--- a/src/types/simple.rs
+++ b/src/types/simple.rs
@@ -97,6 +97,10 @@ pub trait PrimType: TypeRowElem + std::fmt::Debug + sealed::Sealed {
     fn tag(&self) -> TypeTag;
 }
 
+impl TypeRowElem for SimpleType {}
+impl TypeRowElem for ClassicType {}
+impl TypeRowElem for HashableType {}
+
 // sealed trait pattern to prevent users extending PrimType
 mod sealed {
     use super::{ClassicType, HashableType, SimpleType};

--- a/src/types/simple/serialize.rs
+++ b/src/types/simple/serialize.rs
@@ -90,7 +90,7 @@ where
                 c: T::TAG,
             },
             Container::Array(inner, len) => SerSimpleType::Array {
-                inner: box_convert(*inner),
+                inner: Box::new((*inner).into()),
                 len,
                 c: T::TAG,
             },
@@ -134,21 +134,6 @@ impl From<SimpleType> for SerSimpleType {
     }
 }
 
-pub(crate) fn box_convert_try<T, F>(value: T) -> Box<F>
-where
-    T: TryInto<F>,
-    <T as TryInto<F>>::Error: std::fmt::Debug,
-{
-    Box::new((value).try_into().unwrap())
-}
-
-pub(crate) fn box_convert<T, F>(value: T) -> Box<F>
-where
-    T: Into<F>,
-{
-    Box::new((value).into())
-}
-
 fn try_convert_list<T: TryInto<T2>, T2: TypeRowElem>(
     values: Vec<T>,
 ) -> Result<TypeRow<T2>, T::Error> {
@@ -184,7 +169,7 @@ impl From<SerSimpleType> for SimpleType {
                 handle_container!(c, Sum(Box::new(try_convert_list(inner).unwrap())))
             }
             SerSimpleType::Array { inner, len, c } => {
-                handle_container!(c, Array(box_convert_try(*inner), len))
+                handle_container!(c, Array(Box::new((*inner).try_into().unwrap()), len))
             }
             SerSimpleType::Alias { name: s, c } => handle_container!(c, Alias(s)),
             SerSimpleType::Opaque { custom, c } => {

--- a/src/types/type_row.rs
+++ b/src/types/type_row.rs
@@ -12,8 +12,6 @@ use crate::utils::display_list;
 /// Base trait for anything that can be put in a [TypeRow]
 pub trait TypeRowElem: Clone + 'static {}
 
-impl<T: Clone + 'static> TypeRowElem for T {}
-
 /// List of types, used for function signatures.
 #[derive(Clone, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
 //#[cfg_attr(feature = "pyo3", pyclass)] // TODO: expose unparameterized versions


### PR DESCRIPTION
* Also inlining singly-used methods `box_convert` and `box_convert_try`
* And switch TypeRowElem from a blanket impl to "elective" - we elect to allow only TypeRows of SimpleType/ClassicType/HashableType