### PR TITLE
Move resource validation routines to new module

### DIFF
--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -52,7 +52,8 @@ pub struct Hugr {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
-/// The type of a node on a graph
+/// The type of a node on a graph. In addition to the [`OpType`], it also
+/// describes the resources inferred to be used by the node.
 pub struct NodeType {
     /// The underlying OpType
     op: OpType,
@@ -97,16 +98,34 @@ impl NodeType {
     pub fn op_signature(&self) -> AbstractSignature {
         self.op.signature()
     }
+
+    /// The input resources defined for this node.
+    ///
+    /// The output resources will correspond to the input resources plus any
+    /// resource delta defined by the operation type.
+    ///
+    /// If the input resources are not known, this will return None.
+    pub fn input_resources(&self) -> Option<&ResourceSet> {
+        self.input_resources.as_ref()
+    }
 }
 
 impl NodeType {
-    #![allow(missing_docs)]
     delegate! {
         to self.op {
+            /// Tag identifying the operation.
             pub fn tag(&self) -> OpTag;
+            /// Returns the number of inputs ports for the operation.
             pub fn input_count(&self) -> usize;
+            /// Returns the number of outputs ports for the operation.
             pub fn output_count(&self) -> usize;
         }
+    }
+}
+
+impl<'a> From<&'a NodeType> for &'a OpType {
+    fn from(nt: &'a NodeType) -> Self {
+        &nt.op
     }
 }
 

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -14,12 +14,13 @@ use pyo3::prelude::*;
 
 use crate::ops::validate::{ChildrenEdgeData, ChildrenValidationError, EdgeValidationError};
 use crate::ops::{OpTag, OpTrait, OpType, ValidateOp};
-use crate::resource::ResourceSet;
+use crate::resource::validate::{ResourceError, ResourceValidator};
 use crate::types::{ClassicType, EdgeKind, SimpleType};
 use crate::{Direction, Hugr, Node, Port};
 
 use super::hierarchical_views::{HierarchyView, SiblingGraph};
 use super::view::HugrView;
+use super::NodeType;
 
 /// Structure keeping track of pre-computed information used in the validation
 /// process.
@@ -30,8 +31,8 @@ struct ValidationContext<'a> {
     hugr: &'a Hugr,
     /// Dominator tree for each CFG region, using the container node as index.
     dominators: HashMap<Node, Dominators<Node>>,
-    /// Resource requirements associated with each edge
-    resources: HashMap<(Node, Direction), ResourceSet>,
+    /// Context for the resource validation.
+    resource_validator: ResourceValidator,
 }
 
 impl Hugr {
@@ -48,7 +49,7 @@ impl<'a> ValidationContext<'a> {
         Self {
             hugr,
             dominators: HashMap::new(),
-            resources: HashMap::new(),
+            resource_validator: ResourceValidator::new(hugr),
         }
     }
 
@@ -61,72 +62,11 @@ impl<'a> ValidationContext<'a> {
             });
         }
 
-        for node in self.hugr.graph.nodes_iter().map_into() {
-            self.gather_resources(&node)?;
-        }
-
         // Node-specific checks
         for node in self.hugr.graph.nodes_iter().map_into() {
             self.validate_node(node)?;
         }
 
