### PR TITLE
Quantum extension

### DIFF
--- a/src/builder/circuit.rs
+++ b/src/builder/circuit.rs
@@ -140,6 +140,7 @@ mod test {
             Dataflow, DataflowSubContainer, Wire,
         },
         ops::{custom::OpaqueOp, LeafOp},
+        std_extensions::quantum::test::{cx_gate, h_gate, measure},
         type_row,
         types::AbstractSignature,
     };
@@ -159,9 +160,9 @@ mod test {
                 assert_eq!(linear.n_wires(), 2);
 
                 linear
-                    .append(LeafOp::H, [0])?
-                    .append(LeafOp::CX, [0, 1])?
-                    .append(LeafOp::CX, [1, 0])?;
+                    .append(h_gate(), [0])?
+                    .append(cx_gate(), [0, 1])?
+                    .append(cx_gate(), [1, 0])?;
 
                 let outs = linear.finish();
                 f_build.finish_with_outputs(outs)
@@ -191,12 +192,12 @@ mod test {
                 let mut linear = f_build.as_circuit(vec![q0, q1]);
 
                 let measure_out = linear
-                    .append(LeafOp::CX, [0, 1])?
+                    .append(cx_gate(), [0, 1])?
                     .append_and_consume(
                         my_custom_op,
                         [CircuitUnit::Linear(0), CircuitUnit::Wire(angle)],
                     )?
-                    .append_with_outputs(LeafOp::Measure, [0])?;
+                    .append_with_outputs(measure(), [0])?;
 
                 let out_qbs = linear.finish();
                 f_build.finish_with_outputs(out_qbs.into_iter().chain(measure_out))

--- a/src/builder/circuit.rs
+++ b/src/builder/circuit.rs
@@ -136,9 +136,10 @@ mod test {
 
     use crate::{
         builder::{
-            test::{build_main, BIT, NAT, QB},
+            test::{build_main, NAT, QB},
             Dataflow, DataflowSubContainer, Wire,
         },
+        extension::prelude::BOOL_T,
         ops::{custom::OpaqueOp, LeafOp},
         std_extensions::quantum::test::{cx_gate, h_gate, measure},
         type_row,
@@ -185,7 +186,7 @@ mod test {
             .into(),
         );
         let build_res = build_main(
-            AbstractSignature::new_df(type_row![QB, QB, NAT], type_row![QB, QB, BIT]).pure(),
+            AbstractSignature::new_df(type_row![QB, QB, NAT], type_row![QB, QB, BOOL_T]).pure(),
             |mut f_build| {
                 let [q0, q1, angle]: [Wire; 3] = f_build.input_wires_arr();
 

--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -218,9 +218,11 @@ mod test {
 
     use crate::builder::build_traits::DataflowHugr;
     use crate::builder::{DataflowSubContainer, ModuleBuilder};
+    use crate::extension::prelude::BOOL_T;
     use crate::hugr::validate::InterGraphEdgeError;
     use crate::ops::{handle::NodeHandle, LeafOp, OpTag};
 
+    use crate::std_extensions::logic::test::and_op;
     use crate::{
         builder::{
             test::{n_identity, BIT, NAT, QB},
@@ -274,7 +276,7 @@ mod test {
 
             let f_build = module_builder.define_function(
                 "main",
-                AbstractSignature::new_df(type_row![BIT], type_row![BIT, BIT]).pure(),
+                AbstractSignature::new_df(type_row![BOOL_T], type_row![BOOL_T, BOOL_T]).pure(),
             )?;
 
             f(f_build)?;
@@ -298,7 +300,7 @@ mod test {
         copy_scaffold(
             |mut f_build| {
                 let [b1] = f_build.input_wires_arr();
-                let xor = f_build.add_dataflow_op(LeafOp::Xor, [b1, b1])?;
+                let xor = f_build.add_dataflow_op(and_op(), [b1, b1])?;
                 f_build.finish_with_outputs([xor.out_wire(0), b1])
             },
             "Copy input and use with binary function",
@@ -307,8 +309,8 @@ mod test {
         copy_scaffold(
             |mut f_build| {
                 let [b1] = f_build.input_wires_arr();
-                let xor1 = f_build.add_dataflow_op(LeafOp::Xor, [b1, b1])?;
-                let xor2 = f_build.add_dataflow_op(LeafOp::Xor, [b1, xor1.out_wire(0)])?;
+                let xor1 = f_build.add_dataflow_op(and_op(), [b1, b1])?;
+                let xor2 = f_build.add_dataflow_op(and_op(), [b1, xor1.out_wire(0)])?;
                 f_build.finish_with_outputs([xor2.out_wire(0), b1])
             },
             "Copy multiple times",

--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -223,6 +223,7 @@ mod test {
     use crate::ops::{handle::NodeHandle, LeafOp, OpTag};
 
     use crate::std_extensions::logic::test::and_op;
+    use crate::std_extensions::quantum::test::h_gate;
     use crate::{
         builder::{
             test::{n_identity, BIT, NAT, QB},
@@ -246,7 +247,7 @@ mod test {
 
                 let [int, qb] = func_builder.input_wires_arr();
 
-                let q_out = func_builder.add_dataflow_op(LeafOp::H, vec![qb])?;
+                let q_out = func_builder.add_dataflow_op(h_gate(), vec![qb])?;
 
                 let inner_builder = func_builder.dfg_builder(
                     AbstractSignature::new_df(type_row![NAT], type_row![NAT]),

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -12,7 +12,7 @@ use smol_str::SmolStr;
 use thiserror::Error;
 
 use crate::ops;
-use crate::ops::custom::OpaqueOp;
+use crate::ops::custom::{ExtensionOp, OpaqueOp};
 use crate::types::type_param::{check_type_arg, TypeArgError};
 use crate::types::type_param::{TypeArg, TypeParam};
 use crate::types::CustomType;
@@ -245,6 +245,16 @@ impl Extension {
             Entry::Occupied(_) => Err(ExtensionBuildError::OpDefExists(extension_value.name)),
             Entry::Vacant(ve) => Ok(ve.insert(extension_value)),
         }
+    }
+
+    /// Instantiate an [`ExtensionOp`] which references an [`OpDef`] in this resource.
+    pub fn instantiate_extension_op(
+        &self,
+        op_name: &str,
+        args: impl Into<Vec<TypeArg>>,
+    ) -> Result<ExtensionOp, SignatureError> {
+        let op_def = self.get_op(op_name).expect("Op not found.");
+        ExtensionOp::new(op_def.clone(), args)
     }
 }
 

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -247,7 +247,7 @@ impl Extension {
         }
     }
 
-    /// Instantiate an [`ExtensionOp`] which references an [`OpDef`] in this resource.
+    /// Instantiate an [`ExtensionOp`] which references an [`OpDef`] in this extension.
     pub fn instantiate_extension_op(
         &self,
         op_name: &str,

--- a/src/extension/op_def.rs
+++ b/src/extension/op_def.rs
@@ -225,6 +225,7 @@ impl OpDef {
             SignatureFunc::CustomFunc(bf) => bf.compute_signature(&self.name, args, &self.misc)?,
         };
         // TODO bring this assert back once resource inference is done?
+        // https://github.com/CQCL-DEV/hugr/issues/425
         // assert!(res.contains(self.extension()));
         Ok(AbstractSignature::new_df(ins, outs).with_extension_delta(&res))
     }

--- a/src/extension/op_def.rs
+++ b/src/extension/op_def.rs
@@ -224,7 +224,8 @@ impl OpDef {
             }
             SignatureFunc::CustomFunc(bf) => bf.compute_signature(&self.name, args, &self.misc)?,
         };
-        assert!(res.contains(self.extension()));
+        // TODO bring this assert back once resource inference is done?
+        // assert!(res.contains(self.extension()));
         Ok(AbstractSignature::new_df(ins, outs).with_extension_delta(&res))
     }
 

--- a/src/hugr/rewrite/simple_replace.rs
+++ b/src/hugr/rewrite/simple_replace.rs
@@ -209,12 +209,13 @@ mod test {
         BuildError, Container, DFGBuilder, Dataflow, DataflowHugr, DataflowSubContainer,
         HugrBuilder, ModuleBuilder,
     };
-    use crate::extension::prelude::USIZE_T;
+    use crate::extension::prelude::BOOL_T;
     use crate::hugr::views::HugrView;
     use crate::hugr::{Hugr, Node};
     use crate::ops::OpTag;
     use crate::ops::{LeafOp, OpTrait, OpType};
     use crate::types::{AbstractSignature, Type};
+    use crate::utils::test::and_op;
     use crate::{type_row, Port};
 
     use super::SimpleReplacement;
@@ -510,14 +511,14 @@ mod test {
 
     #[test]
     fn test_replace_after_copy() {
-        let one_bit: Vec<Type> = vec![USIZE_T];
-        let two_bit: Vec<Type> = vec![USIZE_T, USIZE_T];
+        let one_bit = type_row![BOOL_T];
+        let two_bit = type_row![BOOL_T, BOOL_T];
 
         let mut builder =
             DFGBuilder::new(AbstractSignature::new_df(one_bit.clone(), one_bit.clone())).unwrap();
         let inw = builder.input_wires().exactly_one().unwrap();
         let outw = builder
-            .add_dataflow_op(LeafOp::Xor, [inw, inw])
+            .add_dataflow_op(and_op(), [inw, inw])
             .unwrap()
             .outputs();
         let [input, _] = builder.io();
@@ -525,7 +526,7 @@ mod test {
 
         let mut builder = DFGBuilder::new(AbstractSignature::new_df(two_bit, one_bit)).unwrap();
         let inw = builder.input_wires();
-        let outw = builder.add_dataflow_op(LeafOp::Xor, inw).unwrap().outputs();
+        let outw = builder.add_dataflow_op(and_op(), inw).unwrap().outputs();
         let [repl_input, repl_output] = builder.io();
         let repl = builder.finish_hugr_with_outputs(outw).unwrap();
 

--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -272,6 +272,7 @@ pub mod test {
             Container, DFGBuilder, Dataflow, DataflowHugr, DataflowSubContainer, HugrBuilder,
             ModuleBuilder,
         },
+        extension::prelude::BOOL_T,
         hugr::NodeType,
         ops::{dataflow::IOTrait, Input, LeafOp, Module, Output, DFG},
         types::{AbstractSignature, Type},
@@ -430,12 +431,12 @@ pub mod test {
 
     #[test]
     fn dfg_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
-        let tp: Vec<Type> = vec![NAT; 2];
+        let tp: Vec<Type> = vec![BOOL_T; 2];
         let mut dfg = DFGBuilder::new(AbstractSignature::new_df(tp.clone(), tp))?;
         let mut params: [_; 2] = dfg.input_wires_arr();
         for p in params.iter_mut() {
             *p = dfg
-                .add_dataflow_op(LeafOp::Xor, [*p, *p])
+                .add_dataflow_op(LeafOp::Noop { ty: BOOL_T }, [*p])
                 .unwrap()
                 .out_wire(0);
         }

--- a/src/hugr/views/hierarchy.rs
+++ b/src/hugr/views/hierarchy.rs
@@ -473,7 +473,8 @@ where
 mod test {
     use crate::{
         builder::{Container, Dataflow, DataflowSubContainer, HugrBuilder, ModuleBuilder},
-        ops::{handle::NodeHandle, LeafOp},
+        ops::handle::NodeHandle,
+        std_extensions::quantum::test::h_gate,
         type_row,
         types::{AbstractSignature, Type},
     };
@@ -497,7 +498,7 @@ mod test {
 
             let [int, qb] = func_builder.input_wires_arr();
 
-            let q_out = func_builder.add_dataflow_op(LeafOp::H, vec![qb])?;
+            let q_out = func_builder.add_dataflow_op(h_gate(), vec![qb])?;
 
             let inner_id = {
                 let inner_builder = func_builder.dfg_builder(

--- a/src/ops/leaf.rs
+++ b/src/ops/leaf.rs
@@ -48,8 +48,6 @@ pub enum LeafOp {
     },
     /// A qubit measurement operation.
     Measure,
-    /// A bitwise XOR operation.
-    Xor,
     /// An operation that packs all its inputs into a tuple.
     MakeTuple {
         ///Tuple element types.
@@ -100,7 +98,6 @@ impl OpName for LeafOp {
             LeafOp::Reset => "Reset",
             LeafOp::Noop { ty: _ } => "Noop",
             LeafOp::Measure => "Measure",
-            LeafOp::Xor => "Xor",
             LeafOp::MakeTuple { tys: _ } => "MakeTuple",
             LeafOp::UnpackTuple { tys: _ } => "UnpackTuple",
             LeafOp::Tag { .. } => "Tag",
@@ -132,7 +129,6 @@ impl OpTrait for LeafOp {
             LeafOp::Reset => "Qubit reset",
             LeafOp::Noop { ty: _ } => "Noop gate",
             LeafOp::Measure => "Qubit measurement gate",
-            LeafOp::Xor => "Bitwise XOR",
             LeafOp::MakeTuple { tys: _ } => "MakeTuple operation",
             LeafOp::UnpackTuple { tys: _ } => "UnpackTuple operation",
             LeafOp::Tag { .. } => "Tag Sum operation",
@@ -166,9 +162,6 @@ impl OpTrait for LeafOp {
             LeafOp::CX | LeafOp::ZZMax => AbstractSignature::new_linear(type_row![QB_T, QB_T]),
             LeafOp::Measure => {
                 AbstractSignature::new_df(type_row![QB_T], type_row![QB_T, BIT_TYPE])
-            }
-            LeafOp::Xor => {
-                AbstractSignature::new_df(type_row![BIT_TYPE, BIT_TYPE], type_row![BIT_TYPE])
             }
             LeafOp::CustomOp(ext) => ext.signature(),
             LeafOp::MakeTuple { tys: types } => {

--- a/src/ops/leaf.rs
+++ b/src/ops/leaf.rs
@@ -4,8 +4,7 @@ use smol_str::SmolStr;
 
 use super::custom::ExternalOp;
 use super::{OpName, OpTag, OpTrait, StaticTag};
-use crate::extension::prelude::{QB_T, USIZE_T};
-use crate::type_row;
+
 use crate::{
     extension::{ExtensionId, ExtensionSet},
     types::{AbstractSignature, EdgeKind, SignatureDescription, Type, TypeRow},
@@ -19,35 +18,12 @@ pub enum LeafOp {
     /// A user-defined operation that can be downcasted by the extensions that
     /// define it.
     CustomOp(Box<ExternalOp>),
-    /// A Hadamard gate.
-    H,
-    /// A T gate.
-    T,
-    /// An S gate.
-    S,
-    /// A Pauli X gate.
-    X,
-    /// A Pauli Y gate.
-    Y,
-    /// A Pauli Z gate.
-    Z,
-    /// An adjoint T gate.
-    Tadj,
-    /// An adjoint S gate.
-    Sadj,
-    /// A controlled X gate.
-    CX,
-    /// A maximally entangling ZZ phase gate.
-    ZZMax,
-    /// A qubit reset operation.
-    Reset,
+
     /// A no-op operation.
     Noop {
         /// The type of edges connecting the Noop.
         ty: Type,
     },
-    /// A qubit measurement operation.
-    Measure,
     /// An operation that packs all its inputs into a tuple.
     MakeTuple {
         ///Tuple element types.
@@ -85,19 +61,7 @@ impl OpName for LeafOp {
     fn name(&self) -> SmolStr {
         match self {
             LeafOp::CustomOp(ext) => return ext.name(),
-            LeafOp::H => "H",
-            LeafOp::T => "T",
-            LeafOp::S => "S",
-            LeafOp::X => "X",
-            LeafOp::Y => "Y",
-            LeafOp::Z => "Z",
-            LeafOp::Tadj => "Tadj",
-            LeafOp::Sadj => "Sadj",
-            LeafOp::CX => "CX",
-            LeafOp::ZZMax => "ZZMax",
-            LeafOp::Reset => "Reset",
             LeafOp::Noop { ty: _ } => "Noop",
-            LeafOp::Measure => "Measure",
             LeafOp::MakeTuple { tys: _ } => "MakeTuple",
             LeafOp::UnpackTuple { tys: _ } => "UnpackTuple",
             LeafOp::Tag { .. } => "Tag",
@@ -116,19 +80,7 @@ impl OpTrait for LeafOp {
     fn description(&self) -> &str {
         match self {
             LeafOp::CustomOp(ext) => ext.description(),
-            LeafOp::H => "Hadamard gate",
-            LeafOp::T => "T gate",
-            LeafOp::S => "S gate",
-            LeafOp::X => "Pauli X gate",
-            LeafOp::Y => "Pauli Y gate",
-            LeafOp::Z => "Pauli Z gate",
-            LeafOp::Tadj => "Adjoint T gate",
-            LeafOp::Sadj => "Adjoint S gate",
-            LeafOp::CX => "Controlled X gate",
-            LeafOp::ZZMax => "Maximally entangling ZZPhase gate",
-            LeafOp::Reset => "Qubit reset",
             LeafOp::Noop { ty: _ } => "Noop gate",
-            LeafOp::Measure => "Qubit measurement gate",
             LeafOp::MakeTuple { tys: _ } => "MakeTuple operation",
             LeafOp::UnpackTuple { tys: _ } => "UnpackTuple operation",
             LeafOp::Tag { .. } => "Tag Sum operation",
@@ -145,23 +97,9 @@ impl OpTrait for LeafOp {
         // Static signatures. The `TypeRow`s in the `AbstractSignature` use a
         // copy-on-write strategy, so we can avoid unnecessary allocations.
 
-        const BIT_TYPE: Type = USIZE_T;
         match self {
             LeafOp::Noop { ty: typ } => {
                 AbstractSignature::new_df(vec![typ.clone()], vec![typ.clone()])
-            }
-            LeafOp::H
-            | LeafOp::Reset
-            | LeafOp::T
-            | LeafOp::S
-            | LeafOp::Tadj
-            | LeafOp::Sadj
-            | LeafOp::X
-            | LeafOp::Y
-            | LeafOp::Z => AbstractSignature::new_linear(type_row![QB_T]),
-            LeafOp::CX | LeafOp::ZZMax => AbstractSignature::new_linear(type_row![QB_T, QB_T]),
-            LeafOp::Measure => {
-                AbstractSignature::new_df(type_row![QB_T], type_row![QB_T, BIT_TYPE])
             }
             LeafOp::CustomOp(ext) => ext.signature(),
             LeafOp::MakeTuple { tys: types } => {

--- a/src/std_extensions.rs
+++ b/src/std_extensions.rs
@@ -5,4 +5,5 @@
 pub mod arithmetic;
 pub mod collections;
 pub mod logic;
+pub mod quantum;
 pub mod rotation;

--- a/src/std_extensions/logic.rs
+++ b/src/std_extensions/logic.rs
@@ -112,10 +112,10 @@ lazy_static! {
 }
 
 #[cfg(test)]
-mod test {
-    use crate::{extension::prelude::BOOL_T, Extension};
+pub(crate) mod test {
+    use crate::{extension::prelude::BOOL_T, ops::LeafOp, types::type_param::TypeArg, Extension};
 
-    use super::{extension, FALSE_NAME, TRUE_NAME};
+    use super::{extension, AND_NAME, EXTENSION, FALSE_NAME, TRUE_NAME};
 
     #[test]
     fn test_logic_extension() {
@@ -134,5 +134,13 @@ mod test {
             let simpl = v.typed_value().const_type();
             assert_eq!(simpl, &BOOL_T);
         }
+    }
+
+    /// Generate a logic extension and operation over [`crate::prelude::BOOL_T`]
+    pub(crate) fn and_op() -> LeafOp {
+        EXTENSION
+            .instantiate_extension_op(AND_NAME, [TypeArg::USize(2)])
+            .unwrap()
+            .into()
     }
 }

--- a/src/std_extensions/logic.rs
+++ b/src/std_extensions/logic.rs
@@ -9,23 +9,30 @@ use crate::{
     types::type_param::{TypeArg, TypeArgError, TypeParam},
     Extension,
 };
+use lazy_static::lazy_static;
 
 /// Name of extension false value.
 pub const FALSE_NAME: &str = "FALSE";
 /// Name of extension true value.
 pub const TRUE_NAME: &str = "TRUE";
 
+/// Name of the "not" operation.
+pub const NOT_NAME: &str = "Not";
+/// Name of the "and" operation.
+pub const AND_NAME: &str = "And";
+/// Name of the "or" operation.
+pub const OR_NAME: &str = "Or";
 /// The extension identifier.
 pub const EXTENSION_ID: SmolStr = SmolStr::new_inline("logic");
 
 /// Extension for basic logical operations.
-pub fn extension() -> Extension {
+fn extension() -> Extension {
     const H_INT: TypeParam = TypeParam::USize;
     let mut extension = Extension::new(EXTENSION_ID);
 
     extension
         .add_op_custom_sig_simple(
-            "Not".into(),
+            SmolStr::new_inline(NOT_NAME),
             "logical 'not'".into(),
             vec![],
             |_arg_values: &[TypeArg]| {
@@ -40,7 +47,7 @@ pub fn extension() -> Extension {
 
     extension
         .add_op_custom_sig_simple(
-            "And".into(),
+            SmolStr::new_inline(AND_NAME),
             "logical 'and'".into(),
             vec![H_INT],
             |arg_values: &[TypeArg]| {
@@ -66,7 +73,7 @@ pub fn extension() -> Extension {
 
     extension
         .add_op_custom_sig_simple(
-            "Or".into(),
+            SmolStr::new_inline(OR_NAME),
             "logical 'or'".into(),
             vec![H_INT],
             |arg_values: &[TypeArg]| {
@@ -97,6 +104,11 @@ pub fn extension() -> Extension {
         .add_value(TRUE_NAME, ops::Const::simple_predicate(1, 2))
         .unwrap();
     extension
+}
+
+lazy_static! {
+    /// Reference to the logic Extension.
+    pub static ref EXTENSION: Extension = extension();
 }
 
 #[cfg(test)]

--- a/src/std_extensions/quantum.rs
+++ b/src/std_extensions/quantum.rs
@@ -50,7 +50,9 @@ fn extension() -> Extension {
                 Ok((
                     type_row![QB_T],
                     type_row![QB_T, BOOL_T],
-                    // TODO add logic as an extension delta when inference is done?
+                    // TODO add logic as an extension delta when inference is
+                    // done?
+                    // https://github.com/CQCL-DEV/hugr/issues/425
                     ExtensionSet::new(),
                 ))
             },

--- a/src/std_extensions/quantum.rs
+++ b/src/std_extensions/quantum.rs
@@ -2,7 +2,7 @@
 
 use smol_str::SmolStr;
 
-use crate::extension::prelude::{QB_T, USIZE_T};
+use crate::extension::prelude::{BOOL_T, QB_T};
 use crate::extension::{ExtensionSet, SignatureError};
 use crate::type_row;
 use crate::types::type_param::TypeArg;
@@ -49,8 +49,9 @@ fn extension() -> Extension {
             |_arg_values: &[TypeArg]| {
                 Ok((
                     type_row![QB_T],
-                    type_row![QB_T, USIZE_T],
-                    ExtensionSet::default(),
+                    type_row![QB_T, BOOL_T],
+                    // TODO add logic as an extension delta when inference is done?
+                    ExtensionSet::new(),
                 ))
             },
         )

--- a/src/std_extensions/quantum.rs
+++ b/src/std_extensions/quantum.rs
@@ -60,7 +60,7 @@ fn extension() -> Extension {
 }
 
 lazy_static! {
-    /// Collections extension definition.
+    /// Quantum extension definition.
     pub static ref EXTENSION: Extension = extension();
 }
 

--- a/src/std_extensions/quantum.rs
+++ b/src/std_extensions/quantum.rs
@@ -1,0 +1,91 @@
+//! Basic HUGR quantum operations
+
+use smol_str::SmolStr;
+
+use crate::extension::prelude::{QB_T, USIZE_T};
+use crate::extension::{ExtensionSet, SignatureError};
+use crate::type_row;
+use crate::types::type_param::TypeArg;
+use crate::types::TypeRow;
+use crate::Extension;
+
+use lazy_static::lazy_static;
+
+/// The extension identifier.
+pub const EXTENSION_ID: SmolStr = SmolStr::new_inline("quantum");
+fn one_qb_func(_: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
+    Ok((type_row![QB_T], type_row![QB_T], ExtensionSet::new()))
+}
+
+fn two_qb_func(_: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
+    Ok((
+        type_row![QB_T, QB_T],
+        type_row![QB_T, QB_T],
+        ExtensionSet::new(),
+    ))
+}
+
+fn extension() -> Extension {
+    let mut extension = Extension::new(EXTENSION_ID);
+
+    extension
+        .add_op_custom_sig_simple(
+            SmolStr::new_inline("H"),
+            "Hadamard".into(),
+            vec![],
+            one_qb_func,
+        )
+        .unwrap();
+
+    extension
+        .add_op_custom_sig_simple(SmolStr::new_inline("CX"), "CX".into(), vec![], two_qb_func)
+        .unwrap();
+
+    extension
+        .add_op_custom_sig_simple(
+            SmolStr::new_inline("Measure"),
+            "Measure a qubit, returning the qubit and the measurement result.".into(),
+            vec![],
+            |_arg_values: &[TypeArg]| {
+                Ok((
+                    type_row![QB_T],
+                    type_row![QB_T, USIZE_T],
+                    ExtensionSet::default(),
+                ))
+            },
+        )
+        .unwrap();
+
+    extension
+}
+
+lazy_static! {
+    /// Collections extension definition.
+    pub static ref EXTENSION: Extension = extension();
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use crate::ops::LeafOp;
+
+    use super::EXTENSION;
+
+    fn get_gate(gate_name: &str) -> LeafOp {
+        EXTENSION
+            .instantiate_extension_op(gate_name, [])
+            .unwrap()
+            .into()
+    }
+
+    pub(crate) fn h_gate() -> LeafOp {
+        get_gate("H")
+    }
+
+    pub(crate) fn cx_gate() -> LeafOp {
+        get_gate("CX")
+    }
+
+    pub(crate) fn measure() -> LeafOp {
+        get_gate("Measure")
+    }
+}


### PR DESCRIPTION
Closes #365
remove quantum ops that are not used in tests

more can be added later as required

Early commits also remove XOR and replace use with logic extension

Required some fixups to enable use of `ExtensionOp`