### PR TITLE
Spec out polymorphism "extension"

### DIFF
--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -1013,8 +1013,6 @@ Type ::= Tuple(#) -- fixed-arity, heterogenous components
        | Function[Extensions](#, #) -- monomorphic
        | Opaque(Name, TypeArgs) -- a (instantiation of a) custom type defined by an extension
 ```
-<!--      Function(TypeParams, #, #, Extensions) -- polymorphic, so move TypeParams section here
-#       | Variable -- refers to a TypeParam bound by an enclosing Graph-->
 
 The majority of types will be Opaque ones defined by extensions including the [standard library](#standard-library). However a number of types can be constructed using only the core type constructors: for example the empty tuple type, aka `unit`, with exactly one instance (so 0 bits of data); the empty sum, with no instances; the empty Function type (taking no arguments and producing no results - `void -> void`); and compositions thereof.
 

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -1738,7 +1738,7 @@ These operations allow this.
     However the result is not `O` but `Sum(O,ErrorType)`
   - `parallel`, `sequence`, `partial`? Note that these could be executed
     in first order graphs as straightforward (albeit expensive)
-    manipulations of Graph `struct`s/protobufs\!
+    manipulations of Hugr `struct`s/protobufs/etc.\!
 
 $\displaystyle{\frac{\mathrm{body} : [R] \textbf{Function}[R]([R] \textrm{Var}(I), [R] \textrm{Sum}(\textrm{Var}(I), \textrm{Var}(O))) \quad v : [R] \textrm{Var}(I)}{\textrm{loop}(\mathrm{body}, v) : [R] \textrm{Var}(O)}}$
 

--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -1758,14 +1758,6 @@ $\displaystyle{\frac{\Theta : [R] \textbf{Function}[R](\vec{X}, \vec{Y}) \quad \
 **CallIndirect** - This has the same feature as **loop**: running a
 graph requires it’s extensions.
 
-$\displaystyle{\frac{}{\textbf{to\\_const} \langle \textbf{Function}[R](\vec{I}, \vec{O}) \rangle (\mathrm{name}) : [\emptyset] \textbf{Function}[R](\vec{I}, \vec{O})}}$
-
-**to_const** - For operations which instantiate a graph (**to\_const**
-and **Call**) the functions are given an extra parameter at graph
-construction time which corresponds to the function type that they are
-meant to instantiate. This type will be given by a typeless edge from
-the graph in question to the operation, with the graph’s type added as
-an edge weight.
 
 ## Glossary
 


### PR DESCRIPTION
When we allow for type variables that could be, say, sizes of arrays, this works out worse than I thought.