-        Ok(())
-    }
-
-    /// Check that input and output nodes match up with the signature of their parents
-    /// This must be done after the `gather_resources` step
-    fn validate_io_resources(
-        &self,
-        hugr: &impl HugrView,
-        parent: Node,
-    ) -> Result<(), ValidationError> {
-        if let Some([input, output]) = hugr.get_io(parent) {
-            let parent_input_resources =
-                self.resources.get(&(parent, Direction::Incoming)).unwrap();
-            let parent_output_resources =
-                self.resources.get(&(parent, Direction::Outgoing)).unwrap();
-            for dir in Direction::BOTH {
-                let input_resources = self.resources.get(&(input, dir)).unwrap();
-                let output_resources = self.resources.get(&(output, dir)).unwrap();
-                if parent_input_resources != input_resources {
-                    return Err(ValidationError::ParentIOResourceMismatch {
-                        parent,
-                        parent_resources: parent_input_resources.clone(),
-                        child: input,
-                        child_resources: input_resources.clone(),
-                    });
-                };
-                if parent_output_resources != output_resources {
-                    return Err(ValidationError::ParentIOResourceMismatch {
-                        parent,
-                        parent_resources: parent_output_resources.clone(),
-                        child: output,
-                        child_resources: output_resources.clone(),
-                    });
-                };
-            }
-        };
-        Ok(())
-    }
-
-    /// Use the signature supplied by a dataflow node to work out the
-    /// resource requirements for all of its input and output edges, then put
-    /// those requirements in the ValidationContext
-    fn gather_resources(&mut self, node: &Node) -> Result<(), ValidationError> {
-        let node_type = self.hugr.get_nodetype(*node);
-
-        match node_type.signature() {
-            // Require that input resources are specified on every node for this check
-            None => return Err(ValidationError::MissingInputResources(*node)),
-            Some(sig) => {
-                for dir in Direction::BOTH {
-                    assert!(self
-                        .resources
-                        .insert((*node, dir), sig.get_resources(&dir))
-                        .is_none());
-                }
-            }
-        }
         Ok(())
     }
 
