### PR TITLE
feat: Change `TypeParam::USize` to `TypeParam::BoundedNat` and use in int extensions

### DIFF
--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -907,17 +907,17 @@ The declaration of the `params` uses a language that is a distinct, simplified
 form of the [Type System](#type-system) - writing terminals that appear in the YAML in quotes,
 the value of each member of `params` is given by the following production:
 ```
-TypeParam ::= "Type"("Any"|"Copy"|"Eq") | "USize" | "Extensions" | "List"(TypeParam) | "Tuple"([TypeParam]) | Opaque
+TypeParam ::= "Type"("Any"|"Copy"|"Eq") | "BoundedUSize(u64)" | "Extensions" | "List"(TypeParam) | "Tuple"([TypeParam]) | Opaque
 
 Opaque ::= string<[TypeArgs]>
 
-TypeArgs ::= Type(Type) | USize(u64) | Extensions | List([TypeArg]) | Tuple([TypeArg])
+TypeArgs ::= Type(Type) | BoundedUSize(u64) | Extensions | List([TypeArg]) | Tuple([TypeArg])
 
 Type ::= Name<[TypeArg]>
 ```
 (We write `[Foo]` to indicate a list of Foo's; and omit `<>` where the contents is the empty list).
 
-To use an OpDef as an Op, or a TypeDef as a type, the user must provide a type argument for each type param in the def: a type in the appropriate class, a constant usize, a set of extensions, a list or tuple of arguments.
+To use an OpDef as an Op, or a TypeDef as a type, the user must provide a type argument for each type param in the def: a type in the appropriate class, a bounded usize, a set of extensions, a list or tuple of arguments.
 
 **Implementation note** Reading this format into Rust is made easy by `serde` and
 [serde\_yaml](https://github.com/dtolnay/serde-yaml) (see the

--- a/src/extension/prelude.rs
+++ b/src/extension/prelude.rs
@@ -30,7 +30,7 @@ lazy_static! {
         prelude
             .add_type(
                 SmolStr::new_inline("array"),
-                vec![TypeParam::Type(TypeBound::Any), TypeParam::USize],
+                vec![TypeParam::Type(TypeBound::Any), TypeParam::max_usize()],
                 "array".into(),
                 TypeDefBound::FromParams(vec![0]),
             )
@@ -68,7 +68,7 @@ pub(crate) const BOOL_T: Type = Type::new_simple_predicate(2);
 pub fn new_array(typ: Type, size: u64) -> Type {
     let array_def = PRELUDE.get_type("array").unwrap();
     let custom_t = array_def
-        .instantiate_concrete(vec![TypeArg::Type(typ), TypeArg::USize(size)])
+        .instantiate_concrete(vec![TypeArg::Type(typ), TypeArg::BoundedUSize(size)])
         .unwrap();
     Type::new_extension(custom_t)
 }

--- a/src/extension/prelude.rs
+++ b/src/extension/prelude.rs
@@ -30,7 +30,7 @@ lazy_static! {
         prelude
             .add_type(
                 SmolStr::new_inline("array"),
-                vec![TypeParam::Type(TypeBound::Any), TypeParam::max_usize()],
+                vec![TypeParam::Type(TypeBound::Any), TypeParam::max_nat()],
                 "array".into(),
                 TypeDefBound::FromParams(vec![0]),
             )
@@ -68,7 +68,7 @@ pub(crate) const BOOL_T: Type = Type::new_simple_predicate(2);
 pub fn new_array(typ: Type, size: u64) -> Type {
     let array_def = PRELUDE.get_type("array").unwrap();
     let custom_t = array_def
-        .instantiate_concrete(vec![TypeArg::Type(typ), TypeArg::BoundedUSize(size)])
+        .instantiate_concrete(vec![TypeArg::Type(typ), TypeArg::BoundedNat(size)])
         .unwrap();
     Type::new_extension(custom_t)
 }

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -199,7 +199,12 @@ mod test {
 
     #[test]
     fn test_yaml_const() {
-        let typ_int = CustomType::new("mytype", vec![TypeArg::USize(8)], "myrsrc", TypeBound::Eq);
+        let typ_int = CustomType::new(
+            "mytype",
+            vec![TypeArg::BoundedUSize(8)],
+            "myrsrc",
+            TypeBound::Eq,
+        );
         let val: Value = CustomSerialized::new(typ_int.clone(), YamlValue::Number(6.into())).into();
         let classic_t = Type::new_extension(typ_int.clone());
         assert_matches!(classic_t.least_upper_bound(), TypeBound::Eq);

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -201,7 +201,7 @@ mod test {
     fn test_yaml_const() {
         let typ_int = CustomType::new(
             "mytype",
-            vec![TypeArg::BoundedUSize(8)],
+            vec![TypeArg::BoundedNat(8)],
             "myrsrc",
             TypeBound::Eq,
         );

--- a/src/std_extensions/arithmetic/conversions.rs
+++ b/src/std_extensions/arithmetic/conversions.rs
@@ -7,16 +7,13 @@ use smol_str::SmolStr;
 use crate::{
     extension::{ExtensionSet, SignatureError},
     type_row,
-    types::{
-        type_param::{TypeArg, TypeParam},
-        Type, TypeRow,
-    },
+    types::{type_param::TypeArg, Type, TypeRow},
     utils::collect_array,
     Extension,
 };
 
-use super::float_types::FLOAT64_TYPE;
 use super::int_types::int_type;
+use super::{float_types::FLOAT64_TYPE, int_types::LOG_WIDTH_TYPE_PARAM};
 
 /// The extension identifier.
 pub const EXTENSION_ID: SmolStr = SmolStr::new_inline("arithmetic.conversions");
@@ -57,7 +54,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "trunc_u".into(),
             "float to unsigned int".to_owned(),
-            vec![TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM],
             ftoi_sig,
         )
         .unwrap();
@@ -65,7 +62,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "trunc_s".into(),
             "float to signed int".to_owned(),
-            vec![TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM],
             ftoi_sig,
         )
         .unwrap();
@@ -73,7 +70,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "convert_u".into(),
             "unsigned int to float".to_owned(),
-            vec![TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM],
             itof_sig,
         )
         .unwrap();
@@ -81,7 +78,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "convert_s".into(),
             "signed int to float".to_owned(),
-            vec![TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM],
             itof_sig,
         )
         .unwrap();

--- a/src/std_extensions/arithmetic/conversions.rs
+++ b/src/std_extensions/arithmetic/conversions.rs
@@ -59,7 +59,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "trunc_u".into(),
             "float to unsigned int".to_owned(),
-            vec![TypeParam::USize],
+            vec![TypeParam::max_usize()],
             ftoi_sig,
         )
         .unwrap();
@@ -67,7 +67,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "trunc_s".into(),
             "float to signed int".to_owned(),
-            vec![TypeParam::USize],
+            vec![TypeParam::max_usize()],
             ftoi_sig,
         )
         .unwrap();
@@ -75,7 +75,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "convert_u".into(),
             "unsigned int to float".to_owned(),
-            vec![TypeParam::USize],
+            vec![TypeParam::max_usize()],
             itof_sig,
         )
         .unwrap();
@@ -83,7 +83,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "convert_s".into(),
             "signed int to float".to_owned(),
-            vec![TypeParam::USize],
+            vec![TypeParam::max_usize()],
             itof_sig,
         )
         .unwrap();

--- a/src/std_extensions/arithmetic/conversions.rs
+++ b/src/std_extensions/arithmetic/conversions.rs
@@ -16,18 +16,17 @@ use crate::{
 };
 
 use super::float_types::FLOAT64_TYPE;
-use super::int_types::{get_width_power, int_type};
+use super::int_types::int_type;
 
 /// The extension identifier.
 pub const EXTENSION_ID: SmolStr = SmolStr::new_inline("arithmetic.conversions");
 
 fn ftoi_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg] = collect_array(arg_values);
-    let n: u8 = get_width_power(arg);
     Ok((
         type_row![FLOAT64_TYPE],
         vec![Type::new_sum(vec![
-            int_type(n),
+            int_type(arg.clone()),
             crate::extension::prelude::ERROR_TYPE,
         ])]
         .into(),
@@ -37,9 +36,8 @@ fn ftoi_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), 
 
 fn itof_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg] = collect_array(arg_values);
-    let n: u8 = get_width_power(arg);
     Ok((
-        vec![int_type(n)].into(),
+        vec![int_type(arg.clone())].into(),
         type_row![FLOAT64_TYPE],
         ExtensionSet::default(),
     ))

