### PR TITLE
chore: Format let-else with nightly rustfmt

### DIFF
--- a/src/algorithm/half_node.rs
+++ b/src/algorithm/half_node.rs
@@ -126,7 +126,14 @@ mod test {
             .map(|(s, _)| s)
             .exactly_one()
             .unwrap();
-        let [&left,&right] = edge_classes.keys().filter(|(s,_)| *s == split).map(|(_,t)|t).collect::<Vec<_>>()[..] else {panic!("Split node should have two successors");};
+        let [&left, &right] = edge_classes
+            .keys()
+            .filter(|(s, _)| *s == split)
+            .map(|(_, t)| t)
+            .collect::<Vec<_>>()[..]
+        else {
+            panic!("Split node should have two successors");
+        };
         let classes = group_by(edge_classes);
         assert_eq!(
             classes,

--- a/src/algorithm/nest_cfgs.rs
+++ b/src/algorithm/nest_cfgs.rs
@@ -450,7 +450,14 @@ pub(crate) mod test {
         // that we *can* (as we'll need to for "real" module Hugr's).
         let v: SiblingGraph = SiblingGraph::new(&h, h.root());
         let edge_classes = EdgeClassifier::get_edge_classes(&SimpleCfgView::new(&v));
-        let [&left,&right] = edge_classes.keys().filter(|(s,_)| *s == split).map(|(_,t)|t).collect::<Vec<_>>()[..] else {panic!("Split node should have two successors");};
+        let [&left, &right] = edge_classes
+            .keys()
+            .filter(|(s, _)| *s == split)
+            .map(|(_, t)| t)
+            .collect::<Vec<_>>()[..]
+        else {
+            panic!("Split node should have two successors");
+        };
 
         let classes = group_by(edge_classes);
         assert_eq!(
@@ -483,7 +490,14 @@ pub(crate) mod test {
             .unwrap();
 
         let edge_classes = EdgeClassifier::get_edge_classes(&SimpleCfgView::new(&h));
-        let [&left,&right] = edge_classes.keys().filter(|(s,_)| *s == entry).map(|(_,t)|t).collect::<Vec<_>>()[..] else {panic!("Entry node should have two successors");};
+        let [&left, &right] = edge_classes
+            .keys()
+            .filter(|(s, _)| *s == entry)
+            .map(|(_, t)| t)
+            .collect::<Vec<_>>()[..]
+        else {
+            panic!("Entry node should have two successors");
+        };
 
         let classes = group_by(edge_classes);
         assert_eq!(
@@ -516,7 +530,14 @@ pub(crate) mod test {
         let v = SimpleCfgView::new(&h);
         let edge_classes = EdgeClassifier::get_edge_classes(&v);
         let SimpleCfgView { h: _, entry, exit } = v;
-        let [&left,&right] = edge_classes.keys().filter(|(s,_)| *s == split).map(|(_,t)|t).collect::<Vec<_>>()[..] else {panic!("Split node should have two successors");};
+        let [&left, &right] = edge_classes
+            .keys()
+            .filter(|(s, _)| *s == split)
+            .map(|(_, t)| t)
+            .collect::<Vec<_>>()[..]
+        else {
+            panic!("Split node should have two successors");
+        };
         let classes = group_by(edge_classes);
         assert_eq!(
             classes,
@@ -552,7 +573,14 @@ pub(crate) mod test {
             .map(|(s, _)| s)
             .exactly_one()
             .unwrap();
-        let [&left,&right] = edge_classes.keys().filter(|(s,_)| *s == head).map(|(_,t)|t).collect::<Vec<_>>()[..] else {panic!("Loop header should have two successors");};
+        let [&left, &right] = edge_classes
+            .keys()
+            .filter(|(s, _)| *s == head)
+            .map(|(_, t)| t)
+            .collect::<Vec<_>>()[..]
+        else {
+            panic!("Loop header should have two successors");
+        };
         let classes = group_by(edge_classes);
         assert_eq!(
             classes,

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -672,21 +672,21 @@ fn wire_up<T: Dataflow + ?Sized>(
             }
 
             let src_parent = src_parent.expect("Node has no parent");
-            let Some(src_sibling) =
-                        iter::successors(dst_parent, |&p| base.get_parent(p))
-                            .tuple_windows()
-                            .find_map(|(ancestor, ancestor_parent)| {
-                                (ancestor_parent == src_parent).then_some(ancestor)
-                            })
-                    else {
-                        let val_err: ValidationError = InterGraphEdgeError::NoRelation {
-                            from: src,
-                            from_offset: Port::new_outgoing(src_port),
-                            to: dst,
-                            to_offset: Port::new_incoming(dst_port),
-                        }.into();
-                        return Err(val_err.into());
-                    };
+            let Some(src_sibling) = iter::successors(dst_parent, |&p| base.get_parent(p))
+                .tuple_windows()
+                .find_map(|(ancestor, ancestor_parent)| {
+                    (ancestor_parent == src_parent).then_some(ancestor)
+                })
+            else {
+                let val_err: ValidationError = InterGraphEdgeError::NoRelation {
+                    from: src,
+                    from_offset: Port::new_outgoing(src_port),
+                    to: dst,
+                    to_offset: Port::new_incoming(dst_port),
+                }
+                .into();
+                return Err(val_err.into());
+            };
 
             // TODO: Avoid adding duplicate edges
             // This should be easy with https://github.com/CQCL-DEV/hugr/issues/130

--- a/src/hugr/rewrite/outline_cfg.rs
+++ b/src/hugr/rewrite/outline_cfg.rs
@@ -90,8 +90,9 @@ impl Rewrite for OutlineCfg {
         let (entry, exit, outside) = self.compute_entry_exit_outside(h)?;
         // 1. Compute signature
         // These panic()s only happen if the Hugr would not have passed validate()
-        let OpType::BasicBlock(BasicBlock::DFB {inputs, ..}) = h.get_optype(entry)
-            else {panic!("Entry node is not a basic block")};
+        let OpType::BasicBlock(BasicBlock::DFB { inputs, .. }) = h.get_optype(entry) else {
+            panic!("Entry node is not a basic block")
+        };
         let inputs = inputs.clone();
         let outputs = match h.get_optype(outside) {
             OpType::BasicBlock(b) => b.dataflow_input().clone(),

--- a/src/ops/custom.rs
+++ b/src/ops/custom.rs
@@ -219,8 +219,11 @@ pub fn resolve_extension_ops(
                 if let Some(r) = extension_registry.get(&opaque.extension) {
                     // Fail if the Extension was found but did not have the expected operation
                     let Some(def) = r.get_op(&opaque.op_name) else {
-                    return Err(CustomOpError::OpNotFoundInExtension(opaque.op_name.to_string(), r.name().to_string()));
-                };
+                        return Err(CustomOpError::OpNotFoundInExtension(
+                            opaque.op_name.to_string(),
+                            r.name().to_string(),
+                        ));
+                    };
                     // TODO input extensions. From type checker, or just drop by storing only delta in Signature.
                     let op = ExternalOp::Extension(
                         ExtensionOp::new(def.clone(), opaque.args.clone()).unwrap(),

--- a/src/ops/validate.rs
+++ b/src/ops/validate.rs
@@ -160,7 +160,9 @@ impl ValidateOp for super::Conditional {
         // Each child must have its predicate variant's row and the rest of `inputs` as input,
         // and matching output
         for (i, (child, optype)) in children.into_iter().enumerate() {
-            let OpType::Case(case_op) = optype else {panic!("Child check should have already checked valid ops.")};
+            let OpType::Case(case_op) = optype else {
+                panic!("Child check should have already checked valid ops.")
+            };
             let sig = &case_op.signature;
             if sig.input != self.case_input_row(i).unwrap() || sig.output != self.outputs {
                 return Err(ChildrenValidationError::ConditionalCaseSignature {
@@ -437,9 +439,10 @@ fn validate_io_nodes<'a>(
 /// Validate an edge between two basic blocks in a CFG sibling graph.
 fn validate_cfg_edge(edge: ChildrenEdgeData) -> Result<(), EdgeValidationError> {
     let [source, target]: [&BasicBlock; 2] = [&edge.source_op, &edge.target_op].map(|op| {
-        let OpType::BasicBlock(block_op) = op else {panic!("CFG sibling graphs can only contain basic block operations.")};
+        let OpType::BasicBlock(block_op) = op else {
+            panic!("CFG sibling graphs can only contain basic block operations.")
+        };
         block_op
-
     });
 
     if source.successor_input(edge.source_port.index()).as_ref() != Some(target.dataflow_input()) {

--- a/src/std_extensions/collections.rs
+++ b/src/std_extensions/collections.rs
@@ -44,7 +44,7 @@ impl CustomConst for ListValue {
             .map_err(|_| error())?;
 
         // constant can only hold classic type.
-        let [TypeArg::Type(t)] =  typ.args() else {
+        let [TypeArg::Type(t)] = typ.args() else {
             return Err(error());
         };
 
@@ -118,7 +118,9 @@ fn get_type(name: &str) -> &TypeDef {
 
 fn list_types(args: &[TypeArg]) -> Result<(Type, Type), SignatureError> {
     let list_custom_type = get_type(&LIST_TYPENAME).instantiate_concrete(args)?;
-    let [TypeArg::Type(element_type)] = args else {panic!("should be checked by def.")};
+    let [TypeArg::Type(element_type)] = args else {
+        panic!("should be checked by def.")
+    };
 
     let list_type: Type = Type::new_extension(list_custom_type);
     Ok((list_type, element_type.clone()))


### PR DESCRIPTION
Preventively fixes CI errors before rust 1.72 is released, and rustfmt starts having opinions on let-else formatting.

https://blog.rust-lang.org/2023/07/01/rustfmt-supports-let-else-statements.html