### PR TITLE
Const usize, qubit, and ERROR type definitions in the prelude

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -88,7 +88,6 @@ impl From<BuildError> for PyErr {
 
 #[cfg(test)]
 mod test {
-    use crate::types::test::{QB_T, USIZE_T};
     use crate::types::{Signature, Type};
     use crate::Hugr;
 
@@ -96,9 +95,9 @@ mod test {
     use super::{BuildError, Container, FuncID, FunctionBuilder, ModuleBuilder};
     use super::{DataflowSubContainer, HugrBuilder};
 
-    pub(super) const NAT: Type = USIZE_T;
-    pub(super) const BIT: Type = USIZE_T;
-    pub(super) const QB: Type = QB_T;
+    pub(super) const NAT: Type = crate::resource::prelude::USIZE_T;
+    pub(super) const BIT: Type = crate::resource::prelude::USIZE_T;
+    pub(super) const QB: Type = crate::resource::prelude::QB_T;
 
     /// Wire up inputs of a Dataflow container to the outputs.
     pub(super) fn n_identity<T: DataflowSubContainer>(

--- a/src/builder/tail_loop.rs
+++ b/src/builder/tail_loop.rs
@@ -100,16 +100,15 @@ mod test {
         },
         hugr::ValidationError,
         ops::Const,
-        type_row,
-        types::Type,
-        Hugr,
+        resource::prelude::USIZE_T,
+        type_row, Hugr,
     };
 
     use super::*;
     #[test]
     fn basic_loop() -> Result<(), BuildError> {
         let build_result: Result<Hugr, ValidationError> = {
-            let mut loop_b = TailLoopBuilder::new(vec![], vec![BIT], vec![Type::new_usize()])?;
+            let mut loop_b = TailLoopBuilder::new(vec![], vec![BIT], vec![USIZE_T])?;
             let [i1] = loop_b.input_wires_arr();
             let const_wire = loop_b.add_load_const(Const::usize(1))?;
 
@@ -133,11 +132,8 @@ mod test {
             let _fdef = {
                 let [b1] = fbuild.input_wires_arr();
                 let loop_id = {
-                    let mut loop_b = fbuild.tail_loop_builder(
-                        vec![(Type::new_usize(), b1)],
-                        vec![],
-                        type_row![NAT],
-                    )?;
+                    let mut loop_b =
+                        fbuild.tail_loop_builder(vec![(USIZE_T, b1)], vec![], type_row![NAT])?;
                     let signature = loop_b.loop_signature()?.clone();
                     let const_wire = loop_b.add_load_const(Const::true_val())?;
                     let [b1] = loop_b.input_wires_arr();

--- a/src/extensions/arithmetic/conversions.rs
+++ b/src/extensions/arithmetic/conversions.rs
@@ -8,7 +8,7 @@ use crate::{
     resource::{ResourceSet, SignatureError},
     types::{
         type_param::{TypeArg, TypeParam},
-        Type, TypeRow, ERROR_TYPE,
+        Type, TypeRow,
     },
     utils::collect_array,
     Resource,
@@ -25,7 +25,11 @@ fn ftoi_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ResourceSet), S
     let n: u8 = get_width(arg)?;
     Ok((
         vec![float64_type()].into(),
-        vec![Type::new_sum(vec![int_type(n), ERROR_TYPE])].into(),
+        vec![Type::new_sum(vec![
+            int_type(n),
+            crate::resource::prelude::ERROR_TYPE,
+        ])]
+        .into(),
         ResourceSet::default(),
     ))
 }

--- a/src/extensions/arithmetic/int_ops.rs
+++ b/src/extensions/arithmetic/int_ops.rs
@@ -4,8 +4,8 @@ use smol_str::SmolStr;
 
 use super::super::logic::bool_type;
 use super::int_types::{get_width, int_type};
+use crate::resource::prelude::ERROR_TYPE;
 use crate::types::type_param::TypeParam;
-use crate::types::ERROR_TYPE;
 use crate::utils::collect_array;
 use crate::{
     resource::{ResourceSet, SignatureError},

--- a/src/hugr/rewrite/simple_replace.rs
+++ b/src/hugr/rewrite/simple_replace.rs
@@ -213,13 +213,13 @@ mod test {
     use crate::hugr::{Hugr, Node};
     use crate::ops::OpTag;
     use crate::ops::{LeafOp, OpTrait, OpType};
-    use crate::types::test::QB_T;
+    use crate::resource::prelude::USIZE_T;
     use crate::types::{AbstractSignature, Type};
     use crate::{type_row, Port};
 
     use super::SimpleReplacement;
 
-    const QB: Type = QB_T;
+    const QB: Type = crate::resource::prelude::QB_T;
 
     /// Creates a hugr like the following:
     /// --   H   --
@@ -510,8 +510,8 @@ mod test {
 
     #[test]
     fn test_replace_after_copy() {
-        let one_bit: Vec<Type> = vec![Type::new_usize()];
-        let two_bit: Vec<Type> = vec![Type::new_usize(), Type::new_usize()];
+        let one_bit: Vec<Type> = vec![USIZE_T];
+        let two_bit: Vec<Type> = vec![USIZE_T, USIZE_T];
 
         let mut builder =
             DFGBuilder::new(AbstractSignature::new_df(one_bit.clone(), one_bit.clone())).unwrap();

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -676,14 +676,13 @@ mod test {
     use crate::ops::dataflow::IOTrait;
     use crate::ops::{self, LeafOp, OpType};
     use crate::resource::ResourceSet;
-    use crate::types::test::{QB_T, USIZE_T};
     use crate::types::{AbstractSignature, Type};
     use crate::Direction;
     use crate::{type_row, Node};
 
-    const NAT: Type = USIZE_T;
-    const B: Type = USIZE_T;
-    const Q: Type = QB_T;
+    const NAT: Type = crate::resource::prelude::USIZE_T;
+    const B: Type = crate::resource::prelude::USIZE_T;
+    const Q: Type = crate::resource::prelude::QB_T;
 
     /// Creates a hugr with a single function definition that copies a bit `copies` times.
     ///
@@ -715,12 +714,7 @@ mod test {
             .add_op_with_parent(parent, ops::Output::new(vec![B; copies]))
             .unwrap();
         let copy = b
-            .add_op_with_parent(
-                parent,
-                LeafOp::Noop {
-                    ty: Type::new_usize(),
-                },
-            )
+            .add_op_with_parent(parent, LeafOp::Noop { ty: NAT })
             .unwrap();
 
         b.connect(input, 0, copy, 0).unwrap();
@@ -887,12 +881,7 @@ mod test {
             .unwrap();
 
         // Replace the output operation of the df subgraph with a copy
-        b.replace_op(
-            output,
-            NodeType::pure(LeafOp::Noop {
-                ty: Type::new_usize(),
-            }),
-        );
+        b.replace_op(output, NodeType::pure(LeafOp::Noop { ty: NAT }));
         assert_matches!(
             b.validate(),
             Err(ValidationError::InvalidInitialChild { parent, .. }) => assert_eq!(parent, def)
@@ -1067,12 +1056,7 @@ mod test {
         );
         // Second input of Xor from a constant
         let cst = h.add_op_with_parent(h.root(), ops::Const::usize(1))?;
-        let lcst = h.add_op_with_parent(
-            h.root(),
-            ops::LoadConstant {
-                datatype: Type::new_usize(),
-            },
-        )?;
+        let lcst = h.add_op_with_parent(h.root(), ops::LoadConstant { datatype: NAT })?;
         h.connect(cst, 0, lcst, 0)?;
         h.connect(lcst, 0, xor, 1)?;
         // We are missing the edge from Input to LoadConstant, hence:

--- a/src/hugr/views/hierarchy.rs
+++ b/src/hugr/views/hierarchy.rs
@@ -475,16 +475,13 @@ mod test {
         builder::{Container, Dataflow, DataflowSubContainer, HugrBuilder, ModuleBuilder},
         ops::{handle::NodeHandle, LeafOp},
         type_row,
-        types::{
-            test::{QB_T, USIZE_T},
-            AbstractSignature, Type,
-        },
+        types::{AbstractSignature, Type},
     };
 
     use super::*;
 
-    const NAT: Type = USIZE_T;
-    const QB: Type = QB_T;
+    const NAT: Type = crate::resource::prelude::USIZE_T;
+    const QB: Type = crate::resource::prelude::QB_T;
 
     /// Make a module hugr with a fn definition containing an inner dfg node.
     ///

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -1,7 +1,7 @@
 //! Constant value definitions.
 
 use crate::{
-    resource::PRELUDE,
+    resource::prelude::{USIZE_CUSTOM_T, USIZE_T},
     types::{ConstTypeError, CustomCheckFail, CustomType, EdgeKind, Type, TypeRow},
     values::{CustomConst, Value},
 };
@@ -92,22 +92,17 @@ impl Const {
             }
 
             fn check_custom_type(&self, typ: &CustomType) -> Result<(), CustomCheckFail> {
-                let correct = PRELUDE
-                    .get_type("usize")
-                    .unwrap()
-                    .instantiate_concrete(vec![])
-                    .unwrap();
-                if typ == &correct {
+                if typ == &USIZE_CUSTOM_T {
                     Ok(())
                 } else {
-                    Err(CustomCheckFail::TypeMismatch(correct, typ.clone()))
+                    Err(CustomCheckFail::TypeMismatch(USIZE_CUSTOM_T, typ.clone()))
                 }
             }
         }
 
         Self {
             value: ConstUsize(u).into(),
-            typ: Type::new_usize(),
+            typ: USIZE_T,
         }
     }
 }
@@ -195,7 +190,7 @@ mod test {
 
     #[test]
     fn test_constant_values() {
-        let int_type: Type = Type::new_usize();
+        let int_type: Type = USIZE_T;
         let int_value = Const::usize(257).value;
         int_type.check_type(&int_value).unwrap();
         COPYABLE_T.check_type(&serialized_float(17.4)).unwrap();

--- a/src/ops/leaf.rs
+++ b/src/ops/leaf.rs
@@ -4,6 +4,7 @@ use smol_str::SmolStr;
 
 use super::custom::ExternalOp;
 use super::{OpName, OpTag, OpTrait, StaticTag};
+use crate::resource::prelude::{QB_T, USIZE_T};
 use crate::{
     resource::{ResourceId, ResourceSet},
     types::{AbstractSignature, EdgeKind, SignatureDescription, Type, TypeRow},
@@ -150,14 +151,8 @@ impl OpTrait for LeafOp {
         // copy-on-write strategy, so we can avoid unnecessary allocations.
 
         // TODO use constants and type_row! once static prelude is implemented
-        let qb_type: Type = Type::new_extension(
-            crate::resource::PRELUDE
-                .get_type("qubit")
-                .unwrap()
-                .instantiate_concrete(vec![])
-                .unwrap(),
-        );
-        let bit_type: Type = Type::new_usize();
+        let qb_type: Type = QB_T;
+        let bit_type: Type = USIZE_T;
 
         match self {
             LeafOp::Noop { ty: typ } => {

--- a/src/ops/validate.rs
+++ b/src/ops/validate.rs
@@ -451,23 +451,21 @@ fn validate_cfg_edge(edge: ChildrenEdgeData) -> Result<(), EdgeValidationError> 
 
 #[cfg(test)]
 mod test {
-    use crate::ops;
     use crate::resource::prelude::USIZE_T;
-    use crate::{ops::dataflow::IOTrait, ops::LeafOp, types::Type};
+    use crate::{ops, type_row};
+    use crate::{ops::dataflow::IOTrait, ops::LeafOp};
     use cool_asserts::assert_matches;
 
     use super::*;
 
     #[test]
     fn test_validate_io_nodes() {
-        let bit_type: Type = USIZE_T;
-
-        let in_types: TypeRow = vec![bit_type.clone()].into();
-        let out_types: TypeRow = vec![bit_type.clone(), bit_type.clone()].into();
+        let in_types: TypeRow = type_row![USIZE_T];
+        let out_types: TypeRow = type_row![USIZE_T, USIZE_T];
 
         let input_node: OpType = ops::Input::new(in_types.clone()).into();
         let output_node = ops::Output::new(out_types.clone()).into();
-        let leaf_node = LeafOp::Noop { ty: bit_type }.into();
+        let leaf_node = LeafOp::Noop { ty: USIZE_T }.into();
 
         // Well-formed dataflow sibling nodes. Check the input and output node signatures.
         let children = vec![

--- a/src/ops/validate.rs
+++ b/src/ops/validate.rs
@@ -452,6 +452,7 @@ fn validate_cfg_edge(edge: ChildrenEdgeData) -> Result<(), EdgeValidationError> 
 #[cfg(test)]
 mod test {
     use crate::ops;
+    use crate::resource::prelude::USIZE_T;
     use crate::{ops::dataflow::IOTrait, ops::LeafOp, types::Type};
     use cool_asserts::assert_matches;
 
@@ -459,7 +460,7 @@ mod test {
 
     #[test]
     fn test_validate_io_nodes() {
-        let bit_type: Type = Type::new_usize();
+        let bit_type: Type = USIZE_T;
 
         let in_types: TypeRow = vec![bit_type.clone()].into();
         let out_types: TypeRow = vec![bit_type.clone(), bit_type.clone()].into();

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -19,7 +19,10 @@ mod op_def;
 pub use op_def::{CustomSignatureFunc, OpDef};
 mod type_def;
 pub use type_def::{TypeDef, TypeDefBound};
+pub mod prelude;
 pub mod validate;
+
+pub use prelude::PRELUDE;
 
 /// An error that can occur in computing the signature of a node.
 /// TODO: decide on failure modes
@@ -280,50 +283,4 @@ impl FromIterator<ResourceId> for ResourceSet {
     fn from_iter<I: IntoIterator<Item = ResourceId>>(iter: I) -> Self {
         Self(HashSet::from_iter(iter))
     }
-}
-
-use lazy_static::lazy_static;
-
-lazy_static! {
-    /// Prelude resource
-    pub static ref PRELUDE: Resource = {
-        let mut prelude = Resource::new(SmolStr::new_inline("prelude"));
-        prelude
-            .add_type(
-                SmolStr::new_inline("float64"),
-                vec![],
-                "float64".into(),
-                TypeDefBound::Explicit(crate::types::TypeBound::Copyable),
-            )
-            .unwrap();
-
-            prelude
-            .add_type(
-                SmolStr::new_inline("usize"),
-                vec![],
-                "usize".into(),
-                TypeDefBound::Explicit(crate::types::TypeBound::Eq),
-            )
-            .unwrap();
-
-
-            prelude
-            .add_type(
-                SmolStr::new_inline("array"),
-                vec![TypeParam::Type(None), TypeParam::USize],
-                "array".into(),
-                TypeDefBound::FromParams(vec![0]),
-            )
-            .unwrap();
-
-            prelude
-            .add_type(
-                SmolStr::new_inline("qubit"),
-                vec![],
-                "qubit".into(),
-                TypeDefBound::NoBound,
-            )
-            .unwrap();
-        prelude
-    };
 }

--- a/src/resource/prelude.rs
+++ b/src/resource/prelude.rs
@@ -3,7 +3,14 @@
 use lazy_static::lazy_static;
 use smol_str::SmolStr;
 
-use crate::{resource::TypeDefBound, types::type_param::TypeParam, Resource};
+use crate::{
+    resource::TypeDefBound,
+    types::{
+        type_param::{TypeArg, TypeParam},
+        CustomType, Type, TypeBound,
+    },
+    Resource,
+};
 
 lazy_static! {
     /// Prelude resource
@@ -47,4 +54,28 @@ lazy_static! {
             .unwrap();
         prelude
     };
+}
+
+pub(crate) const USIZE_CUSTOM_T: CustomType = CustomType::new_simple(
+    SmolStr::new_inline("usize"),
+    SmolStr::new_inline("prelude"),
+    Some(TypeBound::Eq),
+);
+
+pub(crate) const QB_CUSTOM_T: CustomType = CustomType::new_simple(
+    SmolStr::new_inline("qubit"),
+    SmolStr::new_inline("prelude"),
+    None,
+);
+
+pub(crate) const QB_T: Type = Type::new_extension(QB_CUSTOM_T);
+pub(crate) const USIZE_T: Type = Type::new_extension(USIZE_CUSTOM_T);
+
+/// Initialize a new array of type `typ` of length `size`
+pub fn new_array(typ: Type, size: u64) -> Type {
+    let array_def = PRELUDE.get_type("array").unwrap();
+    let custom_t = array_def
+        .instantiate_concrete(vec![TypeArg::Type(typ), TypeArg::USize(size)])
+        .unwrap();
+    Type::new_extension(custom_t)
 }

--- a/src/resource/prelude.rs
+++ b/src/resource/prelude.rs
@@ -1,0 +1,50 @@
+//! Prelude extension - available in all contexts, defining common types,
+//! operations and constants.
+use lazy_static::lazy_static;
+use smol_str::SmolStr;
+
+use crate::{resource::TypeDefBound, types::type_param::TypeParam, Resource};
+
+lazy_static! {
+    /// Prelude resource
+    pub static ref PRELUDE: Resource = {
+        let mut prelude = Resource::new(SmolStr::new_inline("prelude"));
+        prelude
+            .add_type(
+                SmolStr::new_inline("float64"),
+                vec![],
+                "float64".into(),
+                TypeDefBound::Explicit(crate::types::TypeBound::Copyable),
+            )
+            .unwrap();
+
+            prelude
+            .add_type(
+                SmolStr::new_inline("usize"),
+                vec![],
+                "usize".into(),
+                TypeDefBound::Explicit(crate::types::TypeBound::Eq),
+            )
+            .unwrap();
+
+
+            prelude
+            .add_type(
+                SmolStr::new_inline("array"),
+                vec![TypeParam::Type(None), TypeParam::USize],
+                "array".into(),
+                TypeDefBound::FromParams(vec![0]),
+            )
+            .unwrap();
+
+            prelude
+            .add_type(
+                SmolStr::new_inline("qubit"),
+                vec![],
+                "qubit".into(),
+                TypeDefBound::NoBound,
+            )
+            .unwrap();
+        prelude
+    };
+}

--- a/src/resource/prelude.rs
+++ b/src/resource/prelude.rs
@@ -79,3 +79,9 @@ pub fn new_array(typ: Type, size: u64) -> Type {
         .unwrap();
     Type::new_extension(custom_t)
 }
+
+pub(crate) const ERROR_TYPE: Type = Type::new_extension(CustomType::new_simple(
+    smol_str::SmolStr::new_inline("error"),
+    smol_str::SmolStr::new_inline("prelude"),
+    Some(TypeBound::Eq),
+));

--- a/src/types.rs
+++ b/src/types.rs
@@ -17,12 +17,11 @@ use itertools::FoldWhile::{Continue, Done};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
+use crate::ops::AliasDecl;
 use crate::type_row;
-use crate::{ops::AliasDecl, resource::PRELUDE};
 use std::fmt::Debug;
 
 use self::primitive::PrimType;
-use self::type_param::TypeArg;
 
 /// The kinds of edges in a HUGR, excluding Hierarchy.
 //#[cfg_attr(feature = "pyo3", pyclass)] # TODO: Manually derive pyclass with non-unit variants
@@ -166,17 +165,6 @@ impl Type {
         Self::new(TypeEnum::Prim(PrimType::Graph(Box::new(signature))))
     }
 
-    /// Initialize a new usize type.
-    pub fn new_usize() -> Self {
-        Self::new_extension(
-            PRELUDE
-                .get_type("usize")
-                .unwrap()
-                .instantiate_concrete(vec![])
-                .unwrap(),
-        )
-    }
-
     /// Initialize a new tuple type by providing the elements..
     #[inline(always)]
     pub fn new_tuple(types: impl Into<TypeRow>) -> Self {
@@ -206,14 +194,6 @@ impl Type {
         Self(type_e, bound)
     }
 
-    /// Initialize a new array of type `typ` of length `size`
-    pub fn new_array(typ: Type, size: u64) -> Self {
-        let array_def = PRELUDE.get_type("array").unwrap();
-        let custom_t = array_def
-            .instantiate_concrete(vec![TypeArg::Type(typ), TypeArg::USize(size)])
-            .unwrap();
-        Self::new_extension(custom_t)
-    }
     /// New Sum of Tuple types, used as predicates in branching.
     /// Tuple rows are defined in order by input rows.
     pub fn new_predicate<V>(variant_rows: impl IntoIterator<Item = V>) -> Self
@@ -266,34 +246,20 @@ pub(crate) const ERROR_TYPE: Type = Type(
 #[cfg(test)]
 pub(crate) mod test {
 
-    use smol_str::SmolStr;
-
     use super::{
         custom::test::{ANY_CUST, COPYABLE_CUST, EQ_CUST},
         *,
     };
-    use crate::ops::AliasDecl;
+    use crate::{ops::AliasDecl, resource::prelude::USIZE_T};
 
     pub(crate) const EQ_T: Type = Type::new_extension(EQ_CUST);
     pub(crate) const COPYABLE_T: Type = Type::new_extension(COPYABLE_CUST);
     pub(crate) const ANY_T: Type = Type::new_extension(ANY_CUST);
 
-    pub(crate) const USIZE_T: Type = Type::new_extension(CustomType::new_simple(
-        SmolStr::new_inline("usize"),
-        SmolStr::new_inline("prelude"),
-        Some(TypeBound::Eq),
-    ));
-
-    pub(crate) const QB_T: Type = Type::new_extension(CustomType::new_simple(
-        SmolStr::new_inline("qubit"),
-        SmolStr::new_inline("prelude"),
-        None,
-    ));
-
     #[test]
     fn construct() {
         let t: Type = Type::new_tuple(vec![
-            Type::new_usize(),
+            USIZE_T,
             Type::new_graph(AbstractSignature::new_linear(vec![])),
             Type::new_extension(CustomType::new(
                 "my_custom",

--- a/src/types.rs
+++ b/src/types.rs
@@ -234,15 +234,6 @@ where
         .into()
 }
 
-pub(crate) const ERROR_TYPE: Type = Type(
-    TypeEnum::Prim(primitive::PrimType::E(CustomType::new_simple(
-        smol_str::SmolStr::new_inline("error"),
-        smol_str::SmolStr::new_inline("MyRsrc"),
-        Some(TypeBound::Eq),
-    ))),
-    Some(TypeBound::Copyable),
-);
-
 #[cfg(test)]
 pub(crate) mod test {
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -191,8 +191,9 @@ impl Type {
 
     /// Initialize a new custom type.
     // TODO remove? Resources/TypeDefs should just provide `Type` directly
-    pub fn new_extension(opaque: CustomType) -> Self {
-        Self::new(TypeEnum::Prim(PrimType::E(opaque)))
+    pub const fn new_extension(opaque: CustomType) -> Self {
+        let bound = opaque.bound();
+        Type(TypeEnum::Prim(PrimType::E(opaque)), bound)
     }
 
     /// Initialize a new alias.
@@ -269,37 +270,25 @@ pub(crate) mod test {
 
     use super::{
         custom::test::{ANY_CUST, COPYABLE_CUST, EQ_CUST},
-        primitive::PrimType,
         *,
     };
     use crate::ops::AliasDecl;
 
-    pub(crate) const EQ_T: Type = Type(TypeEnum::Prim(PrimType::E(EQ_CUST)), Some(TypeBound::Eq));
+    pub(crate) const EQ_T: Type = Type::new_extension(EQ_CUST);
+    pub(crate) const COPYABLE_T: Type = Type::new_extension(COPYABLE_CUST);
+    pub(crate) const ANY_T: Type = Type::new_extension(ANY_CUST);
 
-    pub(crate) const COPYABLE_T: Type = Type(
-        TypeEnum::Prim(PrimType::E(COPYABLE_CUST)),
-        Some(TypeBound::Copyable),
-    );
-
-    pub(crate) const ANY_T: Type = Type(TypeEnum::Prim(PrimType::E(ANY_CUST)), None);
-
-    pub(crate) const USIZE_T: Type = Type(
-        TypeEnum::Prim(PrimType::E(CustomType::new_simple(
-            SmolStr::new_inline("usize"),
-            SmolStr::new_inline("prelude"),
-            Some(TypeBound::Eq),
-        ))),
+    pub(crate) const USIZE_T: Type = Type::new_extension(CustomType::new_simple(
+        SmolStr::new_inline("usize"),
+        SmolStr::new_inline("prelude"),
         Some(TypeBound::Eq),
-    );
+    ));
 
-    pub(crate) const QB_T: Type = Type(
-        TypeEnum::Prim(PrimType::E(CustomType::new_simple(
-            SmolStr::new_inline("qubit"),
-            SmolStr::new_inline("prelude"),
-            None,
-        ))),
+    pub(crate) const QB_T: Type = Type::new_extension(CustomType::new_simple(
+        SmolStr::new_inline("qubit"),
+        SmolStr::new_inline("prelude"),
         None,
-    );
+    ));
 
     #[test]
     fn construct() {

--- a/src/types/custom.rs
+++ b/src/types/custom.rs
@@ -52,7 +52,7 @@ impl CustomType {
     }
 
     /// Returns the bound of this [`CustomType`].
-    pub fn bound(&self) -> Option<TypeBound> {
+    pub const fn bound(&self) -> Option<TypeBound> {
         self.bound
     }
 }

--- a/src/types/serialize.rs
+++ b/src/types/serialize.rs
@@ -7,12 +7,13 @@ use super::custom::CustomType;
 use super::AbstractSignature;
 
 use crate::ops::AliasDecl;
-use crate::resource::prelude::{new_array, USIZE_T};
+use crate::resource::prelude::{new_array, QB_T, USIZE_T};
 use crate::types::primitive::PrimType;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 #[serde(tag = "t")]
 pub(crate) enum SerSimpleType {
+    Q,
     I,
     G(Box<AbstractSignature>),
     Tuple { inner: Vec<SerSimpleType> },
@@ -24,6 +25,13 @@ pub(crate) enum SerSimpleType {
 
 impl From<Type> for SerSimpleType {
     fn from(value: Type) -> Self {
+        if value == QB_T {
+            return SerSimpleType::Q;
+        }
+        if value == USIZE_T {
+            return SerSimpleType::I;
+        }
+        // TODO short circuiting for array.
         let Type(value, _) = value;
         match value {
             TypeEnum::Prim(t) => match t {
@@ -44,6 +52,7 @@ impl From<Type> for SerSimpleType {
 impl From<SerSimpleType> for Type {
     fn from(value: SerSimpleType) -> Type {
         match value {
+            SerSimpleType::Q => QB_T,
             SerSimpleType::I => USIZE_T,
             SerSimpleType::G(sig) => Type::new_graph(*sig),
             SerSimpleType::Tuple { inner } => {

--- a/src/types/serialize.rs
+++ b/src/types/serialize.rs
@@ -7,6 +7,7 @@ use super::custom::CustomType;
 use super::AbstractSignature;
 
 use crate::ops::AliasDecl;
+use crate::resource::prelude::{new_array, USIZE_T};
 use crate::types::primitive::PrimType;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
@@ -43,7 +44,7 @@ impl From<Type> for SerSimpleType {
 impl From<SerSimpleType> for Type {
     fn from(value: SerSimpleType) -> Type {
         match value {
-            SerSimpleType::I => Type::new_usize(),
+            SerSimpleType::I => USIZE_T,
             SerSimpleType::G(sig) => Type::new_graph(*sig),
             SerSimpleType::Tuple { inner } => {
                 Type::new_tuple(inner.into_iter().map_into().collect_vec())
@@ -51,7 +52,7 @@ impl From<SerSimpleType> for Type {
             SerSimpleType::Sum { inner } => {
                 Type::new_sum(inner.into_iter().map_into().collect_vec())
             }
-            SerSimpleType::Array { inner, len } => Type::new_array((*inner).into(), len),
+            SerSimpleType::Array { inner, len } => new_array((*inner).into(), len),
             SerSimpleType::Opaque(custom) => Type::new_extension(custom),
             SerSimpleType::Alias(a) => Type::new_alias(a),
         }
@@ -61,6 +62,7 @@ impl From<SerSimpleType> for Type {
 #[cfg(test)]
 mod test {
     use crate::hugr::serialize::test::ser_roundtrip;
+    use crate::resource::prelude::USIZE_T;
     use crate::types::test::COPYABLE_T;
     use crate::types::AbstractSignature;
     use crate::types::Type;
@@ -72,11 +74,11 @@ mod test {
         assert_eq!(ser_roundtrip(&g), g);
 
         // A Simple tuple
-        let t = Type::new_tuple(vec![Type::new_usize(), g]);
+        let t = Type::new_tuple(vec![USIZE_T, g]);
         assert_eq!(ser_roundtrip(&t), t);
 
         // A Classic sum
-        let t = Type::new_sum(vec![Type::new_usize(), COPYABLE_T]);
+        let t = Type::new_sum(vec![USIZE_T, COPYABLE_T]);
         assert_eq!(ser_roundtrip(&t), t);
     }
 }


### PR DESCRIPTION
Isolate PRELUDE "stringy" codes to the `prelude` module - can be improved with statics etc. in future.