### PR TITLE
Change compute_signature to return FunctionType (et al)

### DIFF
--- a/src/std_extensions/arithmetic/conversions.rs
+++ b/src/std_extensions/arithmetic/conversions.rs
@@ -9,7 +9,7 @@ use crate::{
     type_row,
     types::{
         type_param::{TypeArg, TypeParam},
-        Type, TypeRow,
+        FunctionType, Type,
     },
     utils::collect_array,
     Extension,
@@ -21,28 +21,28 @@ use super::int_types::{get_width, int_type};
 /// The extension identifier.
 pub const EXTENSION_ID: SmolStr = SmolStr::new_inline("arithmetic.conversions");
 
-fn ftoi_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
+fn ftoi_sig(arg_values: &[TypeArg]) -> Result<FunctionType, SignatureError> {
     let [arg] = collect_array(arg_values);
     let n: u8 = get_width(arg)?;
-    Ok((
-        type_row![FLOAT64_TYPE],
-        vec![Type::new_sum(vec![
+    Ok(FunctionType {
+        input: type_row![FLOAT64_TYPE],
+        output: vec![Type::new_sum(vec![
             int_type(n),
             crate::extension::prelude::ERROR_TYPE,
         ])]
         .into(),
-        ExtensionSet::default(),
-    ))
+        extension_reqs: ExtensionSet::default(),
+    })
 }
 
-fn itof_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
+fn itof_sig(arg_values: &[TypeArg]) -> Result<FunctionType, SignatureError> {
     let [arg] = collect_array(arg_values);
     let n: u8 = get_width(arg)?;
-    Ok((
-        vec![int_type(n)].into(),
-        type_row![FLOAT64_TYPE],
-        ExtensionSet::default(),
-    ))
+    Ok(FunctionType {
+        input: vec![int_type(n)].into(),
+        output: type_row![FLOAT64_TYPE],
+        extension_reqs: ExtensionSet::default(),
+    })
 }
 
 /// Extension for basic arithmetic operations.

--- a/src/std_extensions/arithmetic/float_ops.rs
+++ b/src/std_extensions/arithmetic/float_ops.rs
@@ -5,7 +5,7 @@ use smol_str::SmolStr;
 use crate::{
     extension::{ExtensionSet, SignatureError},
     type_row,
-    types::{type_param::TypeArg, TypeRow},
+    types::{type_param::TypeArg, FunctionType},
     Extension,
 };
 
@@ -14,28 +14,28 @@ use super::float_types::FLOAT64_TYPE;
 /// The extension identifier.
 pub const EXTENSION_ID: SmolStr = SmolStr::new_inline("arithmetic.float");
 
-fn fcmp_sig(_arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
-    Ok((
-        type_row![FLOAT64_TYPE; 2],
-        type_row![crate::extension::prelude::BOOL_T],
-        ExtensionSet::default(),
-    ))
+fn fcmp_sig(_arg_values: &[TypeArg]) -> Result<FunctionType, SignatureError> {
+    Ok(FunctionType {
+        input: type_row![FLOAT64_TYPE; 2],
+        output: type_row![crate::extension::prelude::BOOL_T],
+        extension_reqs: ExtensionSet::default(),
+    })
 }
 
-fn fbinop_sig(_arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
-    Ok((
-        type_row![FLOAT64_TYPE; 2],
-        type_row![FLOAT64_TYPE],
-        ExtensionSet::default(),
-    ))
+fn fbinop_sig(_arg_values: &[TypeArg]) -> Result<FunctionType, SignatureError> {
+    Ok(FunctionType {
+        input: type_row![FLOAT64_TYPE; 2],
+        output: type_row![FLOAT64_TYPE],
+        extension_reqs: ExtensionSet::default(),
+    })
 }
 
-fn funop_sig(_arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
-    Ok((
-        type_row![FLOAT64_TYPE],
-        type_row![FLOAT64_TYPE],
-        ExtensionSet::default(),
-    ))
+fn funop_sig(_arg_values: &[TypeArg]) -> Result<FunctionType, SignatureError> {
+    Ok(FunctionType {
+        input: type_row![FLOAT64_TYPE],
+        output: type_row![FLOAT64_TYPE],
+        extension_reqs: ExtensionSet::default(),
+    })
 }
 
 /// Extension for basic arithmetic operations.

--- a/src/std_extensions/arithmetic/int_ops.rs
+++ b/src/std_extensions/arithmetic/int_ops.rs
@@ -6,6 +6,7 @@ use super::int_types::{get_width, int_type};
 use crate::extension::prelude::{BOOL_T, ERROR_TYPE};
 use crate::type_row;
 use crate::types::type_param::TypeParam;
+use crate::types::FunctionType;
 use crate::utils::collect_array;
 use crate::{
     extension::{ExtensionSet, SignatureError},
@@ -16,123 +17,123 @@ use crate::{
 /// The extension identifier.
 pub const EXTENSION_ID: SmolStr = SmolStr::new_inline("arithmetic.int");
 
-fn iwiden_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
+fn iwiden_sig(arg_values: &[TypeArg]) -> Result<FunctionType, SignatureError> {
     let [arg0, arg1] = collect_array(arg_values);
     let m: u8 = get_width(arg0)?;
     let n: u8 = get_width(arg1)?;
     if m > n {
         return Err(SignatureError::InvalidTypeArgs);
     }
-    Ok((
-        vec![int_type(m)].into(),
-        vec![int_type(n)].into(),
-        ExtensionSet::default(),
-    ))
+    Ok(FunctionType {
+        input: vec![int_type(m)].into(),
+        output: vec![int_type(n)].into(),
+        extension_reqs: ExtensionSet::default(),
+    })
 }
 
-fn inarrow_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
+fn inarrow_sig(arg_values: &[TypeArg]) -> Result<FunctionType, SignatureError> {
     let [arg0, arg1] = collect_array(arg_values);
     let m: u8 = get_width(arg0)?;
     let n: u8 = get_width(arg1)?;
     if m < n {
         return Err(SignatureError::InvalidTypeArgs);
     }
-    Ok((
-        vec![int_type(m)].into(),
-        vec![Type::new_sum(vec![int_type(n), ERROR_TYPE])].into(),
-        ExtensionSet::default(),
-    ))
+    Ok(FunctionType {
+        input: vec![int_type(m)].into(),
+        output: vec![Type::new_sum(vec![int_type(n), ERROR_TYPE])].into(),
+        extension_reqs: ExtensionSet::default(),
+    })
 }
 
-fn itob_sig(_arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
-    Ok((
-        vec![int_type(1)].into(),
-        type_row![BOOL_T],
-        ExtensionSet::default(),
-    ))
+fn itob_sig(_arg_values: &[TypeArg]) -> Result<FunctionType, SignatureError> {
+    Ok(FunctionType {
+        input: vec![int_type(1)].into(),
+        output: type_row![BOOL_T],
+        extension_reqs: ExtensionSet::default(),
+    })
 }
 
-fn btoi_sig(_arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
-    Ok((
-        type_row![BOOL_T],
-        vec![int_type(1)].into(),
-        ExtensionSet::default(),
-    ))
+fn btoi_sig(_arg_values: &[TypeArg]) -> Result<FunctionType, SignatureError> {
+    Ok(FunctionType {
+        input: type_row![BOOL_T],
+        output: vec![int_type(1)].into(),
+        extension_reqs: ExtensionSet::default(),
+    })
 }
 
-fn icmp_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
+fn icmp_sig(arg_values: &[TypeArg]) -> Result<FunctionType, SignatureError> {
     let [arg] = collect_array(arg_values);
     let n: u8 = get_width(arg)?;
-    Ok((
-        vec![int_type(n); 2].into(),
-        type_row![BOOL_T],
-        ExtensionSet::default(),
-    ))
+    Ok(FunctionType {
+        input: vec![int_type(n); 2].into(),
+        output: type_row![BOOL_T],
+        extension_reqs: ExtensionSet::default(),
+    })
 }
 
-fn ibinop_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
+fn ibinop_sig(arg_values: &[TypeArg]) -> Result<FunctionType, SignatureError> {
     let [arg] = collect_array(arg_values);
     let n: u8 = get_width(arg)?;
-    Ok((
-        vec![int_type(n); 2].into(),
-        vec![int_type(n)].into(),
-        ExtensionSet::default(),
-    ))
+    Ok(FunctionType {
+        input: vec![int_type(n); 2].into(),
+        output: vec![int_type(n)].into(),
+        extension_reqs: ExtensionSet::default(),
+    })
 }
 
-fn iunop_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
+fn iunop_sig(arg_values: &[TypeArg]) -> Result<FunctionType, SignatureError> {
     let [arg] = collect_array(arg_values);
     let n: u8 = get_width(arg)?;
-    Ok((
-        vec![int_type(n)].into(),
-        vec![int_type(n)].into(),
-        ExtensionSet::default(),
-    ))
+    Ok(FunctionType {
+        input: vec![int_type(n)].into(),
+        output: vec![int_type(n)].into(),
+        extension_reqs: ExtensionSet::default(),
+    })
 }
 
-fn idivmod_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
+fn idivmod_sig(arg_values: &[TypeArg]) -> Result<FunctionType, SignatureError> {
     let [arg0, arg1] = collect_array(arg_values);
     let n: u8 = get_width(arg0)?;
     let m: u8 = get_width(arg1)?;
     let intpair: TypeRow = vec![int_type(n), int_type(m)].into();
-    Ok((
-        intpair.clone(),
-        vec![Type::new_sum(vec![Type::new_tuple(intpair), ERROR_TYPE])].into(),
-        ExtensionSet::default(),
-    ))
+    Ok(FunctionType {
+        input: intpair.clone(),
+        output: vec![Type::new_sum(vec![Type::new_tuple(intpair), ERROR_TYPE])].into(),
+        extension_reqs: ExtensionSet::default(),
+    })
 }
 
-fn idiv_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
+fn idiv_sig(arg_values: &[TypeArg]) -> Result<FunctionType, SignatureError> {
     let [arg0, arg1] = collect_array(arg_values);
     let n: u8 = get_width(arg0)?;
     let m: u8 = get_width(arg1)?;
-    Ok((
-        vec![int_type(n), int_type(m)].into(),
-        vec![Type::new_sum(vec![int_type(n), ERROR_TYPE])].into(),
-        ExtensionSet::default(),
-    ))
+    Ok(FunctionType {
+        input: vec![int_type(n), int_type(m)].into(),
+        output: vec![Type::new_sum(vec![int_type(n), ERROR_TYPE])].into(),
+        extension_reqs: ExtensionSet::default(),
+    })
 }
 
-fn imod_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
+fn imod_sig(arg_values: &[TypeArg]) -> Result<FunctionType, SignatureError> {
     let [arg0, arg1] = collect_array(arg_values);
     let n: u8 = get_width(arg0)?;
     let m: u8 = get_width(arg1)?;
-    Ok((
-        vec![int_type(n), int_type(m)].into(),
-        vec![Type::new_sum(vec![int_type(m), ERROR_TYPE])].into(),
-        ExtensionSet::default(),
-    ))
+    Ok(FunctionType {
+        input: vec![int_type(n), int_type(m)].into(),
+        output: vec![Type::new_sum(vec![int_type(m), ERROR_TYPE])].into(),
+        extension_reqs: ExtensionSet::default(),
+    })
 }
 
-fn ish_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
+fn ish_sig(arg_values: &[TypeArg]) -> Result<FunctionType, SignatureError> {
     let [arg0, arg1] = collect_array(arg_values);
     let n: u8 = get_width(arg0)?;
     let m: u8 = get_width(arg1)?;
-    Ok((
-        vec![int_type(n), int_type(m)].into(),
-        vec![int_type(n)].into(),
-        ExtensionSet::default(),
-    ))
+    Ok(FunctionType {
+        input: vec![int_type(n), int_type(m)].into(),
+        output: vec![int_type(n)].into(),
+        extension_reqs: ExtensionSet::default(),
+    })
 }
 
 /// Extension for basic integer operations.

--- a/src/std_extensions/collections.rs
+++ b/src/std_extensions/collections.rs
@@ -8,7 +8,7 @@ use crate::{
     extension::{ExtensionSet, SignatureError, TypeDef, TypeDefBound},
     types::{
         type_param::{TypeArg, TypeParam},
-        CustomCheckFailure, CustomType, Type, TypeBound, TypeRow,
+        CustomCheckFailure, CustomType, FunctionType, Type, TypeBound, TypeRow,
     },
     values::{CustomConst, Value},
     Extension,
@@ -80,11 +80,11 @@ fn extension() -> Extension {
             vec![],
             move |args: &[TypeArg]| {
                 let (list_type, element_type) = list_types(args)?;
-
-                let inputs = TypeRow::from(vec![list_type.clone()]);
-                let outputs = TypeRow::from(vec![list_type, element_type]);
-                let extension_set = ExtensionSet::singleton(&EXTENSION_NAME);
-                Ok((inputs, outputs, extension_set))
+                Ok(FunctionType {
+                    input: TypeRow::from(vec![list_type.clone()]),
+                    output: TypeRow::from(vec![list_type, element_type]),
+                    extension_reqs: ExtensionSet::singleton(&EXTENSION_NAME),
+                })
             },
         )
         .unwrap();
@@ -97,11 +97,11 @@ fn extension() -> Extension {
             vec![],
             move |args: &[TypeArg]| {
                 let (list_type, element_type) = list_types(args)?;
-
-                let outputs = TypeRow::from(vec![list_type.clone()]);
-                let inputs = TypeRow::from(vec![list_type, element_type]);
-                let extension_set = ExtensionSet::singleton(&EXTENSION_NAME);
-                Ok((inputs, outputs, extension_set))
+                Ok(FunctionType {
+                    output: TypeRow::from(vec![list_type.clone()]),
+                    input: TypeRow::from(vec![list_type, element_type]),
+                    extension_reqs: ExtensionSet::singleton(&EXTENSION_NAME),
+                })
             },
         )
         .unwrap();

--- a/src/std_extensions/logic.rs
+++ b/src/std_extensions/logic.rs
@@ -6,7 +6,10 @@ use smol_str::SmolStr;
 use crate::{
     extension::{prelude::BOOL_T, ExtensionSet},
     ops, type_row,
-    types::type_param::{TypeArg, TypeArgError, TypeParam},
+    types::{
+        type_param::{TypeArg, TypeArgError, TypeParam},
+        FunctionType,
+    },
     Extension,
 };
 use lazy_static::lazy_static;
@@ -36,11 +39,11 @@ fn extension() -> Extension {
             "logical 'not'".into(),
             vec![],
             |_arg_values: &[TypeArg]| {
-                Ok((
-                    type_row![BOOL_T],
-                    type_row![BOOL_T],
-                    ExtensionSet::default(),
-                ))
+                Ok(FunctionType {
+                    input: type_row![BOOL_T],
+                    output: type_row![BOOL_T],
+                    extension_reqs: ExtensionSet::default(),
+                })
             },
         )
         .unwrap();
@@ -62,11 +65,11 @@ fn extension() -> Extension {
                         .into());
                     }
                 };
-                Ok((
-                    vec![BOOL_T; n as usize].into(),
-                    type_row![BOOL_T],
-                    ExtensionSet::default(),
-                ))
+                Ok(FunctionType {
+                    input: vec![BOOL_T; n as usize].into(),
+                    output: type_row![BOOL_T],
+                    extension_reqs: ExtensionSet::default(),
+                })
             },
         )
         .unwrap();
@@ -88,11 +91,11 @@ fn extension() -> Extension {
                         .into());
                     }
                 };
-                Ok((
-                    vec![BOOL_T; n as usize].into(),
-                    type_row![BOOL_T],
-                    ExtensionSet::default(),
-                ))
+                Ok(FunctionType {
+                    input: vec![BOOL_T; n as usize].into(),
+                    output: type_row![BOOL_T],
+                    extension_reqs: ExtensionSet::default(),
+                })
             },
         )
         .unwrap();

--- a/src/std_extensions/quantum.rs
+++ b/src/std_extensions/quantum.rs
@@ -6,23 +6,27 @@ use crate::extension::prelude::{BOOL_T, QB_T};
 use crate::extension::{ExtensionSet, SignatureError};
 use crate::type_row;
 use crate::types::type_param::TypeArg;
-use crate::types::TypeRow;
+use crate::types::FunctionType;
 use crate::Extension;
 
 use lazy_static::lazy_static;
 
 /// The extension identifier.
 pub const EXTENSION_ID: SmolStr = SmolStr::new_inline("quantum");
-fn one_qb_func(_: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
-    Ok((type_row![QB_T], type_row![QB_T], ExtensionSet::new()))
+fn one_qb_func(_: &[TypeArg]) -> Result<FunctionType, SignatureError> {
+    Ok(FunctionType {
+        input: type_row![QB_T],
+        output: type_row![QB_T],
+        extension_reqs: ExtensionSet::new(),
+    })
 }
 
-fn two_qb_func(_: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
-    Ok((
-        type_row![QB_T, QB_T],
-        type_row![QB_T, QB_T],
-        ExtensionSet::new(),
-    ))
+fn two_qb_func(_: &[TypeArg]) -> Result<FunctionType, SignatureError> {
+    Ok(FunctionType {
+        input: type_row![QB_T, QB_T],
+        output: type_row![QB_T, QB_T],
+        extension_reqs: ExtensionSet::new(),
+    })
 }
 
 fn extension() -> Extension {
@@ -47,14 +51,14 @@ fn extension() -> Extension {
             "Measure a qubit, returning the qubit and the measurement result.".into(),
             vec![],
             |_arg_values: &[TypeArg]| {
-                Ok((
-                    type_row![QB_T],
-                    type_row![QB_T, BOOL_T],
+                Ok(FunctionType {
+                    input: type_row![QB_T],
+                    output: type_row![QB_T, BOOL_T],
                     // TODO add logic as an extension delta when inference is
                     // done?
                     // https://github.com/CQCL-DEV/hugr/issues/425
-                    ExtensionSet::new(),
-                ))
+                    extension_reqs: ExtensionSet::new(),
+                })
             },
         )
         .unwrap();

--- a/src/std_extensions/rotation.rs
+++ b/src/std_extensions/rotation.rs
@@ -12,7 +12,7 @@ use pyo3::prelude::*;
 
 use crate::extension::ExtensionSet;
 use crate::types::type_param::TypeArg;
-use crate::types::{CustomCheckFailure, CustomType, Type, TypeBound, TypeRow};
+use crate::types::{CustomCheckFailure, CustomType, FunctionType, Type, TypeBound, TypeRow};
 use crate::values::CustomConst;
 use crate::{ops, Extension};
 
@@ -47,7 +47,11 @@ pub fn extension() -> Extension {
             |_arg_values: &[TypeArg]| {
                 let t: TypeRow =
                     vec![Type::new_extension(RotationType::Angle.custom_type())].into();
-                Ok((t.clone(), t, ExtensionSet::default()))
+                Ok(FunctionType {
+                    input: t.clone(),
+                    output: t,
+                    extension_reqs: ExtensionSet::default(),
+                })
             },
         )
         .unwrap();


### PR DESCRIPTION
Addressing a longstanding TODO.

I used `FunctionType {input: ..., output:...,  extension_reqs:... }` but alternatively one could use `FunctionType::new(..., ...).with_extension_delta(...)`.  (I missed this at first because it looks like other similar methods returning a Signature, so it might be preferable)