--- a/src/std_extensions/arithmetic/conversions.rs
+++ b/src/std_extensions/arithmetic/conversions.rs
@@ -16,14 +16,14 @@ use crate::{
 };
 
 use super::float_types::FLOAT64_TYPE;
-use super::int_types::{get_width, int_type};
+use super::int_types::{get_width_power, int_type};
 
 /// The extension identifier.
 pub const EXTENSION_ID: SmolStr = SmolStr::new_inline("arithmetic.conversions");
 
 fn ftoi_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg] = collect_array(arg_values);
-    let n: u8 = get_width(arg)?;
+    let n: u8 = get_width_power(arg);
     Ok((
         type_row![FLOAT64_TYPE],
         vec![Type::new_sum(vec![
@@ -37,7 +37,7 @@ fn ftoi_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), 
 
 fn itof_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg] = collect_array(arg_values);
-    let n: u8 = get_width(arg)?;
+    let n: u8 = get_width_power(arg);
     Ok((
         vec![int_type(n)].into(),
         type_row![FLOAT64_TYPE],

--- a/src/std_extensions/arithmetic/int_ops.rs
+++ b/src/std_extensions/arithmetic/int_ops.rs
@@ -2,7 +2,7 @@
 
 use smol_str::SmolStr;
 
-use super::int_types::{get_width, int_type};
+use super::int_types::{get_width_power, int_type};
 use crate::extension::prelude::{BOOL_T, ERROR_TYPE};
 use crate::type_row;
 use crate::types::type_param::TypeParam;
@@ -18,8 +18,8 @@ pub const EXTENSION_ID: SmolStr = SmolStr::new_inline("arithmetic.int");
 
 fn iwiden_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg0, arg1] = collect_array(arg_values);
-    let m: u8 = get_width(arg0)?;
-    let n: u8 = get_width(arg1)?;
+    let m: u8 = get_width_power(arg0);
+    let n: u8 = get_width_power(arg1);
     if m > n {
         return Err(SignatureError::InvalidTypeArgs);
     }
@@ -32,8 +32,8 @@ fn iwiden_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet)
 
 fn inarrow_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg0, arg1] = collect_array(arg_values);
-    let m: u8 = get_width(arg0)?;
-    let n: u8 = get_width(arg1)?;
+    let m: u8 = get_width_power(arg0);
+    let n: u8 = get_width_power(arg1);
     if m < n {
         return Err(SignatureError::InvalidTypeArgs);
     }
@@ -62,7 +62,7 @@ fn btoi_sig(_arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet),
 
 fn icmp_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg] = collect_array(arg_values);
-    let n: u8 = get_width(arg)?;
+    let n: u8 = get_width_power(arg);
     Ok((
         vec![int_type(n); 2].into(),
         type_row![BOOL_T],
@@ -72,7 +72,7 @@ fn icmp_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), 
 
 fn ibinop_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg] = collect_array(arg_values);
-    let n: u8 = get_width(arg)?;
+    let n: u8 = get_width_power(arg);
     Ok((
         vec![int_type(n); 2].into(),
         vec![int_type(n)].into(),
@@ -82,7 +82,7 @@ fn ibinop_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet)
 
 fn iunop_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg] = collect_array(arg_values);
-    let n: u8 = get_width(arg)?;
+    let n: u8 = get_width_power(arg);
     Ok((
         vec![int_type(n)].into(),
         vec![int_type(n)].into(),
@@ -92,8 +92,8 @@ fn iunop_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet),
 
 fn idivmod_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg0, arg1] = collect_array(arg_values);
-    let n: u8 = get_width(arg0)?;
-    let m: u8 = get_width(arg1)?;
+    let n: u8 = get_width_power(arg0);
+    let m: u8 = get_width_power(arg1);
     let intpair: TypeRow = vec![int_type(n), int_type(m)].into();
     Ok((
         intpair.clone(),
@@ -104,8 +104,8 @@ fn idivmod_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet
 
 fn idiv_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg0, arg1] = collect_array(arg_values);
-    let n: u8 = get_width(arg0)?;
-    let m: u8 = get_width(arg1)?;
+    let n: u8 = get_width_power(arg0);
+    let m: u8 = get_width_power(arg1);
     Ok((
         vec![int_type(n), int_type(m)].into(),
         vec![Type::new_sum(vec![int_type(n), ERROR_TYPE])].into(),
@@ -115,8 +115,8 @@ fn idiv_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), 
 
 fn imod_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg0, arg1] = collect_array(arg_values);
-    let n: u8 = get_width(arg0)?;
-    let m: u8 = get_width(arg1)?;
+    let n: u8 = get_width_power(arg0);
+    let m: u8 = get_width_power(arg1);
     Ok((
         vec![int_type(n), int_type(m)].into(),
         vec![Type::new_sum(vec![int_type(m), ERROR_TYPE])].into(),
@@ -126,8 +126,8 @@ fn imod_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), 
 
 fn ish_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg0, arg1] = collect_array(arg_values);
-    let n: u8 = get_width(arg0)?;
-    let m: u8 = get_width(arg1)?;
+    let n: u8 = get_width_power(arg0);
+    let m: u8 = get_width_power(arg1);
     Ok((
         vec![int_type(n), int_type(m)].into(),
         vec![int_type(n)].into(),

--- a/src/std_extensions/arithmetic/int_ops.rs
+++ b/src/std_extensions/arithmetic/int_ops.rs
@@ -89,7 +89,7 @@ fn iunop_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet),
 
 fn idivmod_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg0, arg1] = collect_array(arg_values);
-    let intpair: TypeRow = vec![int_type(arg1.clone()), int_type(arg0.clone())].into();
+    let intpair: TypeRow = vec![int_type(arg0.clone()), int_type(arg1.clone())].into();
     Ok((
         intpair.clone(),
         vec![Type::new_sum(vec![Type::new_tuple(intpair), ERROR_TYPE])].into(),
@@ -100,8 +100,8 @@ fn idivmod_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet
 fn idiv_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg0, arg1] = collect_array(arg_values);
     Ok((
-        vec![int_type(arg1.clone()), int_type(arg0.clone())].into(),
-        vec![Type::new_sum(vec![int_type(arg1.clone()), ERROR_TYPE])].into(),
+        vec![int_type(arg0.clone()), int_type(arg1.clone())].into(),
+        vec![Type::new_sum(vec![int_type(arg0.clone()), ERROR_TYPE])].into(),
         ExtensionSet::default(),
     ))
 }
@@ -109,8 +109,8 @@ fn idiv_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), 
 fn imod_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg0, arg1] = collect_array(arg_values);
     Ok((
-        vec![int_type(arg1.clone()), int_type(arg0.clone())].into(),
-        vec![Type::new_sum(vec![int_type(arg0.clone()), ERROR_TYPE])].into(),
+        vec![int_type(arg0.clone()), int_type(arg1.clone())].into(),
+        vec![Type::new_sum(vec![int_type(arg1.clone()), ERROR_TYPE])].into(),
         ExtensionSet::default(),
     ))
 }
@@ -118,8 +118,8 @@ fn imod_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), 
 fn ish_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg0, arg1] = collect_array(arg_values);
     Ok((
-        vec![int_type(arg1.clone()), int_type(arg0.clone())].into(),
-        vec![int_type(arg1.clone())].into(),
+        vec![int_type(arg0.clone()), int_type(arg1.clone())].into(),
+        vec![int_type(arg0.clone())].into(),
         ExtensionSet::default(),
     ))
 }

--- a/src/std_extensions/arithmetic/int_ops.rs
+++ b/src/std_extensions/arithmetic/int_ops.rs
@@ -146,7 +146,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "iwiden_u".into(),
             "widen an unsigned integer to a wider one with the same value".to_owned(),
-            vec![TypeParam::USize, TypeParam::USize],
+            vec![TypeParam::max_usize(), TypeParam::max_usize()],
             iwiden_sig,
         )
         .unwrap();
@@ -154,7 +154,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "iwiden_s".into(),
             "widen a signed integer to a wider one with the same value".to_owned(),
-            vec![TypeParam::USize, TypeParam::USize],
+            vec![TypeParam::max_usize(), TypeParam::max_usize()],
             iwiden_sig,
         )
         .unwrap();