@@ -147,7 +87,8 @@ impl<'a> ValidationContext<'a> {
     /// - Matching the number of ports with the signature
     /// - Dataflow ports are correct. See `validate_df_port`
     fn validate_node(&mut self, node: Node) -> Result<(), ValidationError> {
-        let op_type = self.hugr.get_optype(node);
+        let node_type = self.hugr.get_nodetype(node);
+        let op_type = &node_type.op;
 
         // The Hugr can have only one root node.
         if node == self.hugr.root() {
@@ -195,54 +136,16 @@ impl<'a> ValidationContext<'a> {
         }
 
         // Check operation-specific constraints
-        self.validate_operation(node, op_type)?;
+        self.validate_operation(node, node_type)?;
 
-        // If this is a DataflowParent, check that the I/O nodes
-        // match the parent's signature
-        self.validate_io_resources(&self.hugr, node)?;
+        // If this is a container with I/O nodes, check that the resources they
+        // define match the resources of the container.
+        if let Some([input, output]) = self.hugr.get_io(node) {
+            self.resource_validator
+                .validate_io_resources(node, input, output)?;
+        }
 
         Ok(())
-    }
-
-    /// Check that two `PortIndex` have compatible resource requirements,
-    /// according to the information accumulated by `gather_resources`.
-    ///
-    /// This resource checking assumes that free resource variables
-    ///   (e.g. implicit lifting of `A -> B` to `[R]A -> [R]B`)
-    /// and adding of lift nodes
-    ///   (i.e. those which transform an edge from `A` to `[R]A`)
-    /// has already been done.
-    fn check_resources_compatible(
-        &self,
-        src: &(Node, Port),
-        tgt: &(Node, Port),
-    ) -> Result<(), ValidationError> {
-        let rs_src = self.resources.get(&(src.0, Direction::Outgoing)).unwrap();
-        let rs_tgt = self.resources.get(&(tgt.0, Direction::Incoming)).unwrap();
-
-        if rs_src == rs_tgt {
-            Ok(())
-        } else if rs_src.is_subset(rs_tgt) {
-            // The extra resource requirements reside in the target node.
-            // If so, we can fix this mismatch with a lift node
-            Err(ValidationError::TgtExceedsSrcResources {
-                from: src.0,
-                from_offset: src.1,
-                from_resources: rs_src.clone(),
-                to: tgt.0,
-                to_offset: tgt.1,
-                to_resources: rs_tgt.clone(),
-            })
-        } else {
-            Err(ValidationError::SrcExceedsTgtResources {
-                from: src.0,
-                from_offset: src.1,
-                from_resources: rs_src.clone(),
-                to: tgt.0,
-                to_offset: tgt.1,
-                to_resources: rs_tgt.clone(),
-            })
-        }
     }
 
     /// Check whether a port is valid.
@@ -297,7 +200,8 @@ impl<'a> ValidationContext<'a> {
             let other_node: Node = self.hugr.graph.port_node(link).unwrap().into();
             let other_offset = self.hugr.graph.port_offset(link).unwrap().into();
 
-            self.check_resources_compatible(&(node, port), &(other_node, other_offset))?;
+            self.resource_validator
+                .check_resources_compatible(&(node, port), &(other_node, other_offset))?;
 
             let other_op = self.hugr.get_optype(other_node);
             let Some(other_kind) = other_op.port_kind(other_offset) else {
@@ -326,7 +230,8 @@ impl<'a> ValidationContext<'a> {
     /// Check operation-specific constraints.
     ///
     /// These are flags defined for each operation type as an [`OpValidityFlags`] object.
-    fn validate_operation(&self, node: Node, op_type: &OpType) -> Result<(), ValidationError> {
+    fn validate_operation(&self, node: Node, node_type: &NodeType) -> Result<(), ValidationError> {
+        let op_type = &node_type.op;
         let flags = op_type.validity_flags();
 
         if self.hugr.hierarchy.child_count(node.index) > 0 {
@@ -687,35 +592,9 @@ pub enum ValidationError {
     /// There are invalid inter-graph edges.
     #[error(transparent)]
     InterGraphEdgeError(#[from] InterGraphEdgeError),
-    /// Missing lift node
-    #[error("Resources at target node {to:?} ({to_offset:?}) ({to_resources}) exceed those at source {from:?} ({from_offset:?}) ({from_resources})")]
-    TgtExceedsSrcResources {
-        from: Node,
-        from_offset: Port,
-        from_resources: ResourceSet,
-        to: Node,
-        to_offset: Port,
-        to_resources: ResourceSet,
-    },
-    /// Too many resource requirements coming from src
-    #[error("Resources at source node {from:?} ({from_offset:?}) ({from_resources}) exceed those at target {to:?} ({to_offset:?}) ({to_resources})")]
-    SrcExceedsTgtResources {
-        from: Node,
-        from_offset: Port,
-        from_resources: ResourceSet,
-        to: Node,
-        to_offset: Port,
-        to_resources: ResourceSet,
-    },
-    #[error("Missing input resources for node {0:?}")]
-    MissingInputResources(Node),
-    #[error("Resources of I/O node ({child:?}) {child_resources:?} don't match those expected by parent node ({parent:?}): {parent_resources:?}")]
-    ParentIOResourceMismatch {
-        parent: Node,
-        parent_resources: ResourceSet,
-        child: Node,
-        child_resources: ResourceSet,
-    },
+    /// There are errors in the resource declarations.
+    #[error(transparent)]
+    ResourceError(#[from] ResourceError),
 }
 
 #[cfg(feature = "pyo3")]
@@ -797,6 +676,7 @@ mod test {
     use crate::hugr::{HugrError, HugrMut, NodeType};
     use crate::ops::dataflow::IOTrait;
     use crate::ops::{self, LeafOp, OpType};
+    use crate::resource::ResourceSet;
     use crate::types::{AbstractSignature, ClassicType, HashableType};
     use crate::Direction;
     use crate::{type_row, Node};
@@ -1238,7 +1118,12 @@ mod test {
         main.finish_with_outputs([f_output])?;
         let handle = module_builder.finish_hugr();
 
-        assert_matches!(handle, Err(ValidationError::TgtExceedsSrcResources { .. }));
+        assert_matches!(
+            handle,
+            Err(ValidationError::ResourceError(
+                ResourceError::TgtExceedsSrcResources { .. }
+            ))
+        );
         Ok(())
     }
 
@@ -1269,7 +1154,12 @@ mod test {
         let [f_output] = f_handle.outputs_arr();
         main.finish_with_outputs([f_output])?;
         let handle = module_builder.finish_hugr();
-        assert_matches!(handle, Err(ValidationError::SrcExceedsTgtResources { .. }));
+        assert_matches!(
+            handle,
+            Err(ValidationError::ResourceError(
+                ResourceError::SrcExceedsTgtResources { .. }
+            ))
+        );
         Ok(())
     }
 
@@ -1326,7 +1216,12 @@ mod test {
 
         main.finish_with_outputs([output])?;
         let handle = module_builder.finish_hugr();
-        assert_matches!(handle, Err(ValidationError::TgtExceedsSrcResources { .. }));
+        assert_matches!(
+            handle,
+            Err(ValidationError::ResourceError(
+                ResourceError::TgtExceedsSrcResources { .. }
+            ))
+        );
         Ok(())
     }
 
@@ -1341,9 +1236,9 @@ mod test {
 
         assert_matches!(
             hugr,
-            Err(BuildError::InvalidHUGR(
-                ValidationError::TgtExceedsSrcResources { .. }
-            ))
+            Err(BuildError::InvalidHUGR(ValidationError::ResourceError(
+                ResourceError::TgtExceedsSrcResources { .. }
+            )))
         );
         Ok(())
     }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -19,6 +19,7 @@ mod op_def;
 pub use op_def::{CustomSignatureFunc, OpDef};
 mod type_def;
 pub use type_def::{TypeDef, TypeDefTag};
+pub mod validate;
 
 /// An error that can occur in computing the signature of a node.
 /// TODO: decide on failure modes

--- a/src/resource/validate.rs
+++ b/src/resource/validate.rs
@@ -1,0 +1,168 @@
+//! Validation routines for instantiations of a resource ops and types in a
+//! Hugr.
+
+use std::collections::HashMap;
+
+use thiserror::Error;
+
+use crate::hugr::NodeType;
+use crate::{Direction, Hugr, HugrView, Node, Port};
+
+use super::ResourceSet;
+
+/// Context for validating the resource requirements defined in a Hugr.
+#[derive(Debug, Clone, Default)]
+pub struct ResourceValidator {
+    /// Resource requirements associated with each edge
+    resources: HashMap<(Node, Direction), ResourceSet>,
+}
+
+impl ResourceValidator {
+    /// Initialise a new resource validator, pre-computing the resource
+    /// requirements for each node in the Hugr.
+    pub fn new(hugr: &Hugr) -> Self {
+        let mut validator = ResourceValidator {
+            resources: HashMap::new(),
+        };
+
+        for node in hugr.nodes() {
+            validator.gather_resources(&node, hugr.get_nodetype(node));
+        }
+
+        validator
+    }
+
+    /// Use the signature supplied by a dataflow node to work out the
+    /// resource requirements for all of its input and output edges, then put
+    /// those requirements in the resource validation context.
+    fn gather_resources(&mut self, node: &Node, node_type: &NodeType) {
+        if let Some(sig) = node_type.signature() {
+            for dir in Direction::BOTH {
+                assert!(self
+                    .resources
+                    .insert((*node, dir), sig.get_resources(&dir))
+                    .is_none());
+            }
+        }
+    }
+
+    /// Get the input or output resource requirements for a particular node in the Hugr.
+    ///
+    /// # Errors
+    ///
+    /// If the node resources are missing.
+    fn query_resources(&self, node: Node, dir: Direction) -> Result<&ResourceSet, ResourceError> {
+        self.resources
+            .get(&(node, dir))
+            .ok_or(ResourceError::MissingInputResources(node))
+    }
+
+    /// Check that two `PortIndex` have compatible resource requirements,
+    /// according to the information accumulated by `gather_resources`.
+    ///
+    /// This resource checking assumes that free resource variables
+    ///   (e.g. implicit lifting of `A -> B` to `[R]A -> [R]B`)
+    /// and adding of lift nodes
+    ///   (i.e. those which transform an edge from `A` to `[R]A`)
+    /// has already been done.
+    pub fn check_resources_compatible(
+        &self,
+        src: &(Node, Port),
+        tgt: &(Node, Port),
+    ) -> Result<(), ResourceError> {
+        let rs_src = self.query_resources(src.0, Direction::Outgoing)?;
+        let rs_tgt = self.query_resources(tgt.0, Direction::Incoming)?;
+
+        if rs_src == rs_tgt {
+            Ok(())
+        } else if rs_src.is_subset(rs_tgt) {
+            // The extra resource requirements reside in the target node.
+            // If so, we can fix this mismatch with a lift node
+            Err(ResourceError::TgtExceedsSrcResources {
+                from: src.0,
+                from_offset: src.1,
+                from_resources: rs_src.clone(),
+                to: tgt.0,
+                to_offset: tgt.1,
+                to_resources: rs_tgt.clone(),
+            })
+        } else {
+            Err(ResourceError::SrcExceedsTgtResources {
+                from: src.0,
+                from_offset: src.1,
+                from_resources: rs_src.clone(),
+                to: tgt.0,
+                to_offset: tgt.1,
+                to_resources: rs_tgt.clone(),
+            })
+        }
+    }
+
+    /// Check that a pair of input and output nodes declare the same resources
+    /// as in the signature of their parents.
+    pub fn validate_io_resources(
+        &self,
+        parent: Node,
+        input: Node,
+        output: Node,
+    ) -> Result<(), ResourceError> {
+        let parent_input_resources = self.query_resources(parent, Direction::Incoming)?;
+        let parent_output_resources = self.query_resources(parent, Direction::Outgoing)?;
+        for dir in Direction::BOTH {
+            let input_resources = self.query_resources(input, dir)?;
+            let output_resources = self.query_resources(output, dir)?;
+            if parent_input_resources != input_resources {
+                return Err(ResourceError::ParentIOResourceMismatch {
+                    parent,
+                    parent_resources: parent_input_resources.clone(),
+                    child: input,
+                    child_resources: input_resources.clone(),
+                });
+            };
+            if parent_output_resources != output_resources {
+                return Err(ResourceError::ParentIOResourceMismatch {
+                    parent,
+                    parent_resources: parent_output_resources.clone(),
+                    child: output,
+                    child_resources: output_resources.clone(),
+                });
+            };
+        }
+        Ok(())
+    }
+}
+
+/// Errors that can occur while validating a Hugr.
+#[derive(Debug, Clone, PartialEq, Error)]
+#[allow(missing_docs)]
+pub enum ResourceError {
+    /// Missing lift node
+    #[error("Resources at target node {to:?} ({to_offset:?}) ({to_resources}) exceed those at source {from:?} ({from_offset:?}) ({from_resources})")]
+    TgtExceedsSrcResources {
+        from: Node,
+        from_offset: Port,
+        from_resources: ResourceSet,
+        to: Node,
+        to_offset: Port,
+        to_resources: ResourceSet,
+    },
+    /// Too many resource requirements coming from src
+    #[error("Resources at source node {from:?} ({from_offset:?}) ({from_resources}) exceed those at target {to:?} ({to_offset:?}) ({to_resources})")]
+    SrcExceedsTgtResources {
+        from: Node,
+        from_offset: Port,
+        from_resources: ResourceSet,
+        to: Node,
+        to_offset: Port,
+        to_resources: ResourceSet,
+    },
+    #[error("Missing input resources for node {0:?}")]
+    MissingInputResources(Node),
+    #[error("Resources of I/O node ({child:?}) {child_resources:?} don't match those expected by parent node ({parent:?}): {parent_resources:?}")]
+    ParentIOResourceMismatch {
+        parent: Node,
+        parent_resources: ResourceSet,
+        child: Node,
+        child_resources: ResourceSet,
+    },
+}


### PR DESCRIPTION
This PR adds a new `resources::validate` module, and moves the different resource logic bits from the Hugr validation there.

This is a tidying up change before adding new things for #362.

The only behaviour change is that `gather_resources` is ran on initialization of the validation context, and the check for whether a node has concrete input resources is done during the validation, when calling `query_resources`.

Drive-by: Some missing docs for NodeType