### PR TITLE
Add static values to resources

### DIFF
--- a/src/builder/tail_loop.rs
+++ b/src/builder/tail_loop.rs
@@ -100,7 +100,7 @@ mod test {
         },
         hugr::ValidationError,
         ops::Const,
-        resource::prelude::USIZE_T,
+        resource::prelude::{ConstUsize, USIZE_T},
         type_row, Hugr,
     };
 
@@ -110,7 +110,7 @@ mod test {
         let build_result: Result<Hugr, ValidationError> = {
             let mut loop_b = TailLoopBuilder::new(vec![], vec![BIT], vec![USIZE_T])?;
             let [i1] = loop_b.input_wires_arr();
-            let const_wire = loop_b.add_load_const(Const::usize(1))?;
+            let const_wire = loop_b.add_load_const(ConstUsize::new(1).into())?;
 
             let break_wire = loop_b.make_break(loop_b.loop_signature()?.clone(), [const_wire])?;
             loop_b.set_outputs(break_wire, [i1])?;
@@ -155,7 +155,7 @@ mod test {
                         let mut branch_1 = conditional_b.case_builder(1)?;
                         let [_b1] = branch_1.input_wires_arr();
 
-                        let wire = branch_1.add_load_const(Const::usize(2))?;
+                        let wire = branch_1.add_load_const(ConstUsize::new(2).into())?;
                         let break_wire = branch_1.make_break(signature, [wire])?;
                         branch_1.finish_with_outputs([break_wire])?;
 

--- a/src/extensions/logic.rs
+++ b/src/extensions/logic.rs
@@ -4,6 +4,7 @@ use itertools::Itertools;
 use smol_str::SmolStr;
 
 use crate::{
+    ops,
     resource::ResourceSet,
     types::{
         type_param::{TypeArg, TypeArgError, TypeParam},
@@ -11,6 +12,11 @@ use crate::{
     },
     Resource,
 };
+
+/// Name of resource false value.
+pub const FALSE_NAME: &str = "FALSE";
+/// Name of resource true value.
+pub const TRUE_NAME: &str = "TRUE";
 
 /// The resource identifier.
 pub const RESOURCE_ID: SmolStr = SmolStr::new_inline("logic");
@@ -93,18 +99,36 @@ pub fn resource() -> Resource {
         .unwrap();
 
     resource
+        .add_value(FALSE_NAME, ops::Const::simple_predicate(0, 2))
+        .unwrap();
+    resource
+        .add_value(TRUE_NAME, ops::Const::simple_predicate(1, 2))
+        .unwrap();
+    resource
 }
 
 #[cfg(test)]
 mod test {
     use crate::Resource;
 
-    use super::resource;
+    use super::{bool_type, resource, FALSE_NAME, TRUE_NAME};
 
     #[test]
     fn test_logic_resource() {
         let r: Resource = resource();
         assert_eq!(r.name(), "logic");
         assert_eq!(r.operations().count(), 3);
+    }
+
+    #[test]
+    fn test_values() {
+        let r: Resource = resource();
+        let false_val = r.get_value(FALSE_NAME).unwrap();
+        let true_val = r.get_value(TRUE_NAME).unwrap();
+
+        for v in [false_val, true_val] {
+            let simpl = v.typed_value().const_type();
+            assert_eq!(simpl, &bool_type());
+        }
     }
 }

--- a/src/extensions/rotation.rs
+++ b/src/extensions/rotation.rs
@@ -12,10 +12,11 @@ use pyo3::prelude::*;
 
 use crate::resource::ResourceSet;
 use crate::types::type_param::TypeArg;
-use crate::types::{CustomCheckFailure, Type, TypeRow};
-use crate::types::{CustomType, TypeBound};
+use crate::types::{CustomCheckFailure, CustomType, Type, TypeBound, TypeRow};
 use crate::values::CustomConst;
-use crate::Resource;
+use crate::{ops, Resource};
+
+pub const PI_NAME: &str = "PI";
 
 pub const RESOURCE_ID: SmolStr = SmolStr::new_inline("rotations");
 
@@ -39,6 +40,17 @@ pub fn resource() -> Resource {
         )
         .unwrap();
 
+    let pi_val = Constant::Angle(AngleValue::Rational(Rational(Rational64::new(1, 1))));
+    let pi_type = Type::new_extension(
+        resource
+            .get_type("angle")
+            .unwrap()
+            .instantiate_concrete([])
+            .unwrap(),
+    );
+    resource
+        .add_value(PI_NAME, ops::Const::new(pi_val.into(), pi_type).unwrap())
+        .unwrap();
     resource
 }
 

--- a/src/extensions/rotation.rs
+++ b/src/extensions/rotation.rs
@@ -335,13 +335,18 @@ mod test {
 
     use rstest::{fixture, rstest};
 
-    use super::{AngleValue, RotationValue, ANGLE_T, ANGLE_T_NAME};
+    use super::{AngleValue, RotationValue, ANGLE_T, ANGLE_T_NAME, PI_NAME};
     use crate::{
         resource::SignatureError,
         types::{CustomType, Type, TypeBound},
         values::CustomConst,
         Resource,
     };
+
+    #[fixture]
+    fn resource() -> Resource {
+        super::resource()
+    }
 
     #[rstest]
     fn test_types(resource: Resource) {
@@ -390,8 +395,10 @@ mod test {
         assert!(res.is_err());
     }
 
-    #[fixture]
-    fn resource() -> Resource {
-        super::resource()
+    #[rstest]
+    fn test_constant(resource: Resource) {
+        let pi_val = resource.get_value(PI_NAME).unwrap();
+
+        ANGLE_T.check_type(pi_val.typed_value().value()).unwrap();
     }
 }

--- a/src/extensions/rotation.rs
+++ b/src/extensions/rotation.rs
@@ -144,11 +144,7 @@ impl CustomConst for RotationValue {
     }
 
     fn equal_consts(&self, other: &dyn CustomConst) -> bool {
-        if let Some(other) = other.as_any().downcast_ref::<RotationValue>() {
-            self == other
-        } else {
-            false
-        }
+        crate::values::downcast_equal_consts(self, other)
     }
 }
 

--- a/src/extensions/rotation.rs
+++ b/src/extensions/rotation.rs
@@ -98,7 +98,7 @@ impl From<RotationType> for CustomType {
     }
 }
 
-/// Constant values for [`Type`].
+/// Constant values for [`RotationType`].
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum Constant {
     Angle(AngleValue),

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -675,6 +675,7 @@ mod test {
     use crate::hugr::{HugrError, HugrInternalsMut, NodeType};
     use crate::ops::dataflow::IOTrait;
     use crate::ops::{self, LeafOp, OpType};
+    use crate::resource::prelude::ConstUsize;
     use crate::resource::ResourceSet;
     use crate::types::{AbstractSignature, Type};
     use crate::Direction;
@@ -1054,8 +1055,9 @@ mod test {
                 port_kind: EdgeKind::Value(B)
             })
         );
+        let const_op: ops::Const = ConstUsize::new(1).into();
         // Second input of Xor from a constant
-        let cst = h.add_op_with_parent(h.root(), ops::Const::usize(1))?;
+        let cst = h.add_op_with_parent(h.root(), const_op)?;
         let lcst = h.add_op_with_parent(h.root(), ops::LoadConstant { datatype: NAT })?;
         h.connect(cst, 0, lcst, 0)?;
         h.connect(lcst, 0, xor, 1)?;

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     types::{ConstTypeError, EdgeKind, Type, TypeRow},
-    values::{KnownTypeConst, Value},
+    values::{CustomConst, KnownTypeConst, Value},
 };
 
 use smol_str::SmolStr;
@@ -105,7 +105,10 @@ impl OpTrait for Const {
 
 // [KnownTypeConst] is guaranteed to be the right type, so can be constructed
 // without initial type check.
-impl<T: KnownTypeConst> From<T> for Const {
+impl<T> From<T> for Const
+where
+    T: KnownTypeConst + CustomConst,
+{
     fn from(value: T) -> Self {
         Const {
             value: Value::custom(value),

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -1,9 +1,8 @@
 //! Constant value definitions.
 
 use crate::{
-    resource::prelude::{USIZE_CUSTOM_T, USIZE_T},
-    types::{ConstTypeError, CustomCheckFailure, CustomType, EdgeKind, Type, TypeRow},
-    values::{CustomConst, Value},
+    types::{ConstTypeError, EdgeKind, Type, TypeRow},
+    values::{KnownTypeConst, Value},
 };
 
 use smol_str::SmolStr;
@@ -80,34 +79,6 @@ impl Const {
             .unzip();
         Self::new(Value::tuple(values), Type::new_tuple(types)).unwrap()
     }
-    /// Constant usize value.
-    pub fn usize(u: u64) -> Self {
-        // TODO replace with prelude constant once implemented
-        #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-        struct ConstUsize(u64);
-        #[typetag::serde]
-        impl CustomConst for ConstUsize {
-            fn name(&self) -> SmolStr {
-                format!("ConstUsize({:?})", self.0).into()
-            }
-
-            fn check_custom_type(&self, typ: &CustomType) -> Result<(), CustomCheckFailure> {
-                if typ == &USIZE_CUSTOM_T {
-                    Ok(())
-                } else {
-                    Err(CustomCheckFailure::TypeMismatch {
-                        expected: USIZE_CUSTOM_T,
-                        found: typ.clone(),
-                    })
-                }
-            }
-        }
-
-        Self {
-            value: ConstUsize(u).into(),
-            typ: USIZE_T,
-        }
-    }
 }
 
 impl OpName for Const {
@@ -132,11 +103,23 @@ impl OpTrait for Const {
     }
 }
 
+// [KnownTypeConst] is guaranteed to be the right type, so can be constructed
+// without initial type check.
+impl<T: KnownTypeConst> From<T> for Const {
+    fn from(value: T) -> Self {
+        Const {
+            value: Value::custom(value),
+            typ: Type::new_extension(T::TYPE),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::Const;
     use crate::{
         builder::{BuildError, DFGBuilder, Dataflow, DataflowHugr},
+        resource::prelude::{ConstUsize, USIZE_T},
         type_row,
         types::{test::COPYABLE_T, TypeRow},
         types::{test::EQ_T, type_param::TypeArg, CustomCheckFailure},
@@ -190,9 +173,8 @@ mod test {
 
     #[test]
     fn test_constant_values() {
-        let int_type: Type = USIZE_T;
-        let int_value = Const::usize(257).value;
-        int_type.check_type(&int_value).unwrap();
+        let int_value: Value = ConstUsize::new(257).into();
+        USIZE_T.check_type(&int_value).unwrap();
         COPYABLE_T.check_type(&serialized_float(17.4)).unwrap();
         assert_matches!(
             COPYABLE_T.check_type(&int_value),
@@ -200,7 +182,7 @@ mod test {
                 CustomCheckFailure::TypeMismatch { .. }
             ))
         );
-        let tuple_ty = Type::new_tuple(vec![int_type, COPYABLE_T]);
+        let tuple_ty = Type::new_tuple(vec![USIZE_T, COPYABLE_T]);
         let tuple_val = Value::tuple([int_value.clone(), serialized_float(5.1)]);
         tuple_ty.check_type(&tuple_val).unwrap();
         let tuple_val2 = Value::tuple(vec![serialized_float(6.1), int_value.clone()]);

--- a/src/resource/prelude.rs
+++ b/src/resource/prelude.rs
@@ -96,7 +96,7 @@ impl CustomConst for ConstUsize {
     }
 
     fn check_custom_type(&self, typ: &CustomType) -> Result<(), CustomCheckFailure> {
-        <Self as KnownTypeConst>::check_custom_type(self, typ)
+        self.check_known_type(typ)
     }
 
     fn equal_consts(&self, other: &dyn CustomConst) -> bool {

--- a/src/resource/prelude.rs
+++ b/src/resource/prelude.rs
@@ -7,8 +7,9 @@ use crate::{
     resource::TypeDefBound,
     types::{
         type_param::{TypeArg, TypeParam},
-        CustomType, Type, TypeBound,
+        CustomCheckFailure, CustomType, Type, TypeBound,
     },
+    values::{CustomConst, KnownTypeConst},
     Resource,
 };
 
@@ -76,3 +77,29 @@ pub(crate) const ERROR_TYPE: Type = Type::new_extension(CustomType::new_simple(
     smol_str::SmolStr::new_inline("prelude"),
     TypeBound::Eq,
 ));
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+/// Structure for holding constant usize values.
+pub struct ConstUsize(u64);
+
+impl ConstUsize {
+    /// Creates a new [`ConstUsize`].
+    pub fn new(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+#[typetag::serde]
+impl CustomConst for ConstUsize {
+    fn name(&self) -> SmolStr {
+        format!("ConstUsize({:?})", self.0).into()
+    }
+
+    fn check_custom_type(&self, typ: &CustomType) -> Result<(), CustomCheckFailure> {
+        <Self as KnownTypeConst>::check_custom_type(self, typ)
+    }
+}
+
+impl KnownTypeConst for ConstUsize {
+    const TYPE: CustomType = USIZE_CUSTOM_T;
+}

--- a/src/resource/prelude.rs
+++ b/src/resource/prelude.rs
@@ -78,7 +78,7 @@ pub(crate) const ERROR_TYPE: Type = Type::new_extension(CustomType::new_simple(
     TypeBound::Eq,
 ));
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 /// Structure for holding constant usize values.
 pub struct ConstUsize(u64);
 
@@ -97,6 +97,10 @@ impl CustomConst for ConstUsize {
 
     fn check_custom_type(&self, typ: &CustomType) -> Result<(), CustomCheckFailure> {
         <Self as KnownTypeConst>::check_custom_type(self, typ)
+    }
+
+    fn equal_consts(&self, other: &dyn CustomConst) -> bool {
+        crate::values::downcast_equal_consts(self, other)
     }
 }
 

--- a/src/values.rs
+++ b/src/values.rs
@@ -9,6 +9,7 @@ use downcast_rs::{impl_downcast, Downcast};
 use smol_str::SmolStr;
 
 use crate::macros::impl_box_clone;
+
 use crate::types::{CustomCheckFailure, CustomType};
 
 /// A constant value of a primitive (or leaf) type.
@@ -118,6 +119,25 @@ pub trait CustomConst:
     fn equal_consts(&self, other: &dyn CustomConst) -> bool {
         let _ = other;
         false
+    }
+}
+
+/// Simpler trait for constant structs that have a known custom type to check against.
+pub trait KnownTypeConst: CustomConst {
+    /// The type of the constants.
+    const TYPE: CustomType;
+
+    /// Fixed implementation of [CustomConst::check_custom_type] that checks
+    /// against known correct type.
+    fn check_custom_type(&self, typ: &CustomType) -> Result<(), CustomCheckFailure> {
+        if typ == &Self::TYPE {
+            Ok(())
+        } else {
+            Err(CustomCheckFailure::TypeMismatch {
+                expected: Self::TYPE,
+                found: typ.clone(),
+            })
+        }
     }
 }
 

--- a/src/values.rs
+++ b/src/values.rs
@@ -136,13 +136,13 @@ pub fn downcast_equal_consts<T: CustomConst + PartialEq>(
 }
 
 /// Simpler trait for constant structs that have a known custom type to check against.
-pub trait KnownTypeConst: CustomConst {
+pub trait KnownTypeConst {
     /// The type of the constants.
     const TYPE: CustomType;
 
     /// Fixed implementation of [CustomConst::check_custom_type] that checks
     /// against known correct type.
-    fn check_custom_type(&self, typ: &CustomType) -> Result<(), CustomCheckFailure> {
+    fn check_known_type(&self, typ: &CustomType) -> Result<(), CustomCheckFailure> {
         if typ == &Self::TYPE {
             Ok(())
         } else {

--- a/src/values.rs
+++ b/src/values.rs
@@ -116,8 +116,21 @@ pub trait CustomConst:
     fn check_custom_type(&self, typ: &CustomType) -> Result<(), CustomCheckFailure>;
 
     /// Compare two constants for equality, using downcasting and comparing the definitions.
-    fn equal_consts(&self, other: &dyn CustomConst) -> bool {
-        let _ = other;
+    // Can't derive PartialEq for trait objects
+    fn equal_consts(&self, _other: &dyn CustomConst) -> bool {
+        // false unless overloaded
+        false
+    }
+}
+
+/// Const equality for types that have PartialEq
+pub fn downcast_equal_consts<T: CustomConst + PartialEq>(
+    value: &T,
+    other: &dyn CustomConst,
+) -> bool {
+    if let Some(other) = other.as_any().downcast_ref::<T>() {
+        value == other
+    } else {
         false
     }
 }


### PR DESCRIPTION
* Addition and retrieval of typed ops::Const to resources
* simplify constant definitions with `KnownConstType`
* move `ConstUsize` to prelude