### PR TITLE
Refactor/types redux2

### DIFF
--- a/src/types/basic.rs
+++ b/src/types/basic.rs
@@ -72,37 +72,15 @@ impl<T: TypeClass> Type<T> {
     }
 }
 
-/*
-Public traits for construction
-*/
-pub trait NewEq {
-    const USIZE: Self;
-}
-
-pub trait NewClassic: NewEq {
-    fn graph(signature: AbstractSignature) -> Self;
-}
-
-impl NewEq for Type<EqLeaf> {
-    const USIZE: Self = Self::Prim(EqLeaf::USize);
-}
-
-impl NewEq for Type<ClassicLeaf> {
-    const USIZE: Self = Self::Prim(ClassicLeaf::E(EqLeaf::USize));
-}
-
-impl NewClassic for Type<ClassicLeaf> {
-    fn graph(signature: AbstractSignature) -> Self {
-        Self::Prim(ClassicLeaf::Graph(Box::new(signature)))
+impl<T: From<EqLeaf>> Type<T> {
+    pub fn usize() -> Self {
+        Self::Prim(EqLeaf::USize.into())
     }
 }
 
-impl NewEq for Type<AnyLeaf> {
-    const USIZE: Self = Self::Prim(AnyLeaf::C(ClassicLeaf::E(EqLeaf::USize)));
-}
-impl NewClassic for Type<AnyLeaf> {
-    fn graph(signature: AbstractSignature) -> Self {
-        Type::<ClassicLeaf>::graph(signature).upcast()
+impl<T: From<ClassicLeaf>> Type<T> {
+    pub fn graph(signature: AbstractSignature) -> Self {
+        Self::Prim(ClassicLeaf::Graph(Box::new(signature)).into())
     }
 }
 
@@ -153,7 +131,7 @@ mod test {
     #[test]
     fn construct() {
         let t: Type<ClassicLeaf> = Type::new_tuple([
-            Type::USIZE,
+            Type::usize(),
             Type::graph(AbstractSignature::new_linear(vec![])),
             Type::new_opaque(CustomType::new(
                 "my_custom",
@@ -166,5 +144,14 @@ mod test {
         let t_any: Type<AnyLeaf> = t.upcast();
 
         assert_eq!(t_any.tag(), TypeTag::Simple);
+    }
+
+    #[test]
+    fn all_constructors() {
+        Type::<EqLeaf>::usize();
+        Type::<ClassicLeaf>::usize();
+        Type::<AnyLeaf>::usize();
+        Type::<ClassicLeaf>::graph(AbstractSignature::new_linear(vec![]));
+        Type::<AnyLeaf>::graph(AbstractSignature::new_linear(vec![]));
     }
 }

--- a/src/types/basic.rs
+++ b/src/types/basic.rs
@@ -110,10 +110,10 @@ pub trait UpCastTo<T2>: Sized {
     fn upcast(self) -> T2;
 }
 
-impl UpCastTo<Type<AnyLeaf>> for Type<ClassicLeaf> {
-    fn upcast(self: Type<ClassicLeaf>) -> Type<AnyLeaf> {
+impl<T: UpCastTo<T2>, T2> UpCastTo<Type<T2>> for Type<T> {
+    fn upcast(self) -> Type<T2> {
         match self {
-            Type::Prim(t) => Type::Prim(AnyLeaf::C(t)),
+            Type::Prim(t) => Type::Prim(t.upcast()),
             Type::Extension(t) => Type::Extension(t),
             Type::Alias(_) => todo!(),
             Type::Array(_, _) => todo!(),
@@ -123,16 +123,27 @@ impl UpCastTo<Type<AnyLeaf>> for Type<ClassicLeaf> {
     }
 }
 
-impl UpCastTo<Type<ClassicLeaf>> for Type<EqLeaf> {
-    fn upcast(self) -> Type<ClassicLeaf> {
-        todo!()
+impl UpCastTo<ClassicLeaf> for EqLeaf {
+    fn upcast(self) -> ClassicLeaf {
+        ClassicLeaf::E(self)
     }
 }
 
-impl UpCastTo<Type<AnyLeaf>> for Type<EqLeaf> {
-    fn upcast(self) -> Type<AnyLeaf> {
-        let cl: Type<ClassicLeaf> = self.upcast();
-        cl.upcast()
+impl From<EqLeaf> for ClassicLeaf {
+    fn from(value: EqLeaf) -> Self {
+        ClassicLeaf::E(value)
+    }
+}
+
+impl<T: Into<ClassicLeaf>> UpCastTo<AnyLeaf> for T {
+    fn upcast(self) -> AnyLeaf {
+        AnyLeaf::C(self.into())
+    }
+}
+
+impl<T: Into<ClassicLeaf>> From<T> for AnyLeaf {
+    fn from(value: T) -> Self {
+        value.upcast()
     }
 }
 


### PR DESCRIPTION
* Elide separate Any/AnyTypeImpl into single AnyLeaf, and same for Classic/Eq
* Impl Into and UpCastTo between leaves...significantly, T is Into<T> but not UpCastTo<T>
* Remove the construction traits by using `impl<T: From<EqLeaf>> Type<T>` for `usize()` and similar for `ClassicLeaf` and `graph()`