@@ -163,7 +163,7 @@ pub fn extension() -> Extension {
             "inarrow_u".into(),
             "narrow an unsigned integer to a narrower one with the same value if possible"
                 .to_owned(),
-            vec![TypeParam::USize, TypeParam::USize],
+            vec![TypeParam::max_usize(), TypeParam::max_usize()],
             inarrow_sig,
         )
         .unwrap();
@@ -171,7 +171,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "inarrow_s".into(),
             "narrow a signed integer to a narrower one with the same value if possible".to_owned(),
-            vec![TypeParam::USize, TypeParam::USize],
+            vec![TypeParam::max_usize(), TypeParam::max_usize()],
             inarrow_sig,
         )
         .unwrap();
@@ -195,7 +195,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "ieq".into(),
             "equality test".to_owned(),
-            vec![TypeParam::USize],
+            vec![TypeParam::max_usize()],
             icmp_sig,
         )
         .unwrap();
@@ -203,7 +203,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "ine".into(),
             "inequality test".to_owned(),
-            vec![TypeParam::USize],
+            vec![TypeParam::max_usize()],
             icmp_sig,
         )
         .unwrap();
@@ -211,7 +211,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "ilt_u".into(),
             "\"less than\" as unsigned integers".to_owned(),
-            vec![TypeParam::USize],
+            vec![TypeParam::max_usize()],
             icmp_sig,
         )
         .unwrap();
@@ -219,7 +219,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "ilt_s".into(),
             "\"less than\" as signed integers".to_owned(),
-            vec![TypeParam::USize],
+            vec![TypeParam::max_usize()],
             icmp_sig,
         )
         .unwrap();
@@ -227,7 +227,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "igt_u".into(),
             "\"greater than\" as unsigned integers".to_owned(),
-            vec![TypeParam::USize],
+            vec![TypeParam::max_usize()],
             icmp_sig,
         )
         .unwrap();
@@ -235,7 +235,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "igt_s".into(),
             "\"greater than\" as signed integers".to_owned(),
-            vec![TypeParam::USize],
+            vec![TypeParam::max_usize()],
             icmp_sig,
         )
         .unwrap();
@@ -243,7 +243,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "ile_u".into(),
             "\"less than or equal\" as unsigned integers".to_owned(),
-            vec![TypeParam::USize],
+            vec![TypeParam::max_usize()],
             icmp_sig,
         )
         .unwrap();
@@ -251,7 +251,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "ile_s".into(),
             "\"less than or equal\" as signed integers".to_owned(),
-            vec![TypeParam::USize],
+            vec![TypeParam::max_usize()],
             icmp_sig,
         )
         .unwrap();
@@ -259,7 +259,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "ige_u".into(),
             "\"greater than or equal\" as unsigned integers".to_owned(),
-            vec![TypeParam::USize],
+            vec![TypeParam::max_usize()],
             icmp_sig,
         )
         .unwrap();
@@ -267,7 +267,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "ige_s".into(),
             "\"greater than or equal\" as signed integers".to_owned(),
-            vec![TypeParam::USize],
+            vec![TypeParam::max_usize()],
             icmp_sig,
         )
         .unwrap();
@@ -275,7 +275,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "imax_u".into(),
             "maximum of unsigned integers".to_owned(),
-            vec![TypeParam::USize],
+            vec![TypeParam::max_usize()],
             ibinop_sig,
         )
         .unwrap();
@@ -283,7 +283,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "imax_s".into(),
             "maximum of signed integers".to_owned(),
-            vec![TypeParam::USize],
+            vec![TypeParam::max_usize()],
             ibinop_sig,
         )
         .unwrap();
@@ -291,7 +291,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "imin_u".into(),
             "minimum of unsigned integers".to_owned(),
-            vec![TypeParam::USize],
+            vec![TypeParam::max_usize()],
             ibinop_sig,
         )
         .unwrap();
@@ -299,7 +299,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "imin_s".into(),
             "minimum of signed integers".to_owned(),
-            vec![TypeParam::USize],
+            vec![TypeParam::max_usize()],
             ibinop_sig,
         )
         .unwrap();
@@ -307,7 +307,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "iadd".into(),
             "addition modulo 2^N (signed and unsigned versions are the same op)".to_owned(),
-            vec![TypeParam::USize],
+            vec![TypeParam::max_usize()],
             ibinop_sig,
         )
         .unwrap();
@@ -315,7 +315,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "isub".into(),
             "subtraction modulo 2^N (signed and unsigned versions are the same op)".to_owned(),
-            vec![TypeParam::USize],
+            vec![TypeParam::max_usize()],
             ibinop_sig,
         )
         .unwrap();
@@ -323,7 +323,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "ineg".into(),
             "negation modulo 2^N (signed and unsigned versions are the same op)".to_owned(),
-            vec![TypeParam::USize],
+            vec![TypeParam::max_usize()],
             iunop_sig,
         )
         .unwrap();
@@ -331,7 +331,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "imul".into(),
             "multiplication modulo 2^N (signed and unsigned versions are the same op)".to_owned(),
-            vec![TypeParam::USize],
+            vec![TypeParam::max_usize()],
             ibinop_sig,
         )
         .unwrap();
@@ -341,7 +341,7 @@ pub fn extension() -> Extension {
             "given unsigned integers 0 <= n < 2^N, 0 <= m < 2^M, generates unsigned q, r where \
             q*m+r=n, 0<=r<m (m=0 is an error)"
                 .to_owned(),
-            vec![TypeParam::USize, TypeParam::USize],
+            vec![TypeParam::max_usize(), TypeParam::max_usize()],
             idivmod_sig,
         )
         .unwrap();
@@ -351,7 +351,7 @@ pub fn extension() -> Extension {
             "given signed integer -2^{N-1} <= n < 2^{N-1} and unsigned 0 <= m < 2^M, generates \
             signed q and unsigned r where q*m+r=n, 0<=r<m (m=0 is an error)"
                 .to_owned(),
-            vec![TypeParam::USize, TypeParam::USize],
+            vec![TypeParam::max_usize(), TypeParam::max_usize()],
             idivmod_sig,
         )
         .unwrap();
@@ -359,7 +359,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "idiv_u".into(),
             "as idivmod_u but discarding the second output".to_owned(),
-            vec![TypeParam::USize, TypeParam::USize],
+            vec![TypeParam::max_usize(), TypeParam::max_usize()],
             idiv_sig,
         )
         .unwrap();
@@ -367,7 +367,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "imod_u".into(),
             "as idivmod_u but discarding the first output".to_owned(),
-            vec![TypeParam::USize, TypeParam::USize],
+            vec![TypeParam::max_usize(), TypeParam::max_usize()],
             idiv_sig,
         )
         .unwrap();
@@ -375,7 +375,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "idiv_s".into(),
             "as idivmod_s but discarding the second output".to_owned(),
-            vec![TypeParam::USize, TypeParam::USize],
+            vec![TypeParam::max_usize(), TypeParam::max_usize()],
             imod_sig,
         )
         .unwrap();
@@ -383,7 +383,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "imod_s".into(),
             "as idivmod_s but discarding the first output".to_owned(),
-            vec![TypeParam::USize, TypeParam::USize],
+            vec![TypeParam::max_usize(), TypeParam::max_usize()],
             imod_sig,
         )
         .unwrap();
@@ -391,7 +391,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "iabs".into(),
             "convert signed to unsigned by taking absolute value".to_owned(),
-            vec![TypeParam::USize],
+            vec![TypeParam::max_usize()],
             iunop_sig,
         )
         .unwrap();
@@ -399,7 +399,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "iand".into(),
             "bitwise AND".to_owned(),
-            vec![TypeParam::USize],
+            vec![TypeParam::max_usize()],
             ibinop_sig,
         )
         .unwrap();
@@ -407,7 +407,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "ior".into(),
             "bitwise OR".to_owned(),
-            vec![TypeParam::USize],
+            vec![TypeParam::max_usize()],
             ibinop_sig,
         )
         .unwrap();
@@ -415,7 +415,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "ixor".into(),
             "bitwise XOR".to_owned(),
-            vec![TypeParam::USize],
+            vec![TypeParam::max_usize()],
             ibinop_sig,
         )
         .unwrap();
@@ -423,7 +423,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "inot".into(),
             "bitwise NOT".to_owned(),
-            vec![TypeParam::USize],
+            vec![TypeParam::max_usize()],
             iunop_sig,
         )
         .unwrap();
