### PR TITLE
only implement upcast for Type

### DIFF
--- a/src/types/basic.rs
+++ b/src/types/basic.rs
@@ -88,7 +88,8 @@ impl<T: From<ClassicLeaf>> Type<T> {
 }
 
 impl<T> Type<T> {
-    pub fn upcast<T2: From<T>>(self) -> Type<T2> {
+    #[inline]
+    fn upcast<T2: From<T>>(self) -> Type<T2> {
         match self {
             Type::Prim(t) => Type::Prim(t.into()),
             Type::Extension(t) => Type::Extension(t),
@@ -97,6 +98,24 @@ impl<T> Type<T> {
             Type::Tuple(vec) => Type::Tuple(vec.into_iter().map(Type::<T>::upcast).collect()),
             Type::Sum(_) => todo!(),
         }
+    }
+}
+
+impl From<Type<EqLeaf>> for Type<ClassicLeaf> {
+    fn from(value: Type<EqLeaf>) -> Self {
+        value.upcast()
+    }
+}
+
+impl From<Type<EqLeaf>> for Type<AnyLeaf> {
+    fn from(value: Type<EqLeaf>) -> Self {
+        value.upcast()
+    }
+}
+
+impl From<Type<ClassicLeaf>> for Type<AnyLeaf> {
+    fn from(value: Type<ClassicLeaf>) -> Self {
+        value.upcast()
     }
 }
 
@@ -128,7 +147,7 @@ mod test {
             )),
         ]);
         assert_eq!(t.tag(), TypeTag::Classic);
-        let t_any: Type<AnyLeaf> = t.upcast();
+        let t_any: Type<AnyLeaf> = t.into();
 
         assert_eq!(t_any.tag(), TypeTag::Simple);
     }

--- a/src/types/basic.rs
+++ b/src/types/basic.rs
@@ -13,6 +13,18 @@ pub enum AnyLeaf {
     C(ClassicLeaf),
 }
 
+impl From<EqLeaf> for ClassicLeaf {
+    fn from(value: EqLeaf) -> Self {
+        ClassicLeaf::E(value)
+    }
+}
+
+impl<T: Into<ClassicLeaf>> From<T> for AnyLeaf {
+    fn from(value: T) -> Self {
+        AnyLeaf::C(value.into())
+    }
+}
+
 mod sealed {
     use super::{AnyLeaf, ClassicLeaf, EqLeaf, Type};
     pub trait SealedLeaf {}
@@ -116,18 +128,6 @@ impl From<Type<EqLeaf>> for Type<AnyLeaf> {
 impl From<Type<ClassicLeaf>> for Type<AnyLeaf> {
     fn from(value: Type<ClassicLeaf>) -> Self {
         value.upcast()
-    }
-}
-
-impl From<EqLeaf> for ClassicLeaf {
-    fn from(value: EqLeaf) -> Self {
-        ClassicLeaf::E(value)
-    }
-}
-
-impl<T: Into<ClassicLeaf>> From<T> for AnyLeaf {
-    fn from(value: T) -> Self {
-        AnyLeaf::C(value.into())
     }
 }
 

--- a/src/types/basic.rs
+++ b/src/types/basic.rs
@@ -87,7 +87,7 @@ impl<T: From<ClassicLeaf>> Type<T> {
     }
 }
 
-impl<T: sealed::SealedLeaf> Type<T> {
+impl<T> Type<T> {
     pub fn upcast<T2: From<T>>(self) -> Type<T2> {
         match self {
             Type::Prim(t) => Type::Prim(t.into()),


### PR DESCRIPTION
Means in public code it is clear that upcasting is an operation only valid for types

leaves are more free, and hopefully mostly used in pattern matching and internal code.