### PR TITLE
Reinstate CustomType::new_simple

### DIFF
--- a/src/types/custom.rs
+++ b/src/types/custom.rs
@@ -41,16 +41,11 @@ impl CustomType {
         }
     }
 
-    /// Creates a new opaque type (constant version, no conversions of arguments)
-    pub const fn new_const(
-        id: SmolStr,
-        args: Vec<TypeArg>,
-        resource: ResourceId,
-        tag: TypeTag,
-    ) -> Self {
+    /// Creates a new opaque type (constant version, no type arguments)
+    pub const fn new_simple(id: SmolStr, resource: ResourceId, tag: TypeTag) -> Self {
         Self {
             id,
-            args,
+            args: vec![],
             resource,
             tag,
         }
@@ -106,9 +101,8 @@ pub(crate) mod test {
     pub(crate) const CLASSIC_T: ClassicType =
         ClassicType::Container(Container::Opaque(CLASSIC_CUST));
 
-    pub(crate) const CLASSIC_CUST: CustomType = CustomType::new_const(
+    pub(crate) const CLASSIC_CUST: CustomType = CustomType::new_simple(
         SmolStr::new_inline("MyType"),
-        vec![],
         SmolStr::new_inline("MyRsrc"),
         TypeTag::Classic,
     );

--- a/src/types/custom.rs
+++ b/src/types/custom.rs
@@ -41,6 +41,21 @@ impl CustomType {
         }
     }
 
+    /// Creates a new opaque type (constant version, no conversions of arguments)
+    pub const fn new_const(
+        id: SmolStr,
+        args: Vec<TypeArg>,
+        resource: ResourceId,
+        tag: TypeTag,
+    ) -> Self {
+        Self {
+            id,
+            args,
+            resource,
+            tag,
+        }
+    }
+
     /// Returns the tag of this [`CustomType`].
     pub fn tag(&self) -> TypeTag {
         self.tag
@@ -91,10 +106,10 @@ pub(crate) mod test {
     pub(crate) const CLASSIC_T: ClassicType =
         ClassicType::Container(Container::Opaque(CLASSIC_CUST));
 
-    pub(crate) const CLASSIC_CUST: CustomType = CustomType {
-        resource: SmolStr::new_inline("MyRsrc"),
-        id: SmolStr::new_inline("MyType"),
-        args: vec![],
-        tag: TypeTag::Classic,
-    };
+    pub(crate) const CLASSIC_CUST: CustomType = CustomType::new_const(
+        SmolStr::new_inline("MyType"),
+        vec![],
+        SmolStr::new_inline("MyRsrc"),
+        TypeTag::Classic,
+    );
 }


### PR DESCRIPTION
`CustomType::new_simple` was removed in #315 but I don't see why we can't. This version allows specifying type-arguments too.

There are uses of `CLASSIC_T` (all in tests) in `src/ops/constant.rs`, `src/resource/type_def.rs`, `src/types/simple/serialize.rs` and a mention in `src/types/simple.rs`. We *could* now create local versions of `CLASSIC_T` for each of those (whereas before there was only one place that we could construct such). But for test code I'm not feeling worried. If you think I should be less lazy then please shout and I will do so ;-)