### PR TITLE
[fix] Fix the logic of get_io

### DIFF
--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -429,18 +429,13 @@ pub(crate) mod test {
 
     #[test]
     fn lift_node() -> Result<(), BuildError> {
-        let mut module_builder = ModuleBuilder::new();
-
         let ab_extensions = ExtensionSet::from_iter(["A".into(), "B".into()]);
         let c_extensions = ExtensionSet::singleton(&"C".into());
         let abc_extensions = ab_extensions.clone().union(&c_extensions);
 
         let parent_sig =
             FunctionType::new(type_row![BIT], type_row![BIT]).with_extension_delta(&abc_extensions);
-        let mut parent = module_builder.define_function(
-            "parent",
-            parent_sig.with_input_extensions(ExtensionSet::new()),
-        )?;
+        let mut parent = DFGBuilder::new(parent_sig)?;
 
         let add_c_sig = FunctionType::new(type_row![BIT], type_row![BIT])
             .with_extension_delta(&c_extensions)
@@ -498,8 +493,7 @@ pub(crate) mod test {
 
         let add_c = add_c.finish_with_outputs(wires)?;
         let [w] = add_c.outputs_arr();
-        parent.finish_with_outputs([w])?;
-        module_builder.finish_hugr()?;
+        parent.finish_hugr_with_outputs([w])?;
 
         Ok(())
     }

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -361,4 +361,14 @@ mod test {
         trait Test: Send + Sync {}
         impl Test for Hugr {}
     }
+
+    #[test]
+    fn io_node() {
+        use crate::builder::test::simple_dfg_hugr;
+        use crate::hugr::views::HugrView;
+        use cool_asserts::assert_matches;
+
+        let hugr = simple_dfg_hugr();
+        assert_matches!((&hugr).get_io(hugr.root()), Some(_));
+    }
 }

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -369,6 +369,6 @@ mod test {
         use cool_asserts::assert_matches;
 
         let hugr = simple_dfg_hugr();
-        assert_matches!((&hugr).get_io(hugr.root()), Some(_));
+        assert_matches!(hugr.get_io(hugr.root()), Some(_));
     }
 }

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -1211,7 +1211,7 @@ mod test {
         assert_matches!(
             handle,
             Err(ValidationError::ExtensionError(
-                ExtensionError::TgtExceedsSrcExtensions { .. }
+                ExtensionError::ParentIOExtensionMismatch { .. }
             ))
         );
         Ok(())

--- a/src/hugr/views.rs
+++ b/src/hugr/views.rs
@@ -314,7 +314,7 @@ where
     #[inline]
     fn get_io(&self, node: Node) -> Option<[Node; 2]> {
         let op = self.get_nodetype(node);
-        if op.tag().is_superset(OpTag::DataflowParent) {
+        if OpTag::DataflowParent.is_superset(op.tag()) {
             self.children(node).take(2).collect_vec().try_into().ok()
         } else {
             None

--- a/src/ops/tag.rs
+++ b/src/ops/tag.rs
@@ -68,7 +68,7 @@ pub enum OpTag {
 }
 
 impl OpTag {
-    /// Returns true if the tag is more general than the given tag.
+    /// Returns true if this tag is more general than `other`.
     #[inline]
     pub const fn is_superset(self, other: OpTag) -> bool {
         // We cannot call iter().any() or even do for loops in const fn yet.


### PR DESCRIPTION
Fix the logic of `get_io` and update the wording of the `is_superset` function.
Due to this bug, some tests weren't having their extension requirements validated, so update those too