@@ -433,7 +433,7 @@ pub fn extension() -> Extension {
             "shift first input left by k bits where k is unsigned interpretation of second input \
             (leftmost bits dropped, rightmost bits set to zero"
                 .to_owned(),
-            vec![TypeParam::USize, TypeParam::USize],
+            vec![TypeParam::max_usize(), TypeParam::max_usize()],
             ish_sig,
         )
         .unwrap();
@@ -443,7 +443,7 @@ pub fn extension() -> Extension {
             "shift first input right by k bits where k is unsigned interpretation of second input \
             (rightmost bits dropped, leftmost bits set to zero)"
                 .to_owned(),
-            vec![TypeParam::USize, TypeParam::USize],
+            vec![TypeParam::max_usize(), TypeParam::max_usize()],
             ish_sig,
         )
         .unwrap();
@@ -453,7 +453,7 @@ pub fn extension() -> Extension {
             "rotate first input left by k bits where k is unsigned interpretation of second input \
             (leftmost bits replace rightmost bits)"
                 .to_owned(),
-            vec![TypeParam::USize, TypeParam::USize],
+            vec![TypeParam::max_usize(), TypeParam::max_usize()],
             ish_sig,
         )
         .unwrap();
@@ -463,7 +463,7 @@ pub fn extension() -> Extension {
             "rotate first input right by k bits where k is unsigned interpretation of second input \
             (rightmost bits replace leftmost bits)"
                 .to_owned(),
-            vec![TypeParam::USize, TypeParam::USize],
+            vec![TypeParam::max_usize(), TypeParam::max_usize()],
             ish_sig,
         )
         .unwrap();

--- a/src/std_extensions/arithmetic/int_ops.rs
+++ b/src/std_extensions/arithmetic/int_ops.rs
@@ -2,7 +2,7 @@
 
 use smol_str::SmolStr;
 
-use super::int_types::{get_width_power, int_type};
+use super::int_types::{get_width_power, int_type, type_arg};
 use crate::extension::prelude::{BOOL_T, ERROR_TYPE};
 use crate::type_row;
 use crate::types::type_param::TypeParam;
@@ -18,35 +18,35 @@ pub const EXTENSION_ID: SmolStr = SmolStr::new_inline("arithmetic.int");
 
 fn iwiden_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg0, arg1] = collect_array(arg_values);
-    let m: u8 = get_width_power(arg0);
-    let n: u8 = get_width_power(arg1);
+    let m: u8 = get_width_power(arg0)?;
+    let n: u8 = get_width_power(arg1)?;
     if m > n {
         return Err(SignatureError::InvalidTypeArgs);
     }
     Ok((
-        vec![int_type(m)].into(),
-        vec![int_type(n)].into(),
+        vec![int_type(arg0.clone())].into(),
+        vec![int_type(arg1.clone())].into(),
         ExtensionSet::default(),
     ))
 }
 
 fn inarrow_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg0, arg1] = collect_array(arg_values);
-    let m: u8 = get_width_power(arg0);
-    let n: u8 = get_width_power(arg1);
+    let m: u8 = get_width_power(arg0)?;
+    let n: u8 = get_width_power(arg1)?;
     if m < n {
         return Err(SignatureError::InvalidTypeArgs);
     }
     Ok((
-        vec![int_type(m)].into(),
-        vec![Type::new_sum(vec![int_type(n), ERROR_TYPE])].into(),
+        vec![int_type(arg0.clone())].into(),
+        vec![Type::new_sum(vec![int_type(arg1.clone()), ERROR_TYPE])].into(),
         ExtensionSet::default(),
     ))
 }
 
 fn itob_sig(_arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     Ok((
-        vec![int_type(1)].into(),
+        vec![int_type(type_arg(1))].into(),
         type_row![BOOL_T],
         ExtensionSet::default(),
     ))
@@ -55,16 +55,15 @@ fn itob_sig(_arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet),
 fn btoi_sig(_arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     Ok((
         type_row![BOOL_T],
-        vec![int_type(1)].into(),
+        vec![int_type(type_arg(1))].into(),
         ExtensionSet::default(),
     ))
 }
 
 fn icmp_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg] = collect_array(arg_values);
-    let n: u8 = get_width_power(arg);
     Ok((
-        vec![int_type(n); 2].into(),
+        vec![int_type(arg.clone()); 2].into(),
         type_row![BOOL_T],
         ExtensionSet::default(),
     ))
@@ -72,29 +71,25 @@ fn icmp_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), 
 
 fn ibinop_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg] = collect_array(arg_values);
-    let n: u8 = get_width_power(arg);
     Ok((
-        vec![int_type(n); 2].into(),
-        vec![int_type(n)].into(),
+        vec![int_type(arg.clone()); 2].into(),
+        vec![int_type(arg.clone())].into(),
         ExtensionSet::default(),
     ))
 }
 
 fn iunop_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg] = collect_array(arg_values);
-    let n: u8 = get_width_power(arg);
     Ok((
-        vec![int_type(n)].into(),
-        vec![int_type(n)].into(),
+        vec![int_type(arg.clone())].into(),
+        vec![int_type(arg.clone())].into(),
         ExtensionSet::default(),
     ))
 }
 
 fn idivmod_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg0, arg1] = collect_array(arg_values);
-    let n: u8 = get_width_power(arg0);
-    let m: u8 = get_width_power(arg1);
-    let intpair: TypeRow = vec![int_type(n), int_type(m)].into();
+    let intpair: TypeRow = vec![int_type(arg1.clone()), int_type(arg0.clone())].into();
     Ok((
         intpair.clone(),
         vec![Type::new_sum(vec![Type::new_tuple(intpair), ERROR_TYPE])].into(),
@@ -104,33 +99,27 @@ fn idivmod_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet
 
 fn idiv_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg0, arg1] = collect_array(arg_values);
-    let n: u8 = get_width_power(arg0);
-    let m: u8 = get_width_power(arg1);
     Ok((
-        vec![int_type(n), int_type(m)].into(),
-        vec![Type::new_sum(vec![int_type(n), ERROR_TYPE])].into(),
+        vec![int_type(arg1.clone()), int_type(arg0.clone())].into(),
+        vec![Type::new_sum(vec![int_type(arg1.clone()), ERROR_TYPE])].into(),
         ExtensionSet::default(),
     ))
 }
 
 fn imod_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg0, arg1] = collect_array(arg_values);
-    let n: u8 = get_width_power(arg0);
-    let m: u8 = get_width_power(arg1);
     Ok((
-        vec![int_type(n), int_type(m)].into(),
-        vec![Type::new_sum(vec![int_type(m), ERROR_TYPE])].into(),
+        vec![int_type(arg1.clone()), int_type(arg0.clone())].into(),
+        vec![Type::new_sum(vec![int_type(arg0.clone()), ERROR_TYPE])].into(),
         ExtensionSet::default(),
     ))
 }
 
 fn ish_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg0, arg1] = collect_array(arg_values);
-    let n: u8 = get_width_power(arg0);
-    let m: u8 = get_width_power(arg1);
     Ok((
-        vec![int_type(n), int_type(m)].into(),
-        vec![int_type(n)].into(),
+        vec![int_type(arg1.clone()), int_type(arg0.clone())].into(),
+        vec![int_type(arg1.clone())].into(),
         ExtensionSet::default(),
     ))
 }

--- a/src/std_extensions/arithmetic/int_ops.rs
+++ b/src/std_extensions/arithmetic/int_ops.rs
@@ -2,7 +2,7 @@
 
 use smol_str::SmolStr;
 
-use super::int_types::{get_width_power, int_type, type_arg};
+use super::int_types::{get_log_width, int_type, type_arg};
 use crate::extension::prelude::{BOOL_T, ERROR_TYPE};
 use crate::type_row;
 use crate::types::type_param::TypeParam;
@@ -18,8 +18,8 @@ pub const EXTENSION_ID: SmolStr = SmolStr::new_inline("arithmetic.int");
 
 fn iwiden_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg0, arg1] = collect_array(arg_values);
-    let m: u8 = get_width_power(arg0)?;
-    let n: u8 = get_width_power(arg1)?;
+    let m: u8 = get_log_width(arg0)?;
+    let n: u8 = get_log_width(arg1)?;
     if m > n {
         return Err(SignatureError::InvalidTypeArgs);
     }
@@ -32,8 +32,8 @@ fn iwiden_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet)
 
 fn inarrow_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     let [arg0, arg1] = collect_array(arg_values);
