### PR TITLE
Allow custom types defined by static references

### DIFF
--- a/src/extension/prelude.rs
+++ b/src/extension/prelude.rs
@@ -48,20 +48,23 @@ lazy_static! {
     };
 }
 
-pub(crate) const USIZE_CUSTOM_T: CustomType = CustomType::new_simple(
+const USIZE_CUSTOM_T: CustomType = CustomType::new_simple(
     SmolStr::new_inline("usize"),
     SmolStr::new_inline("prelude"),
     TypeBound::Eq,
 );
 
-pub(crate) const QB_CUSTOM_T: CustomType = CustomType::new_simple(
+const QB_CUSTOM_T: CustomType = CustomType::new_simple(
     SmolStr::new_inline("qubit"),
     SmolStr::new_inline("prelude"),
     TypeBound::Any,
 );
 
-pub(crate) const QB_T: Type = Type::new_extension(QB_CUSTOM_T);
-pub(crate) const USIZE_T: Type = Type::new_extension(USIZE_CUSTOM_T);
+pub(crate) const USIZE_CUSTOM_REF: &CustomType = &USIZE_CUSTOM_T;
+pub(crate) const QB_CUSTOM_REF: &CustomType = &QB_CUSTOM_T;
+
+pub(crate) const QB_T: Type = Type::new_static_extension(QB_CUSTOM_REF);
+pub(crate) const USIZE_T: Type = Type::new_static_extension(USIZE_CUSTOM_REF);
 pub(crate) const BOOL_T: Type = Type::new_simple_predicate(2);
 
 /// Initialize a new array of type `typ` of length `size`

--- a/src/extension/prelude.rs
+++ b/src/extension/prelude.rs
@@ -60,8 +60,8 @@ const QB_CUSTOM_T: CustomType = CustomType::new_simple(
     TypeBound::Any,
 );
 
-pub(crate) const USIZE_CUSTOM_REF: &CustomType = &USIZE_CUSTOM_T;
-pub(crate) const QB_CUSTOM_REF: &CustomType = &QB_CUSTOM_T;
+const USIZE_CUSTOM_REF: &CustomType = &USIZE_CUSTOM_T;
+const QB_CUSTOM_REF: &CustomType = &QB_CUSTOM_T;
 
 pub(crate) const QB_T: Type = Type::new_static_extension(QB_CUSTOM_REF);
 pub(crate) const USIZE_T: Type = Type::new_static_extension(USIZE_CUSTOM_REF);

--- a/src/types.rs
+++ b/src/types.rs
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::ops::AliasDecl;
 use crate::type_row;
+use crate::utils::MaybeStatic;
 use std::fmt::Debug;
 
 use self::primitive::PrimType;
@@ -212,7 +213,20 @@ impl Type {
     // TODO remove? Extensions/TypeDefs should just provide `Type` directly
     pub const fn new_extension(opaque: CustomType) -> Self {
         let bound = opaque.bound();
-        Type(TypeEnum::Prim(PrimType::Extension(opaque)), bound)
+        Type(
+            TypeEnum::Prim(PrimType::Extension(MaybeStatic::new_value(opaque))),
+            bound,
+        )
+    }
+
+    /// Initialize a new custom type with a static definition - allowing for
+    /// pointer equality comparisons.
+    pub const fn new_static_extension(opaque: &'static CustomType) -> Self {
+        let bound = opaque.bound();
+        Type(
+            TypeEnum::Prim(PrimType::Extension(MaybeStatic::new_static(opaque))),
+            bound,
+        )
     }
 
     /// Initialize a new alias.
@@ -270,14 +284,14 @@ where
 pub(crate) mod test {
 
     use super::{
-        custom::test::{ANY_CUST, COPYABLE_CUST, EQ_CUST},
+        custom::test::{ANY_CUST_REF, COPYABLE_CUST_REF, EQ_CUST_REF},
         *,
     };
     use crate::{extension::prelude::USIZE_T, ops::AliasDecl};
 
-    pub(crate) const EQ_T: Type = Type::new_extension(EQ_CUST);
-    pub(crate) const COPYABLE_T: Type = Type::new_extension(COPYABLE_CUST);
-    pub(crate) const ANY_T: Type = Type::new_extension(ANY_CUST);
+    pub(crate) const EQ_T: Type = Type::new_static_extension(EQ_CUST_REF);
+    pub(crate) const COPYABLE_T: Type = Type::new_static_extension(COPYABLE_CUST_REF);
+    pub(crate) const ANY_T: Type = Type::new_static_extension(ANY_CUST_REF);
 
     #[test]
     fn construct() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::ops::AliasDecl;
 use crate::type_row;
-use crate::utils::MaybeStatic;
+use crate::utils::MaybeRef;
 use std::fmt::Debug;
 
 use self::primitive::PrimType;
@@ -214,7 +214,7 @@ impl Type {
     pub const fn new_extension(opaque: CustomType) -> Self {
         let bound = opaque.bound();
         Type(
-            TypeEnum::Prim(PrimType::Extension(MaybeStatic::new_value(opaque))),
+            TypeEnum::Prim(PrimType::Extension(MaybeRef::new_value(opaque))),
             bound,
         )
     }
@@ -224,7 +224,7 @@ impl Type {
     pub const fn new_static_extension(opaque: &'static CustomType) -> Self {
         let bound = opaque.bound();
         Type(
-            TypeEnum::Prim(PrimType::Extension(MaybeStatic::new_static(opaque))),
+            TypeEnum::Prim(PrimType::Extension(MaybeRef::new_static(opaque))),
             bound,
         )
     }

--- a/src/types/check.rs
+++ b/src/types/check.rs
@@ -53,7 +53,7 @@ impl PrimType {
 
         match (self, val) {
             (PrimType::Extension(e), PrimValue::Extension(e_val)) => {
-                e_val.0.check_custom_type(e)?;
+                e_val.0.check_custom_type(e.as_ref())?;
                 Ok(())
             }
             (PrimType::Graph(_), PrimValue::Graph) => todo!(),

--- a/src/types/custom.rs
+++ b/src/types/custom.rs
@@ -105,4 +105,8 @@ pub(crate) mod test {
         SmolStr::new_inline("MyRsrc"),
         TypeBound::Any,
     );
+
+    pub(crate) const EQ_CUST_REF: &CustomType = &EQ_CUST;
+    pub(crate) const COPYABLE_CUST_REF: &CustomType = &COPYABLE_CUST;
+    pub(crate) const ANY_CUST_REF: &CustomType = &ANY_CUST;
 }

--- a/src/types/primitive.rs
+++ b/src/types/primitive.rs
@@ -1,6 +1,6 @@
 //! Primitive types which are leaves of the type tree
 
-use crate::{ops::AliasDecl, utils::MaybeStatic};
+use crate::{ops::AliasDecl, utils::MaybeRef};
 
 use super::{AbstractSignature, CustomType, TypeBound};
 
@@ -9,7 +9,7 @@ pub(super) enum PrimType {
     // TODO optimise with Box<CustomType> ?
     // or some static version of this?
     #[display(fmt = "{}", "_0.as_ref()")]
-    Extension(MaybeStatic<CustomType>),
+    Extension(MaybeRef<'static, CustomType>),
     #[display(fmt = "Alias({})", "_0.name()")]
     Alias(AliasDecl),
     #[display(fmt = "Graph({})", "_0")]

--- a/src/types/primitive.rs
+++ b/src/types/primitive.rs
@@ -1,16 +1,15 @@
 //! Primitive types which are leaves of the type tree
 
-use crate::ops::AliasDecl;
+use crate::{ops::AliasDecl, utils::MaybeStatic};
 
 use super::{AbstractSignature, CustomType, TypeBound};
 
-#[derive(
-    Clone, PartialEq, Debug, Eq, derive_more::Display, serde::Serialize, serde::Deserialize,
-)]
+#[derive(Clone, PartialEq, Debug, Eq, derive_more::Display)]
 pub(super) enum PrimType {
     // TODO optimise with Box<CustomType> ?
     // or some static version of this?
-    Extension(CustomType),
+    #[display(fmt = "{}", "_0.as_ref()")]
+    Extension(MaybeStatic<CustomType>),
     #[display(fmt = "Alias({})", "_0.name()")]
     Alias(AliasDecl),
     #[display(fmt = "Graph({})", "_0")]
@@ -20,7 +19,7 @@ pub(super) enum PrimType {
 impl PrimType {
     pub(super) fn bound(&self) -> TypeBound {
         match self {
-            PrimType::Extension(c) => c.bound(),
+            PrimType::Extension(c) => c.as_ref().bound(),
             PrimType::Alias(a) => a.bound,
             PrimType::Graph(_) => TypeBound::Copyable,
         }

--- a/src/types/serialize.rs
+++ b/src/types/serialize.rs
@@ -33,7 +33,7 @@ impl From<Type> for SerSimpleType {
         let Type(value, _) = value;
         match value {
             TypeEnum::Prim(t) => match t {
-                PrimType::Extension(c) => SerSimpleType::Opaque(c),
+                PrimType::Extension(c) => SerSimpleType::Opaque(c.into_inner()),
                 PrimType::Alias(a) => SerSimpleType::Alias(a),
                 PrimType::Graph(sig) => SerSimpleType::G(Box::new(*sig)),
             },

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -27,19 +27,6 @@ pub fn collect_array<const N: usize, T: Debug>(arr: &[T]) -> [&T; N] {
     arr.iter().collect_vec().try_into().unwrap()
 }
 
-#[allow(dead_code)]
-// Test only utils
-#[cfg(test)]
-pub(crate) mod test {
-    /// Open a browser page to render a dot string graph.
-    #[cfg(not(ci_run))]
-    pub(crate) fn viz_dotstr(dotstr: &str) {
-        let mut base: String = "https://dreampuf.github.io/GraphvizOnline/#".into();
-        base.push_str(&urlencoding::encode(dotstr));
-        webbrowser::open(&base).unwrap();
-    }
-}
-
 #[derive(Clone, Debug, Eq)]
 /// Utility struct that can be either owned value or reference, used to short
 /// circuit PartialEq with pointer equality when possible.
@@ -77,7 +64,7 @@ impl<'a, T> AsRef<T> for MaybeRef<'a, T> {
 }
 
 // can use pointer equality to compare static instances
-impl<'a, T: PartialEq> PartialEq for MaybeRef<'a, T> {
+impl<'a, T: PartialEq + Eq> PartialEq for MaybeRef<'a, T> {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             // pointer equality can give false-negative
@@ -85,5 +72,18 @@ impl<'a, T: PartialEq> PartialEq for MaybeRef<'a, T> {
             (Self::Value(l0), Self::Value(r0)) => l0 == r0,
             (Self::Value(v), Self::Ref(v_ref)) | (Self::Ref(v_ref), Self::Value(v)) => v == *v_ref,
         }
+    }
+}
+
+#[allow(dead_code)]
+// Test only utils
+#[cfg(test)]
+pub(crate) mod test {
+    /// Open a browser page to render a dot string graph.
+    #[cfg(not(ci_run))]
+    pub(crate) fn viz_dotstr(dotstr: &str) {
+        let mut base: String = "https://dreampuf.github.io/GraphvizOnline/#".into();
+        base.push_str(&urlencoding::encode(dotstr));
+        webbrowser::open(&base).unwrap();
     }
 }


### PR DESCRIPTION
Most of the time can avoid string comparison using pointer equality short circuiting.

Might be a bit sketch.