### PR TITLE
Add a root NodeHandle type param to HugrView

### DIFF
--- a/src/hugr/views.rs
+++ b/src/hugr/views.rs
@@ -11,6 +11,7 @@ use portgraph::{multiportgraph, LinkView, MultiPortGraph, PortView};
 
 use super::{Hugr, NodeMetadata, NodeType};
 use super::{Node, Port};
+use crate::ops::handle::NodeHandle;
 use crate::ops::{OpName, OpTag, OpType};
 use crate::types::EdgeKind;
 use crate::Direction;
@@ -18,6 +19,12 @@ use crate::Direction;
 /// A trait for inspecting HUGRs.
 /// For end users we intend this to be superseded by region-specific APIs.
 pub trait HugrView: sealed::HugrInternals {
+    /// The kind of handle that can be used to refer to the root node.
+    ///
+    /// The handle is guaranteed to be able to contain the operation returned by
+    /// [`root_type`].
+    type RootHandle: NodeHandle;
+
     /// An Iterator over the nodes in a Hugr(View)
     type Nodes<'a>: Iterator<Item = Node>
     where
@@ -199,6 +206,8 @@ impl<T> HugrView for T
 where
     T: AsRef<Hugr>,
 {
+    type RootHandle = Node;
+
     /// An Iterator over the nodes in a Hugr(View)
     type Nodes<'a> = MapInto<multiportgraph::Nodes<'a>, Node> where Self: 'a;
 

--- a/src/hugr/views.rs
+++ b/src/hugr/views.rs
@@ -22,7 +22,7 @@ pub trait HugrView: sealed::HugrInternals {
     /// The kind of handle that can be used to refer to the root node.
     ///
     /// The handle is guaranteed to be able to contain the operation returned by
-    /// [`root_type`].
+    /// [`HugrView::root_type`].
     type RootHandle: NodeHandle;
 
     /// An Iterator over the nodes in a Hugr(View)

--- a/src/hugr/views/hierarchy.rs
+++ b/src/hugr/views/hierarchy.rs
@@ -69,6 +69,8 @@ where
     Root: NodeHandle,
     Base: HugrInternals + HugrView,
 {
+    type RootHandle = Root;
+
     type Nodes<'a> = iter::Chain<iter::Once<Node>, MapInto<portgraph::hierarchy::Children<'a>, Node>>
     where
         Self: 'a;
@@ -238,6 +240,8 @@ where
     Root: NodeHandle,
     Base: HugrInternals + HugrView,
 {
+    type RootHandle = Root;
+
     type Nodes<'a> = MapInto<<RegionGraph<'g, Base> as PortView>::Nodes<'a>, Node>
     where
         Self: 'a;


### PR DESCRIPTION
I'll say this closes #380.

We could go further and add a type parameter in `Hugr<T: NodeHandle>`, but that would probably be annoying to use and it'd break the pyo3 machinery.

Instead, most things should be interfacing via `HugrView`. #284 / #293 will move the builder references to views instead, so we will be able to statically check the root type.