-    let m: u8 = get_width_power(arg0)?;
-    let n: u8 = get_width_power(arg1)?;
+    let m: u8 = get_log_width(arg0)?;
+    let n: u8 = get_log_width(arg1)?;
     if m < n {
         return Err(SignatureError::InvalidTypeArgs);
     }

--- a/src/std_extensions/arithmetic/int_ops.rs
+++ b/src/std_extensions/arithmetic/int_ops.rs
@@ -2,10 +2,9 @@
 
 use smol_str::SmolStr;
 
-use super::int_types::{get_log_width, int_type, type_arg};
+use super::int_types::{get_log_width, int_type, type_arg, LOG_WIDTH_TYPE_PARAM};
 use crate::extension::prelude::{BOOL_T, ERROR_TYPE};
 use crate::type_row;
-use crate::types::type_param::TypeParam;
 use crate::utils::collect_array;
 use crate::{
     extension::{ExtensionSet, SignatureError},
@@ -135,7 +134,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "iwiden_u".into(),
             "widen an unsigned integer to a wider one with the same value".to_owned(),
-            vec![TypeParam::max_usize(), TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
             iwiden_sig,
         )
         .unwrap();
@@ -143,7 +142,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "iwiden_s".into(),
             "widen a signed integer to a wider one with the same value".to_owned(),
-            vec![TypeParam::max_usize(), TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
             iwiden_sig,
         )
         .unwrap();
@@ -152,7 +151,7 @@ pub fn extension() -> Extension {
             "inarrow_u".into(),
             "narrow an unsigned integer to a narrower one with the same value if possible"
                 .to_owned(),
-            vec![TypeParam::max_usize(), TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
             inarrow_sig,
         )
         .unwrap();
@@ -160,7 +159,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "inarrow_s".into(),
             "narrow a signed integer to a narrower one with the same value if possible".to_owned(),
-            vec![TypeParam::max_usize(), TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
             inarrow_sig,
         )
         .unwrap();
@@ -184,7 +183,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "ieq".into(),
             "equality test".to_owned(),
-            vec![TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM],
             icmp_sig,
         )
         .unwrap();
@@ -192,7 +191,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "ine".into(),
             "inequality test".to_owned(),
-            vec![TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM],
             icmp_sig,
         )
         .unwrap();
@@ -200,7 +199,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "ilt_u".into(),
             "\"less than\" as unsigned integers".to_owned(),
-            vec![TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM],
             icmp_sig,
         )
         .unwrap();
@@ -208,7 +207,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "ilt_s".into(),
             "\"less than\" as signed integers".to_owned(),
-            vec![TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM],
             icmp_sig,
         )
         .unwrap();
@@ -216,7 +215,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "igt_u".into(),
             "\"greater than\" as unsigned integers".to_owned(),
-            vec![TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM],
             icmp_sig,
         )
         .unwrap();
@@ -224,7 +223,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "igt_s".into(),
             "\"greater than\" as signed integers".to_owned(),
-            vec![TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM],
             icmp_sig,
         )
         .unwrap();
@@ -232,7 +231,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "ile_u".into(),
             "\"less than or equal\" as unsigned integers".to_owned(),
-            vec![TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM],
             icmp_sig,
         )
         .unwrap();
@@ -240,7 +239,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "ile_s".into(),
             "\"less than or equal\" as signed integers".to_owned(),
-            vec![TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM],
             icmp_sig,
         )
         .unwrap();
@@ -248,7 +247,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "ige_u".into(),
             "\"greater than or equal\" as unsigned integers".to_owned(),
-            vec![TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM],
             icmp_sig,
         )
         .unwrap();
@@ -256,7 +255,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "ige_s".into(),
             "\"greater than or equal\" as signed integers".to_owned(),
-            vec![TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM],
             icmp_sig,
         )
         .unwrap();
@@ -264,7 +263,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "imax_u".into(),
             "maximum of unsigned integers".to_owned(),
-            vec![TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM],
             ibinop_sig,
         )
         .unwrap();
@@ -272,7 +271,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "imax_s".into(),
             "maximum of signed integers".to_owned(),
-            vec![TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM],
             ibinop_sig,
         )
         .unwrap();
@@ -280,7 +279,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "imin_u".into(),
             "minimum of unsigned integers".to_owned(),
-            vec![TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM],
             ibinop_sig,
         )
         .unwrap();
@@ -288,7 +287,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "imin_s".into(),
             "minimum of signed integers".to_owned(),
-            vec![TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM],
             ibinop_sig,
         )
         .unwrap();
@@ -296,7 +295,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "iadd".into(),
             "addition modulo 2^N (signed and unsigned versions are the same op)".to_owned(),
-            vec![TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM],
             ibinop_sig,
         )
         .unwrap();
@@ -304,7 +303,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "isub".into(),
             "subtraction modulo 2^N (signed and unsigned versions are the same op)".to_owned(),
-            vec![TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM],
             ibinop_sig,
         )
         .unwrap();
@@ -312,7 +311,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "ineg".into(),
             "negation modulo 2^N (signed and unsigned versions are the same op)".to_owned(),
-            vec![TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM],
             iunop_sig,
         )
         .unwrap();
@@ -320,7 +319,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "imul".into(),
             "multiplication modulo 2^N (signed and unsigned versions are the same op)".to_owned(),
-            vec![TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM],
             ibinop_sig,
         )
         .unwrap();
@@ -330,7 +329,7 @@ pub fn extension() -> Extension {
             "given unsigned integers 0 <= n < 2^N, 0 <= m < 2^M, generates unsigned q, r where \
             q*m+r=n, 0<=r<m (m=0 is an error)"
                 .to_owned(),
-            vec![TypeParam::max_usize(), TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
             idivmod_sig,
         )
         .unwrap();
@@ -340,7 +339,7 @@ pub fn extension() -> Extension {
             "given signed integer -2^{N-1} <= n < 2^{N-1} and unsigned 0 <= m < 2^M, generates \
             signed q and unsigned r where q*m+r=n, 0<=r<m (m=0 is an error)"
                 .to_owned(),
-            vec![TypeParam::max_usize(), TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
             idivmod_sig,
         )
         .unwrap();
@@ -348,7 +347,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "idiv_u".into(),
             "as idivmod_u but discarding the second output".to_owned(),
-            vec![TypeParam::max_usize(), TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
             idiv_sig,
         )
         .unwrap();
@@ -356,7 +355,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "imod_u".into(),
             "as idivmod_u but discarding the first output".to_owned(),
-            vec![TypeParam::max_usize(), TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
             idiv_sig,
         )
         .unwrap();
@@ -364,7 +363,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "idiv_s".into(),
             "as idivmod_s but discarding the second output".to_owned(),
-            vec![TypeParam::max_usize(), TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
             imod_sig,
         )
         .unwrap();
@@ -372,7 +371,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "imod_s".into(),
             "as idivmod_s but discarding the first output".to_owned(),
-            vec![TypeParam::max_usize(), TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
             imod_sig,
         )
         .unwrap();
@@ -380,7 +379,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "iabs".into(),
             "convert signed to unsigned by taking absolute value".to_owned(),
-            vec![TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM],
             iunop_sig,
         )
         .unwrap();
@@ -388,7 +387,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "iand".into(),
             "bitwise AND".to_owned(),
-            vec![TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM],
             ibinop_sig,
         )
         .unwrap();
@@ -396,7 +395,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "ior".into(),
             "bitwise OR".to_owned(),
-            vec![TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM],
             ibinop_sig,
         )
         .unwrap();
@@ -404,7 +403,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "ixor".into(),
             "bitwise XOR".to_owned(),
-            vec![TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM],
             ibinop_sig,
         )
         .unwrap();
