### PR TITLE
Redux/serialize

### DIFF
--- a/src/types/type_enum.rs
+++ b/src/types/type_enum.rs
@@ -12,9 +12,16 @@ use super::{
 
 mod serialize;
 
-#[derive(Clone, PartialEq, Debug, Eq, derive_more::Display)]
+#[derive(
+    Clone, PartialEq, Debug, Eq, derive_more::Display, serde::Serialize, serde::Deserialize,
+)]
 #[display(bound = "T: Display")]
 #[display(fmt = "{}")]
+#[serde(
+    into = "serialize::SerSimpleType",
+    try_from = "serialize::SerSimpleType",
+    bound = "T:serialize::SerLeaf"
+)]
 pub enum Type<T: TypeClass> {
     Prim(T),
     Extension(Tagged<CustomType, T>),

--- a/src/types/type_enum.rs
+++ b/src/types/type_enum.rs
@@ -10,6 +10,8 @@ use super::{
     AbstractSignature, CustomType, TypeTag,
 };
 
+mod serialize;
+
 #[derive(Clone, PartialEq, Debug, Eq, derive_more::Display)]
 #[display(bound = "T: Display")]
 #[display(fmt = "{}")]

--- a/src/types/type_enum/serialize.rs
+++ b/src/types/type_enum/serialize.rs
@@ -15,10 +15,10 @@ pub(crate) enum SerSimpleType {
     I,
     G(AbstractSignature),
     Tuple {
-        r: Vec<SerSimpleType>,
+        inner: Vec<SerSimpleType>,
     },
     Sum {
-        r: Vec<SerSimpleType>,
+        inner: Vec<SerSimpleType>,
     },
     Array {
         inner: Box<SerSimpleType>,
@@ -36,10 +36,10 @@ impl<T: SerLeaf> From<Type<T>> for SerSimpleType {
         match value {
             Type::Prim(t) => t.ser(),
             Type::Sum(inner) => SerSimpleType::Sum {
-                r: inner.into_iter().map_into().collect(),
+                inner: inner.into_iter().map_into().collect(),
             },
             Type::Tuple(inner) => SerSimpleType::Tuple {
-                r: inner.into_iter().map_into().collect(),
+                inner: inner.into_iter().map_into().collect(),
             },
             Type::Array(inner, len) => SerSimpleType::Array {
                 inner: Box::new((*inner).into()),
@@ -113,13 +113,13 @@ impl<T: TypeClass + SerLeaf> TryFrom<SerSimpleType> for Type<T> {
         match value {
             SerSimpleType::I => Ok(T::usize()),
             SerSimpleType::G(sig) => T::graph(sig),
-            SerSimpleType::Tuple { r: elems } => Ok(Type::new_tuple(
+            SerSimpleType::Tuple { inner: elems } => Ok(Type::new_tuple(
                 elems
                     .into_iter()
                     .map(Type::<T>::try_from)
                     .collect::<Result<Vec<_>, _>>()?,
             )),
-            SerSimpleType::Sum { r: elems } => Ok(Type::new_sum(
+            SerSimpleType::Sum { inner: elems } => Ok(Type::new_sum(
                 elems
                     .into_iter()
                     .map(Type::<T>::try_from)
@@ -149,7 +149,7 @@ mod test {
 
         assert_eq!(ser_roundtrip(&g), g);
 
-        // A Simple tuple
+        // A Simple tuple (that actually happens to be Classic)
         let t = Type::<AnyLeaf>::new_tuple([Type::usize(), g.into()]);
         assert_eq!(ser_roundtrip(&t), t);
 

--- a/src/types/type_enum/serialize.rs
+++ b/src/types/type_enum/serialize.rs
@@ -1,0 +1,244 @@
+use super::ClassicType;
+
+use super::Container;
+
+use super::HashableType;
+use super::PrimType;
+use super::TypeTag;
+
+use itertools::Itertools;
+use smol_str::SmolStr;
+
+use super::super::custom::CustomType;
+
+use super::TypeRow;
+
+use super::SimpleType;
+
+use super::super::AbstractSignature;
+
+use crate::types::type_row::TypeRowElem;
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+#[serde(tag = "t")]
+pub(crate) enum SerSimpleType {
+    Q,
+    I,
+    S,
+    G {
+        signature: Box<AbstractSignature>,
+    },
+    Tuple {
+        row: Vec<SerSimpleType>,
+        c: TypeTag,
+    },
+    Sum {
+        row: Vec<SerSimpleType>,
+        c: TypeTag,
+    },
+    Array {
+        inner: Box<SerSimpleType>,
+        len: usize,
+        c: TypeTag,
+    },
+    Opaque {
+        custom: CustomType,
+        c: TypeTag,
+    },
+    Alias {
+        name: SmolStr,
+        c: TypeTag,
+    },
+    Var {
+        name: SmolStr,
+    },
+}
+
+trait SerializableType: PrimType {
+    const TAG: TypeTag;
+}
+
+impl SerializableType for ClassicType {
+    const TAG: TypeTag = TypeTag::Classic;
+}
+
+impl SerializableType for SimpleType {
+    const TAG: TypeTag = TypeTag::Simple;
+}
+
+impl SerializableType for HashableType {
+    const TAG: TypeTag = TypeTag::Hashable;
+}
+
+impl<T: SerializableType> From<Container<T>> for SerSimpleType
+where
+    SerSimpleType: From<T>,
+    SimpleType: From<T>,
+{
+    fn from(value: Container<T>) -> Self {
+        match value {
+            Container::Sum(inner) => SerSimpleType::Sum {
+                row: inner.into_owned().into_iter().map_into().collect(),
+                c: T::TAG, // We could inspect inner.containing_tag(), but this should have been done already
+            },
+            Container::Tuple(inner) => SerSimpleType::Tuple {
+                row: inner.into_owned().into_iter().map_into().collect(),
+                c: T::TAG,
+            },
+            Container::Array(inner, len) => SerSimpleType::Array {
+                inner: Box::new((*inner).into()),
+                len,
+                c: T::TAG,
+            },
+            Container::Alias(name) => SerSimpleType::Alias { name, c: T::TAG },
+            Container::Opaque(custom) => SerSimpleType::Opaque { custom, c: T::TAG },
+        }
+    }
+}
+
+impl From<HashableType> for SerSimpleType {
+    fn from(value: HashableType) -> Self {
+        match value {
+            HashableType::Variable(s) => SerSimpleType::Var { name: s },
+            HashableType::USize => SerSimpleType::I,
+            HashableType::String => SerSimpleType::S,
+            HashableType::Container(c) => c.into(),
+        }
+    }
+}
+
+impl From<ClassicType> for SerSimpleType {
+    fn from(value: ClassicType) -> Self {
+        match value {
+            ClassicType::Graph(inner) => SerSimpleType::G {
+                signature: Box::new(*inner),
+            },
+            ClassicType::Container(c) => c.into(),
+            ClassicType::Hashable(h) => h.into(),
+        }
+    }
+}
+
+impl From<SimpleType> for SerSimpleType {
+    fn from(value: SimpleType) -> Self {
+        match value {
+            SimpleType::Classic(c) => c.into(),
+            SimpleType::Qubit => SerSimpleType::Q,
+            SimpleType::Qontainer(c) => c.into(),
+        }
+    }
+}
+
+fn try_convert_list<T: TryInto<T2>, T2: TypeRowElem>(
+    values: Vec<T>,
+) -> Result<TypeRow<T2>, T::Error> {
+    let vals = values
+        .into_iter()
+        .map(T::try_into)
+        .collect::<Result<Vec<T2>, T::Error>>()?;
+    Ok(TypeRow::from(vals))
+}
+
+macro_rules! handle_container {
+   ($tag:ident, $variant:ident($($r:expr),*)) => {
+        match $tag {
+            TypeTag::Simple => (Container::<SimpleType>::$variant($($r),*)).into(),
+            TypeTag::Classic => (Container::<ClassicType>::$variant($($r),*)).into(),
+            TypeTag::Hashable => (Container::<HashableType>::$variant($($r),*)).into()
+        }
+    }
+}
+
+impl From<SerSimpleType> for SimpleType {
+    fn from(value: SerSimpleType) -> Self {
+        match value {
+            SerSimpleType::Q => SimpleType::Qubit,
+            SerSimpleType::I => HashableType::USize.into(),
+            SerSimpleType::S => HashableType::String.into(),
+            SerSimpleType::G { signature } => ClassicType::Graph(Box::new(*signature)).into(),
+            SerSimpleType::Tuple { row: inner, c } => {
+                handle_container!(c, Tuple(Box::new(try_convert_list(inner).unwrap())))
+            }
+            SerSimpleType::Sum { row: inner, c } => {
+                handle_container!(c, Sum(Box::new(try_convert_list(inner).unwrap())))
+            }
+            SerSimpleType::Array { inner, len, c } => {
+                handle_container!(c, Array(Box::new((*inner).try_into().unwrap()), len))
+            }
+            SerSimpleType::Alias { name: s, c } => handle_container!(c, Alias(s)),
+            SerSimpleType::Opaque { custom, c } => {
+                handle_container!(c, Opaque(custom))
+            }
+            SerSimpleType::Var { name: s } => {
+                ClassicType::Hashable(HashableType::Variable(s)).into()
+            }
+        }
+    }
+}
+
+impl TryFrom<SerSimpleType> for ClassicType {
+    type Error = String;
+
+    fn try_from(value: SerSimpleType) -> Result<Self, Self::Error> {
+        let s: SimpleType = value.into();
+        if let SimpleType::Classic(c) = s {
+            Ok(c)
+        } else {
+            Err(format!("Not a ClassicType: {}", s))
+        }
+    }
+}
+
+impl TryFrom<SerSimpleType> for HashableType {
+    type Error = String;
+    fn try_from(value: SerSimpleType) -> Result<Self, Self::Error> {
+        match value.try_into()? {
+            ClassicType::Hashable(h) => Ok(h),
+            ty => Err(format!("Classic type is not hashable: {}", ty)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::hugr::serialize::test::ser_roundtrip;
+    use crate::types::custom::test::CLASSIC_T;
+    use crate::types::{ClassicType, Container, HashableType, SimpleType};
+
+    #[test]
+    fn serialize_types_roundtrip() {
+        // A Simple tuple
+        let t = SimpleType::new_tuple(vec![
+            SimpleType::Qubit,
+            SimpleType::from(HashableType::USize),
+        ]);
+        assert_eq!(ser_roundtrip(&t), t);
+
+        // A Classic sum
+        let t = SimpleType::new_sum(vec![
+            SimpleType::Classic(ClassicType::Hashable(HashableType::USize)),
+            SimpleType::Classic(CLASSIC_T),
+        ]);
+        assert_eq!(ser_roundtrip(&t), t);
+
+        // A Hashable list
+        let t = SimpleType::Classic(ClassicType::Hashable(HashableType::Container(
+            Container::Array(Box::new(HashableType::USize), 3),
+        )));
+        assert_eq!(ser_roundtrip(&t), t);
+    }
+
+    #[test]
+    fn serialize_types_current_behaviour() {
+        // This list should be represented as a HashableType::Container.
+        let malformed = SimpleType::Qontainer(Container::Array(
+            Box::new(SimpleType::Classic(ClassicType::Hashable(
+                HashableType::USize,
+            ))),
+            6,
+        ));
+        // If this behaviour changes, i.e. to return the well-formed version, that'd be fine.
+        // Just to document current serialization behaviour that we leave it untouched.
+        assert_eq!(ser_roundtrip(&malformed), malformed);
+    }
+}

--- a/src/types/type_enum/serialize.rs
+++ b/src/types/type_enum/serialize.rs
@@ -1,200 +1,127 @@
-use super::ClassicType;
-
-use super::Container;
-
-use super::HashableType;
-use super::PrimType;
-use super::TypeTag;
+use super::{AnyLeaf, CopyableLeaf, EqLeaf, InvalidBound, Type, TypeClass, TypeTag};
 
 use itertools::Itertools;
 use smol_str::SmolStr;
 
 use super::super::custom::CustomType;
 
-use super::TypeRow;
-
-use super::SimpleType;
-
 use super::super::AbstractSignature;
 
-use crate::types::type_row::TypeRowElem;
+use crate::ops::AliasDecl;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 #[serde(tag = "t")]
 pub(crate) enum SerSimpleType {
-    Q,
     I,
-    S,
-    G {
-        signature: Box<AbstractSignature>,
-    },
-    Tuple {
-        row: Vec<SerSimpleType>,
-        c: TypeTag,
-    },
-    Sum {
-        row: Vec<SerSimpleType>,
-        c: TypeTag,
-    },
+    G(AbstractSignature),
+    Tuple(Vec<SerSimpleType>),
+    Sum(Vec<SerSimpleType>),
     Array {
         inner: Box<SerSimpleType>,
         len: usize,
-        c: TypeTag,
     },
-    Opaque {
-        custom: CustomType,
-        c: TypeTag,
-    },
+    Opaque(CustomType),
     Alias {
         name: SmolStr,
         c: TypeTag,
     },
-    Var {
-        name: SmolStr,
-    },
 }
 
-trait SerializableType: PrimType {
-    const TAG: TypeTag;
-}
-
-impl SerializableType for ClassicType {
-    const TAG: TypeTag = TypeTag::Classic;
-}
-
-impl SerializableType for SimpleType {
-    const TAG: TypeTag = TypeTag::Simple;
-}
-
-impl SerializableType for HashableType {
-    const TAG: TypeTag = TypeTag::Hashable;
-}
-
-impl<T: SerializableType> From<Container<T>> for SerSimpleType
-where
-    SerSimpleType: From<T>,
-    SimpleType: From<T>,
-{
-    fn from(value: Container<T>) -> Self {
+impl<T: SerLeaf> From<Type<T>> for SerSimpleType {
+    fn from(value: Type<T>) -> Self {
         match value {
-            Container::Sum(inner) => SerSimpleType::Sum {
-                row: inner.into_owned().into_iter().map_into().collect(),
-                c: T::TAG, // We could inspect inner.containing_tag(), but this should have been done already
-            },
-            Container::Tuple(inner) => SerSimpleType::Tuple {
-                row: inner.into_owned().into_iter().map_into().collect(),
-                c: T::TAG,
-            },
-            Container::Array(inner, len) => SerSimpleType::Array {
+            Type::Prim(t) => t.ser(),
+            Type::Sum(inner) => SerSimpleType::Sum(inner.into_iter().map_into().collect()),
+            Type::Tuple(inner) => SerSimpleType::Tuple(inner.into_iter().map_into().collect()),
+            Type::Array(inner, len) => SerSimpleType::Array {
                 inner: Box::new((*inner).into()),
                 len,
-                c: T::TAG,
             },
-            Container::Alias(name) => SerSimpleType::Alias { name, c: T::TAG },
-            Container::Opaque(custom) => SerSimpleType::Opaque { custom, c: T::TAG },
-        }
-    }
-}
-
-impl From<HashableType> for SerSimpleType {
-    fn from(value: HashableType) -> Self {
-        match value {
-            HashableType::Variable(s) => SerSimpleType::Var { name: s },
-            HashableType::USize => SerSimpleType::I,
-            HashableType::String => SerSimpleType::S,
-            HashableType::Container(c) => c.into(),
-        }
-    }
-}
-
-impl From<ClassicType> for SerSimpleType {
-    fn from(value: ClassicType) -> Self {
-        match value {
-            ClassicType::Graph(inner) => SerSimpleType::G {
-                signature: Box::new(*inner),
+            Type::Alias(decl) => SerSimpleType::Alias {
+                name: decl.inner().name.clone(),
+                c: decl.inner().tag,
             },
-            ClassicType::Container(c) => c.into(),
-            ClassicType::Hashable(h) => h.into(),
+            Type::Extension(custom) => SerSimpleType::Opaque(custom.inner().clone()),
         }
     }
 }
 
-impl From<SimpleType> for SerSimpleType {
-    fn from(value: SimpleType) -> Self {
+pub(super) trait SerLeaf: TypeClass {
+    fn usize() -> Type<Self>;
+    fn graph(sig: AbstractSignature) -> Result<Type<Self>, InvalidBound>;
+    fn ser(&self) -> SerSimpleType;
+}
+
+impl SerLeaf for EqLeaf {
+    fn usize() -> Type<EqLeaf> {
+        Type::usize()
+    }
+    fn graph(_sig: AbstractSignature) -> Result<Type<EqLeaf>, InvalidBound> {
+        Err(InvalidBound {
+            bound: TypeTag::Hashable,
+            found: TypeTag::Classic,
+        })
+    }
+    fn ser(&self) -> SerSimpleType {
+        match self {
+            EqLeaf::USize => SerSimpleType::I,
+        }
+    }
+}
+
+impl SerLeaf for CopyableLeaf {
+    fn usize() -> Type<CopyableLeaf> {
+        Type::usize()
+    }
+    fn graph(sig: AbstractSignature) -> Result<Type<CopyableLeaf>, InvalidBound> {
+        Ok(Type::graph(sig))
+    }
+    fn ser(&self) -> SerSimpleType {
+        match self {
+            CopyableLeaf::E(e) => e.ser(),
+            CopyableLeaf::Graph(sig) => SerSimpleType::G((**sig).clone()),
+        }
+    }
+}
+
+impl SerLeaf for AnyLeaf {
+    fn usize() -> Type<AnyLeaf> {
+        Type::usize()
+    }
+    fn graph(sig: AbstractSignature) -> Result<Type<AnyLeaf>, InvalidBound> {
+        Ok(Type::graph(sig))
+    }
+    fn ser(&self) -> SerSimpleType {
+        match self {
+            AnyLeaf::C(c) => c.ser(),
+        }
+    }
+}
+
+impl<T: TypeClass + SerLeaf> TryFrom<SerSimpleType> for Type<T> {
+    type Error = InvalidBound;
+
+    fn try_from(value: SerSimpleType) -> Result<Self, InvalidBound> {
         match value {
-            SimpleType::Classic(c) => c.into(),
-            SimpleType::Qubit => SerSimpleType::Q,
-            SimpleType::Qontainer(c) => c.into(),
-        }
-    }
-}
-
-fn try_convert_list<T: TryInto<T2>, T2: TypeRowElem>(
-    values: Vec<T>,
-) -> Result<TypeRow<T2>, T::Error> {
-    let vals = values
-        .into_iter()
-        .map(T::try_into)
-        .collect::<Result<Vec<T2>, T::Error>>()?;
-    Ok(TypeRow::from(vals))
-}
-
-macro_rules! handle_container {
-   ($tag:ident, $variant:ident($($r:expr),*)) => {
-        match $tag {
-            TypeTag::Simple => (Container::<SimpleType>::$variant($($r),*)).into(),
-            TypeTag::Classic => (Container::<ClassicType>::$variant($($r),*)).into(),
-            TypeTag::Hashable => (Container::<HashableType>::$variant($($r),*)).into()
-        }
-    }
-}
-
-impl From<SerSimpleType> for SimpleType {
-    fn from(value: SerSimpleType) -> Self {
-        match value {
-            SerSimpleType::Q => SimpleType::Qubit,
-            SerSimpleType::I => HashableType::USize.into(),
-            SerSimpleType::S => HashableType::String.into(),
-            SerSimpleType::G { signature } => ClassicType::Graph(Box::new(*signature)).into(),
-            SerSimpleType::Tuple { row: inner, c } => {
-                handle_container!(c, Tuple(Box::new(try_convert_list(inner).unwrap())))
+            SerSimpleType::I => Ok(T::usize()),
+            SerSimpleType::G(sig) => T::graph(sig),
+            SerSimpleType::Tuple(elems) => Ok(Type::new_tuple(
+                elems
+                    .into_iter()
+                    .map(Type::<T>::try_from)
+                    .collect::<Result<Vec<_>, _>>()?,
+            )),
+            SerSimpleType::Sum(elems) => Ok(Type::new_sum(
+                elems
+                    .into_iter()
+                    .map(Type::<T>::try_from)
+                    .collect::<Result<Vec<_>, _>>()?,
+            )),
+            SerSimpleType::Array { inner, len } => {
+                Ok(Type::Array(Box::new((*inner).try_into()?), len))
             }
-            SerSimpleType::Sum { row: inner, c } => {
-                handle_container!(c, Sum(Box::new(try_convert_list(inner).unwrap())))
-            }
-            SerSimpleType::Array { inner, len, c } => {
-                handle_container!(c, Array(Box::new((*inner).try_into().unwrap()), len))
-            }
-            SerSimpleType::Alias { name: s, c } => handle_container!(c, Alias(s)),
-            SerSimpleType::Opaque { custom, c } => {
-                handle_container!(c, Opaque(custom))
-            }
-            SerSimpleType::Var { name: s } => {
-                ClassicType::Hashable(HashableType::Variable(s)).into()
-            }
-        }
-    }
-}
-
-impl TryFrom<SerSimpleType> for ClassicType {
-    type Error = String;
-
-    fn try_from(value: SerSimpleType) -> Result<Self, Self::Error> {
-        let s: SimpleType = value.into();
-        if let SimpleType::Classic(c) = s {
-            Ok(c)
-        } else {
-            Err(format!("Not a ClassicType: {}", s))
-        }
-    }
-}
-
-impl TryFrom<SerSimpleType> for HashableType {
-    type Error = String;
-    fn try_from(value: SerSimpleType) -> Result<Self, Self::Error> {
-        match value.try_into()? {
-            ClassicType::Hashable(h) => Ok(h),
-            ty => Err(format!("Classic type is not hashable: {}", ty)),
+            SerSimpleType::Opaque(custom) => Type::new_extension(custom),
+            SerSimpleType::Alias { name, c } => Type::new_alias(AliasDecl::new(name, c)),
         }
     }
 }
@@ -202,43 +129,29 @@ impl TryFrom<SerSimpleType> for HashableType {
 #[cfg(test)]
 mod test {
     use crate::hugr::serialize::test::ser_roundtrip;
-    use crate::types::custom::test::CLASSIC_T;
-    use crate::types::{ClassicType, Container, HashableType, SimpleType};
+    use crate::types::custom::test::CLASSIC_CUST;
+    use crate::types::type_enum::{AnyLeaf, CopyableLeaf, EqLeaf, Type};
+    use crate::types::AbstractSignature;
 
     #[test]
     fn serialize_types_roundtrip() {
+        let g: Type<CopyableLeaf> = Type::graph(AbstractSignature::new_linear(vec![
+            crate::types::SimpleType::Qubit,
+        ]));
+
         // A Simple tuple
-        let t = SimpleType::new_tuple(vec![
-            SimpleType::Qubit,
-            SimpleType::from(HashableType::USize),
-        ]);
+        let t = Type::<AnyLeaf>::new_tuple([Type::usize(), g.into()]);
         assert_eq!(ser_roundtrip(&t), t);
 
         // A Classic sum
-        let t = SimpleType::new_sum(vec![
-            SimpleType::Classic(ClassicType::Hashable(HashableType::USize)),
-            SimpleType::Classic(CLASSIC_T),
+        let t = Type::<CopyableLeaf>::new_sum([
+            Type::usize(),
+            Type::new_extension(CLASSIC_CUST).unwrap(),
         ]);
         assert_eq!(ser_roundtrip(&t), t);
 
-        // A Hashable list
-        let t = SimpleType::Classic(ClassicType::Hashable(HashableType::Container(
-            Container::Array(Box::new(HashableType::USize), 3),
-        )));
+        // A Hashable array
+        let t: Type<EqLeaf> = Type::Array(Box::new(Type::usize()), 3);
         assert_eq!(ser_roundtrip(&t), t);
-    }
-
-    #[test]
-    fn serialize_types_current_behaviour() {
-        // This list should be represented as a HashableType::Container.
-        let malformed = SimpleType::Qontainer(Container::Array(
-            Box::new(SimpleType::Classic(ClassicType::Hashable(
-                HashableType::USize,
-            ))),
-            6,
-        ));
-        // If this behaviour changes, i.e. to return the well-formed version, that'd be fine.
-        // Just to document current serialization behaviour that we leave it untouched.
-        assert_eq!(ser_roundtrip(&malformed), malformed);
     }
 }


### PR DESCRIPTION
Add src/types/type_enum/serialize.rs - we might want to think about moving this when we remove the old simple/serialize.rs.

Note I haven't tried the possibility of serializing Type<T> as a `Type<FlattenedLeaf>` or anything like that, that might also work (?).