@@ -412,7 +411,7 @@ pub fn extension() -> Extension {
         .add_op_custom_sig_simple(
             "inot".into(),
             "bitwise NOT".to_owned(),
-            vec![TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM],
             iunop_sig,
         )
         .unwrap();
@@ -422,7 +421,7 @@ pub fn extension() -> Extension {
             "shift first input left by k bits where k is unsigned interpretation of second input \
             (leftmost bits dropped, rightmost bits set to zero"
                 .to_owned(),
-            vec![TypeParam::max_usize(), TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
             ish_sig,
         )
         .unwrap();
@@ -432,7 +431,7 @@ pub fn extension() -> Extension {
             "shift first input right by k bits where k is unsigned interpretation of second input \
             (rightmost bits dropped, leftmost bits set to zero)"
                 .to_owned(),
-            vec![TypeParam::max_usize(), TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
             ish_sig,
         )
         .unwrap();
@@ -442,7 +441,7 @@ pub fn extension() -> Extension {
             "rotate first input left by k bits where k is unsigned interpretation of second input \
             (leftmost bits replace rightmost bits)"
                 .to_owned(),
-            vec![TypeParam::max_usize(), TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
             ish_sig,
         )
         .unwrap();
@@ -452,7 +451,7 @@ pub fn extension() -> Extension {
             "rotate first input right by k bits where k is unsigned interpretation of second input \
             (rightmost bits replace leftmost bits)"
                 .to_owned(),
-            vec![TypeParam::max_usize(), TypeParam::max_usize()],
+            vec![LOG_WIDTH_TYPE_PARAM, LOG_WIDTH_TYPE_PARAM],
             ish_sig,
         )
         .unwrap();

--- a/src/std_extensions/arithmetic/int_ops.rs
+++ b/src/std_extensions/arithmetic/int_ops.rs
@@ -46,7 +46,7 @@ fn inarrow_sig(arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet
 
 fn itob_sig(_arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     Ok((
-        vec![int_type(type_arg(1))].into(),
+        vec![int_type(type_arg(0))].into(),
         type_row![BOOL_T],
         ExtensionSet::default(),
     ))
@@ -55,7 +55,7 @@ fn itob_sig(_arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet),
 fn btoi_sig(_arg_values: &[TypeArg]) -> Result<(TypeRow, TypeRow, ExtensionSet), SignatureError> {
     Ok((
         type_row![BOOL_T],
-        vec![int_type(type_arg(1))].into(),
+        vec![int_type(type_arg(0))].into(),
         ExtensionSet::default(),
     ))
 }

--- a/src/std_extensions/arithmetic/int_types.rs
+++ b/src/std_extensions/arithmetic/int_types.rs
@@ -1,5 +1,7 @@
 //! Basic integer types
 
+use std::num::NonZeroU64;
+
 use smol_str::SmolStr;
 
 use crate::{
@@ -43,8 +45,11 @@ const fn is_valid_log_width(n: u8) -> bool {
 
 /// The largest allowed log width.
 pub const MAX_LOG_WIDTH: u8 = 7;
+
 /// Type parameter for the log width of the integer.
-pub const LOG_WIDTH_TYPE_PARAM: TypeParam = TypeParam::BoundedUSize(MAX_LOG_WIDTH as u64);
+// unsafe block should be ok as the value is definitely not zero.
+pub const LOG_WIDTH_TYPE_PARAM: TypeParam =
+    TypeParam::bounded_usize(unsafe { NonZeroU64::new_unchecked(MAX_LOG_WIDTH as u64 + 1) });
 
 /// Get the log width  of the specified type argument or error if the argument
 /// is invalid.

--- a/src/std_extensions/arithmetic/int_types.rs
+++ b/src/std_extensions/arithmetic/int_types.rs
@@ -47,7 +47,7 @@ pub const MAX_LOG_WIDTH: u8 = 7;
 pub const LOG_WIDTH_TYPE_PARAM: TypeParam = TypeParam::BoundedUSize(MAX_LOG_WIDTH as u64);
 
 /// Get the log width  of the specified type argument or error if the argument
-/// is invalid..
+/// is invalid.
 pub(super) fn get_log_width(arg: &TypeArg) -> Result<u8, TypeArgError> {
     match arg {
         TypeArg::BoundedUSize(n) if is_valid_log_width(*n as u8) => Ok(*n as u8),

--- a/src/std_extensions/arithmetic/int_types.rs
+++ b/src/std_extensions/arithmetic/int_types.rs
@@ -29,15 +29,15 @@ pub fn int_type(width_arg: TypeArg) -> Type {
 }
 
 const fn is_valid_log_width(n: u8) -> bool {
-    n <= POWERS_OF_TWO
+    n <= MAX_LOG_WIDTH
 }
 
-const POWERS_OF_TWO: u8 = 7;
+const MAX_LOG_WIDTH: u8 = 7;
 /// Type parameter for the log width of the integer.
-pub const LOG_WIDTH_TYPE_PARAM: TypeParam = TypeParam::BoundedUSize(POWERS_OF_TWO as u64);
+pub const LOG_WIDTH_TYPE_PARAM: TypeParam = TypeParam::BoundedUSize(MAX_LOG_WIDTH as u64);
 
 /// Get the bit width of the specified integer type, or error if the width is not supported.
-pub(super) fn get_width_power(arg: &TypeArg) -> Result<u8, TypeArgError> {
+pub(super) fn get_log_width(arg: &TypeArg) -> Result<u8, TypeArgError> {
     match arg {
         TypeArg::BoundedUSize(n) if is_valid_log_width(*n as u8) => Ok(*n as u8),
         _ => Err(TypeArgError::TypeMismatch {
@@ -175,13 +175,13 @@ mod test {
     #[test]
     fn test_int_widths() {
         let type_arg_32 = TypeArg::BoundedUSize(5);
-        assert_matches!(get_width_power(&type_arg_32), Ok(5));
+        assert_matches!(get_log_width(&type_arg_32), Ok(5));
 
         let type_arg_128 = TypeArg::BoundedUSize(7);
-        assert_matches!(get_width_power(&type_arg_128), Ok(7));
+        assert_matches!(get_log_width(&type_arg_128), Ok(7));
         let type_arg_256 = TypeArg::BoundedUSize(8);
         assert_matches!(
-            get_width_power(&type_arg_256),
+            get_log_width(&type_arg_256),
             Err(TypeArgError::TypeMismatch { .. })
         );
     }

--- a/src/std_extensions/arithmetic/int_types.rs
+++ b/src/std_extensions/arithmetic/int_types.rs
@@ -33,7 +33,7 @@ pub(super) fn int_type(width_arg: TypeArg) -> Type {
 lazy_static! {
     /// Array of valid integer types, indexed by log width of the integer.
     pub static ref INT_TYPES: [Type; (MAX_LOG_WIDTH + 1) as usize] = (0..MAX_LOG_WIDTH + 1)
-        .map(|i| int_type(TypeArg::BoundedUSize(i as u64)))
+        .map(|i| int_type(TypeArg::BoundedNat(i as u64)))
         .collect::<Vec<_>>()
         .try_into()
         .unwrap();
@@ -47,15 +47,15 @@ const fn is_valid_log_width(n: u8) -> bool {
 pub const MAX_LOG_WIDTH: u8 = 7;
 
 /// Type parameter for the log width of the integer.
-// unsafe block should be ok as the value is definitely not zero.
+// SAFETY: unsafe block should be ok as the value is definitely not zero.
 pub const LOG_WIDTH_TYPE_PARAM: TypeParam =
-    TypeParam::bounded_usize(unsafe { NonZeroU64::new_unchecked(MAX_LOG_WIDTH as u64 + 1) });
+    TypeParam::bounded_nat(unsafe { NonZeroU64::new_unchecked(MAX_LOG_WIDTH as u64 + 1) });
 
 /// Get the log width  of the specified type argument or error if the argument
 /// is invalid.
 pub(super) fn get_log_width(arg: &TypeArg) -> Result<u8, TypeArgError> {
     match arg {
-        TypeArg::BoundedUSize(n) if is_valid_log_width(*n as u8) => Ok(*n as u8),
+        TypeArg::BoundedNat(n) if is_valid_log_width(*n as u8) => Ok(*n as u8),
         _ => Err(TypeArgError::TypeMismatch {
             arg: arg.clone(),
             param: LOG_WIDTH_TYPE_PARAM,
@@ -64,7 +64,7 @@ pub(super) fn get_log_width(arg: &TypeArg) -> Result<u8, TypeArgError> {
 }
 
 pub(super) const fn type_arg(log_width: u8) -> TypeArg {
-    TypeArg::BoundedUSize(log_width as u64)
+    TypeArg::BoundedNat(log_width as u64)
 }
 /// An unsigned integer
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -190,12 +190,12 @@ mod test {
 
     #[test]
     fn test_int_widths() {
-        let type_arg_32 = TypeArg::BoundedUSize(5);
+        let type_arg_32 = TypeArg::BoundedNat(5);
         assert_matches!(get_log_width(&type_arg_32), Ok(5));
 
-        let type_arg_128 = TypeArg::BoundedUSize(7);
+        let type_arg_128 = TypeArg::BoundedNat(7);
         assert_matches!(get_log_width(&type_arg_128), Ok(7));
-        let type_arg_256 = TypeArg::BoundedUSize(8);
+        let type_arg_256 = TypeArg::BoundedNat(8);
         assert_matches!(
             get_log_width(&type_arg_256),
             Err(TypeArgError::TypeMismatch { .. })

--- a/src/std_extensions/arithmetic/int_types.rs
+++ b/src/std_extensions/arithmetic/int_types.rs
@@ -29,10 +29,10 @@ pub fn int_type(width_arg: TypeArg) -> Type {
 }
 
 const fn is_valid_log_width(n: u8) -> bool {
-    n < POWERS_OF_TWO
+    n <= POWERS_OF_TWO
 }
 
-const POWERS_OF_TWO: u8 = 8;
+const POWERS_OF_TWO: u8 = 7;
 /// Type parameter for the log width of the integer.
 pub const LOG_WIDTH_TYPE_PARAM: TypeParam = TypeParam::BoundedUSize(POWERS_OF_TWO as u64);
 

--- a/src/std_extensions/arithmetic/mod.rs
+++ b/src/std_extensions/arithmetic/mod.rs
@@ -20,7 +20,7 @@ mod test {
         for i in 0..MAX_LOG_WIDTH + 1 {
             assert_eq!(
                 INT_TYPES[i as usize],
-                int_type(TypeArg::BoundedUSize(i as u64))
+                int_type(TypeArg::BoundedNat(i as u64))
             )
         }
     }

--- a/src/std_extensions/arithmetic/mod.rs
+++ b/src/std_extensions/arithmetic/mod.rs
@@ -5,3 +5,23 @@ pub mod float_ops;
 pub mod float_types;
 pub mod int_ops;
 pub mod int_types;
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        std_extensions::arithmetic::int_types::{int_type, INT_TYPES},
+        types::type_param::TypeArg,
+    };
+
+    use super::int_types::MAX_LOG_WIDTH;
+
+    #[test]
+    fn test_int_types() {
+        for i in 0..MAX_LOG_WIDTH + 1 {
+            assert_eq!(
+                INT_TYPES[i as usize],
+                int_type(TypeArg::BoundedUSize(i as u64))
+            )
+        }
+    }
+}

--- a/src/std_extensions/collections.rs
+++ b/src/std_extensions/collections.rs
@@ -160,7 +160,7 @@ mod test {
             .unwrap();
 
         assert!(list_def
-            .instantiate_concrete([TypeArg::BoundedUSize(3)])
+            .instantiate_concrete([TypeArg::BoundedNat(3)])
             .is_err());
 
         list_def.check_custom(&list_type).unwrap();

--- a/src/std_extensions/collections.rs
+++ b/src/std_extensions/collections.rs
@@ -159,7 +159,9 @@ mod test {
             .instantiate_concrete([TypeArg::Type(USIZE_T)])
             .unwrap();
 
-        assert!(list_def.instantiate_concrete([TypeArg::USize(3)]).is_err());
+        assert!(list_def
+            .instantiate_concrete([TypeArg::BoundedUSize(3)])
+            .is_err());
 
         list_def.check_custom(&list_type).unwrap();
         let list_value = ListValue(vec![ConstUsize::new(3).into()]);

--- a/src/std_extensions/logic.rs
+++ b/src/std_extensions/logic.rs
@@ -27,7 +27,7 @@ pub const EXTENSION_ID: SmolStr = SmolStr::new_inline("logic");
 
 /// Extension for basic logical operations.
 fn extension() -> Extension {
-    const H_INT: TypeParam = TypeParam::max_usize();
+    const H_INT: TypeParam = TypeParam::max_nat();
     let mut extension = Extension::new(EXTENSION_ID);
 
     extension
@@ -53,7 +53,7 @@ fn extension() -> Extension {
             |arg_values: &[TypeArg]| {
                 let a = arg_values.iter().exactly_one().unwrap();
                 let n: u64 = match a {
-                    TypeArg::BoundedUSize(n) => *n,
+                    TypeArg::BoundedNat(n) => *n,
                     _ => {
                         return Err(TypeArgError::TypeMismatch {
                             arg: a.clone(),
@@ -79,7 +79,7 @@ fn extension() -> Extension {
             |arg_values: &[TypeArg]| {
                 let a = arg_values.iter().exactly_one().unwrap();
                 let n: u64 = match a {
-                    TypeArg::BoundedUSize(n) => *n,
+                    TypeArg::BoundedNat(n) => *n,
                     _ => {
                         return Err(TypeArgError::TypeMismatch {
                             arg: a.clone(),
@@ -139,7 +139,7 @@ pub(crate) mod test {
     /// Generate a logic extension and operation over [`crate::prelude::BOOL_T`]
     pub(crate) fn and_op() -> LeafOp {
         EXTENSION
-            .instantiate_extension_op(AND_NAME, [TypeArg::BoundedUSize(2)])
+            .instantiate_extension_op(AND_NAME, [TypeArg::BoundedNat(2)])
             .unwrap()
             .into()
     }

--- a/src/std_extensions/logic.rs
+++ b/src/std_extensions/logic.rs
@@ -27,7 +27,7 @@ pub const EXTENSION_ID: SmolStr = SmolStr::new_inline("logic");
 
 /// Extension for basic logical operations.
 fn extension() -> Extension {
-    const H_INT: TypeParam = TypeParam::USize;
+    const H_INT: TypeParam = TypeParam::max_usize();
     let mut extension = Extension::new(EXTENSION_ID);
 
     extension
@@ -53,7 +53,7 @@ fn extension() -> Extension {
             |arg_values: &[TypeArg]| {
                 let a = arg_values.iter().exactly_one().unwrap();
                 let n: u64 = match a {
-                    TypeArg::USize(n) => *n,
+                    TypeArg::BoundedUSize(n) => *n,
                     _ => {
                         return Err(TypeArgError::TypeMismatch {
                             arg: a.clone(),
@@ -79,7 +79,7 @@ fn extension() -> Extension {
             |arg_values: &[TypeArg]| {
                 let a = arg_values.iter().exactly_one().unwrap();
                 let n: u64 = match a {
-                    TypeArg::USize(n) => *n,
+                    TypeArg::BoundedUSize(n) => *n,
                     _ => {
                         return Err(TypeArgError::TypeMismatch {
                             arg: a.clone(),
@@ -139,7 +139,7 @@ pub(crate) mod test {
     /// Generate a logic extension and operation over [`crate::prelude::BOOL_T`]
     pub(crate) fn and_op() -> LeafOp {
         EXTENSION
-            .instantiate_extension_op(AND_NAME, [TypeArg::USize(2)])
+            .instantiate_extension_op(AND_NAME, [TypeArg::BoundedUSize(2)])
             .unwrap()
             .into()
     }

--- a/src/types/type_param.rs
+++ b/src/types/type_param.rs
@@ -21,6 +21,9 @@ pub enum TypeParam {
     Type(TypeBound),
     /// Argument is a [TypeArg::USize].
     USize,
+    /// Argument is a [TypeArg::SimplePredicate] which is bounded by the size
+    /// specified here.
+    SimplePredicate(usize),
     /// Argument is a [TypeArg::Opaque], defined by a [CustomType].
     Opaque(CustomType),
     /// Argument is a [TypeArg::Sequence]. A list of indeterminate size containing parameters.
@@ -41,6 +44,9 @@ pub enum TypeArg {
     Type(Type),
     /// Instance of [TypeParam::USize]. 64-bit unsigned integer.
     USize(u64),
+    /// Instance of [TypeParam::SimplePredicate]. A Sum over unit types with
+    /// specified tag.
+    SimplePredicate(usize),
     ///Instance of [TypeParam::Opaque] An opaque value, stored as serialized blob.
     Opaque(CustomTypeArg),
     /// Instance of [TypeParam::List] or [TypeParam::Tuple], defined by a
@@ -99,6 +105,7 @@ pub fn check_type_arg(arg: &TypeArg, param: &TypeParam) -> Result<(), TypeArgErr
             Ok(())
         }
         (TypeArg::Extensions(_), TypeParam::Extensions) => Ok(()),
+        (TypeArg::SimplePredicate(tag), TypeParam::SimplePredicate(size)) if tag < size => Ok(()),
         _ => Err(TypeArgError::TypeMismatch {
             arg: arg.clone(),
             param: param.clone(),

--- a/src/types/type_param.rs
+++ b/src/types/type_param.rs
@@ -4,6 +4,8 @@
 //!
 //! [`TypeDef`]: crate::extension::TypeDef
 
+use std::num::NonZeroU64;
+
 use thiserror::Error;
 
 use crate::extension::ExtensionSet;
@@ -12,6 +14,20 @@ use super::CustomType;
 use super::Type;
 use super::TypeBound;
 
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+/// The upper non-inclusive bound of a [`TypeParam::BoundedUsize`]
+// A None inner value implies the maximum bound: u64::MAX + 1 (all u64 values valid)
+pub struct UpperBound(Option<NonZeroU64>);
+impl UpperBound {
+    fn valid_value(&self, val: u64) -> bool {
+        match (val, self.0) {
+            (0, _) | (_, None) => true,
+            (val, Some(inner)) if NonZeroU64::new(val).unwrap() < inner => true,
+            _ => false,
+        }
+    }
+}
+
 /// A parameter declared by an OpDef. Specifies a value
 /// that must be provided by each operation node.
 #[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
@@ -19,8 +35,8 @@ use super::TypeBound;
 pub enum TypeParam {
     /// Argument is a [TypeArg::Type].
     Type(TypeBound),
-    /// Argument is a [TypeArg::BoundedUSize] that is at most the stated maximum.
-    BoundedUSize(u64),
+    /// Argument is a [TypeArg::BoundedUSize] that is less than the upper bound.
+    BoundedUSize(UpperBound),
     /// Argument is a [TypeArg::Opaque], defined by a [CustomType].
     Opaque(CustomType),
     /// Argument is a [TypeArg::Sequence]. A list of indeterminate size containing parameters.
@@ -34,9 +50,14 @@ pub enum TypeParam {
 }
 
 impl TypeParam {
-    /// [`TypeParam::BoundedUSize`] with the maximum bound (`u64::MAX`)
+    /// [`TypeParam::BoundedUSize`] with the maximum bound (`u64::MAX` + 1)
     pub const fn max_usize() -> Self {
-        Self::BoundedUSize(u64::MAX)
+        Self::BoundedUSize(UpperBound(None))
+    }
+
+    /// [`TypeParam::BoundedUSize`] with the stated upper bound (non-exclusive)
+    pub const fn bounded_usize(upper_bound: NonZeroU64) -> Self {
+        Self::BoundedUSize(UpperBound(Some(upper_bound)))
     }
 }
 
@@ -99,7 +120,10 @@ pub fn check_type_arg(arg: &TypeArg, param: &TypeParam) -> Result<(), TypeArgErr
                     .try_for_each(|(arg, param)| check_type_arg(arg, param))
             }
         }
-        (TypeArg::BoundedUSize(val), TypeParam::BoundedUSize(max)) if val <= max => Ok(()),
+        (TypeArg::BoundedUSize(val), TypeParam::BoundedUSize(bound)) if bound.valid_value(*val) => {
+            Ok(())
+        }
+
         (TypeArg::Opaque(arg), TypeParam::Opaque(param))
             if param.bound() == TypeBound::Eq && &arg.typ == param =>
         {

--- a/src/types/type_param.rs
+++ b/src/types/type_param.rs
@@ -19,7 +19,7 @@ use super::TypeBound;
 pub enum TypeParam {
     /// Argument is a [TypeArg::Type].
     Type(TypeBound),
-    /// Argument is a [TypeArg::USize] that is less than the stated bound.
+    /// Argument is a [TypeArg::BoundedUSize] that is at most the stated maximum.
     BoundedUSize(u64),
     /// Argument is a [TypeArg::Opaque], defined by a [CustomType].
     Opaque(CustomType),
@@ -46,7 +46,7 @@ impl TypeParam {
 pub enum TypeArg {
     /// Where the (Type/Op)Def declares that an argument is a [TypeParam::Type]
     Type(Type),
-    /// Instance of [TypeParam::USize]. 64-bit unsigned integer.
+    /// Instance of [TypeParam::BoundedUSize]. 64-bit unsigned integer.
     BoundedUSize(u64),
     ///Instance of [TypeParam::Opaque] An opaque value, stored as serialized blob.
     Opaque(CustomTypeArg),
@@ -99,7 +99,7 @@ pub fn check_type_arg(arg: &TypeArg, param: &TypeParam) -> Result<(), TypeArgErr
                     .try_for_each(|(arg, param)| check_type_arg(arg, param))
             }
         }
-        (TypeArg::BoundedUSize(val), TypeParam::BoundedUSize(bound)) if val < bound => Ok(()),
+        (TypeArg::BoundedUSize(val), TypeParam::BoundedUSize(max)) if val <= max => Ok(()),
         (TypeArg::Opaque(arg), TypeParam::Opaque(param))
             if param.bound() == TypeBound::Eq && &arg.typ == param =>
         {

--- a/src/types/type_param.rs
+++ b/src/types/type_param.rs
@@ -15,7 +15,7 @@ use super::Type;
 use super::TypeBound;
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-/// The upper non-inclusive bound of a [`TypeParam::BoundedUsize`]
+/// The upper non-inclusive bound of a [`TypeParam::BoundedNat`]
 // A None inner value implies the maximum bound: u64::MAX + 1 (all u64 values valid)
 pub struct UpperBound(Option<NonZeroU64>);
 impl UpperBound {
@@ -35,8 +35,8 @@ impl UpperBound {
 pub enum TypeParam {
     /// Argument is a [TypeArg::Type].
     Type(TypeBound),
-    /// Argument is a [TypeArg::BoundedUSize] that is less than the upper bound.
-    BoundedUSize(UpperBound),
+    /// Argument is a [TypeArg::BoundedNat] that is less than the upper bound.
+    BoundedNat(UpperBound),
     /// Argument is a [TypeArg::Opaque], defined by a [CustomType].
     Opaque(CustomType),
     /// Argument is a [TypeArg::Sequence]. A list of indeterminate size containing parameters.
@@ -50,14 +50,14 @@ pub enum TypeParam {
 }
 
 impl TypeParam {
-    /// [`TypeParam::BoundedUSize`] with the maximum bound (`u64::MAX` + 1)
-    pub const fn max_usize() -> Self {
-        Self::BoundedUSize(UpperBound(None))
+    /// [`TypeParam::BoundedNat`] with the maximum bound (`u64::MAX` + 1)
+    pub const fn max_nat() -> Self {
+        Self::BoundedNat(UpperBound(None))
     }
 
-    /// [`TypeParam::BoundedUSize`] with the stated upper bound (non-exclusive)
-    pub const fn bounded_usize(upper_bound: NonZeroU64) -> Self {
-        Self::BoundedUSize(UpperBound(Some(upper_bound)))
+    /// [`TypeParam::BoundedNat`] with the stated upper bound (non-exclusive)
+    pub const fn bounded_nat(upper_bound: NonZeroU64) -> Self {
+        Self::BoundedNat(UpperBound(Some(upper_bound)))
     }
 }
 
@@ -67,8 +67,8 @@ impl TypeParam {
 pub enum TypeArg {
     /// Where the (Type/Op)Def declares that an argument is a [TypeParam::Type]
     Type(Type),
-    /// Instance of [TypeParam::BoundedUSize]. 64-bit unsigned integer.
-    BoundedUSize(u64),
+    /// Instance of [TypeParam::BoundedNat]. 64-bit unsigned integer.
+    BoundedNat(u64),
     ///Instance of [TypeParam::Opaque] An opaque value, stored as serialized blob.
     Opaque(CustomTypeArg),
     /// Instance of [TypeParam::List] or [TypeParam::Tuple], defined by a
@@ -120,7 +120,7 @@ pub fn check_type_arg(arg: &TypeArg, param: &TypeParam) -> Result<(), TypeArgErr
                     .try_for_each(|(arg, param)| check_type_arg(arg, param))
             }
         }
-        (TypeArg::BoundedUSize(val), TypeParam::BoundedUSize(bound)) if bound.valid_value(*val) => {
+        (TypeArg::BoundedNat(val), TypeParam::BoundedNat(bound)) if bound.valid_value(*val) => {
             Ok(())
         }
 


### PR DESCRIPTION
Closes #437 

BREAKING CHANGE: `USize` type param and type arg changed to `BoundedNat` with optional maximum. For previous behaviour use `TypeParam::max_nat()`