### PR TITLE
[WIP] Substitution into type schemes to produce FunctionTypes

### DIFF
--- a/src/extension.rs
+++ b/src/extension.rs
@@ -20,7 +20,7 @@ use crate::types::CustomType;
 mod op_def;
 pub use op_def::{CustomSignatureFunc, OpDef};
 mod type_def;
-mod type_template;
+pub mod type_template;
 pub use type_def::{TypeDef, TypeDefBound};
 pub mod prelude;
 pub mod validate;

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -20,6 +20,7 @@ use crate::types::CustomType;
 mod op_def;
 pub use op_def::{CustomSignatureFunc, OpDef};
 mod type_def;
+mod type_template;
 pub use type_def::{TypeDef, TypeDefBound};
 pub mod prelude;
 pub mod validate;

--- a/src/extension/type_def.rs
+++ b/src/extension/type_def.rs
@@ -45,7 +45,7 @@ pub struct TypeDef {
     /// Human readable description of the type definition.
     description: String,
     /// The definition of the type bound of this definition.
-    bound: TypeDefBound,
+    pub(super) bound: TypeDefBound,
 }
 
 impl TypeDef {

--- a/src/extension/type_template.rs
+++ b/src/extension/type_template.rs
@@ -1,0 +1,220 @@
+use std::collections::HashMap;
+
+use smol_str::SmolStr;
+
+use super::{ExtensionId, ExtensionSet, TypeParametrised};
+use crate::{ops::AliasDecl, Extension};
+
+use crate::types::{
+    type_param::{CustomTypeArg, TypeArg, TypeParam},
+    CustomType, FunctionType, Type, TypeRow,
+};
+
+/// deBruijn-indexed Variables
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+struct VariableRef(usize);
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+enum ExtensionSetTemplate {
+    Concrete(ExtensionSet),
+    TypeVar(VariableRef),
+}
+
+/// TypeEnum with Prim inlined (as we need our own version of FunctionType)
+/// and including variables
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+enum TypeTemplate {
+    Extension(CustomTypeTemplate),
+    Alias(AliasDecl),
+    Function(Vec<TypeTemplate>, Vec<TypeTemplate>, ExtensionSetTemplate),
+    Tuple(Vec<TypeTemplate>),
+    Sum(Vec<TypeTemplate>),
+    TypeVar(VariableRef),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+struct CustomTypeTemplate {
+    extension: ExtensionId,
+    id: SmolStr,
+    args: Vec<TypeArgTemplate>,
+    // Should this be min_bound? It might be narrower after substitution
+    //bound: TypeBound,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[non_exhaustive]
+enum TypeArgTemplate {
+    Type(TypeTemplate),
+    USize(u64),
+    Opaque(CustomTypeArg),
+    Sequence(Vec<TypeArgTemplate>),
+    Extensions(ExtensionSet),
+    TypeVar(VariableRef),
+}
+
+impl TypeTemplate {
+    fn substitute(&self, exts: &HashMap<SmolStr, Extension>, vars: &Vec<TypeArg>) -> Type {
+        match self {
+            TypeTemplate::Extension(ctt) => Type::new_extension(ctt.substitute(exts, vars)),
+            TypeTemplate::Alias(decl) => Type::new_alias(decl.clone()),
+            TypeTemplate::Function(ins, outs, es) => Type::new_function(FunctionType {
+                input: TypeRow::from(
+                    ins.iter()
+                        .map(|tt| tt.substitute(exts, vars))
+                        .collect::<Vec<_>>(),
+                ),
+                output: TypeRow::from(
+                    outs.iter()
+                        .map(|tt| tt.substitute(exts, vars))
+                        .collect::<Vec<_>>(),
+                ),
+                extension_reqs: match es {
+                    ExtensionSetTemplate::Concrete(c) => c.clone(),
+                    ExtensionSetTemplate::TypeVar(VariableRef(i)) => {
+                        let TypeArg::Extensions(e) = vars.get(*i).unwrap()
+                            else {panic!("Variable was not Extension");};
+                        e.clone()
+                    }
+                },
+            }),
+            TypeTemplate::Tuple(elems) => Type::new_tuple(
+                elems
+                    .iter()
+                    .map(|tt| tt.substitute(exts, vars))
+                    .collect::<Vec<_>>(),
+            ),
+            TypeTemplate::Sum(elems) => Type::new_sum(
+                elems
+                    .iter()
+                    .map(|tt| tt.substitute(exts, vars))
+                    .collect::<Vec<_>>(),
+            ),
+            TypeTemplate::TypeVar(VariableRef(i)) => {
+                let TypeArg::Type(t) = vars.get(*i).unwrap()
+                else {panic!("Variable was not Type");};
+                t.clone()
+            }
+        }
+    }
+
+    fn validate(
+        &self,
+        exts: &HashMap<SmolStr, Extension>,
+        binders: &Vec<TypeParam>,
+    ) -> Result<(), ()> {
+        match self {
+            TypeTemplate::Extension(ctt) => ctt.validate(exts, binders),
+            TypeTemplate::Alias(_) => Ok(()),
+            TypeTemplate::Function(ins, outs, es) => {
+                ins.iter().try_for_each(|tt| tt.validate(exts, binders))?;
+                outs.iter().try_for_each(|tt| tt.validate(exts, binders))?;
+                if let ExtensionSetTemplate::TypeVar(VariableRef(i)) = es {
+                    if binders.get(*i) == Some(&TypeParam::Extensions) {
+                        return Ok(());
+                    }
+                }
+                Err(())
+            }
+            TypeTemplate::Tuple(elems) => {
+                elems.iter().try_for_each(|tt| tt.validate(exts, binders))
+            }
+            TypeTemplate::Sum(elems) => elems.iter().try_for_each(|tt| tt.validate(exts, binders)),
+            TypeTemplate::TypeVar(VariableRef(i)) => {
+                if let Some(TypeParam::Type(_)) = binders.get(*i) {
+                    Ok(())
+                } else {
+                    Err(())
+                }
+            }
+        }
+    }
+}
+
+impl CustomTypeTemplate {
+    fn substitute(&self, exts: &HashMap<SmolStr, Extension>, vars: &Vec<TypeArg>) -> CustomType {
+        let typdef = exts
+            .get(&self.extension)
+            .unwrap()
+            .get_type(self.id.as_str())
+            .unwrap();
+
+        typdef
+            .instantiate_concrete(
+                self.args
+                    .iter()
+                    .map(|tat| tat.substitute(exts, vars))
+                    .collect::<Vec<_>>(),
+            )
+            .unwrap()
+    }
+
+    fn validate(
+        &self,
+        exts: &HashMap<SmolStr, Extension>,
+        binders: &Vec<TypeParam>,
+    ) -> Result<(), ()> {
+        let params = exts
+            .get(&self.extension)
+            .ok_or(())?
+            .get_type(self.id.as_str())
+            .ok_or(())?
+            .params();
+        if params.len() == binders.len() && binders.iter().zip(params).all(check_type_param_fits) {
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+}
+
+fn check_type_param_fits(tps: (&TypeParam, &TypeParam)) -> bool {
+    match tps {
+        (TypeParam::Type(hbound), TypeParam::Type(pbound)) => hbound.contains(*pbound),
+        (TypeParam::USize, TypeParam::USize) => true,
+        (TypeParam::Opaque(t1), TypeParam::Opaque(t2)) => t1 == t2,
+        (TypeParam::List(hs), TypeParam::List(ps)) => check_type_param_fits((hs, ps)),
+        (TypeParam::Tuple(hs), TypeParam::Tuple(ps)) => {
+            hs.len() == ps.len() && hs.iter().zip(ps).all(check_type_param_fits)
+        }
+        (TypeParam::Extensions, TypeParam::Extensions) => true,
+        _ => false,
+    }
+}
+
+impl TypeArgTemplate {
+    fn substitute(&self, exts: &HashMap<SmolStr, Extension>, vars: &Vec<TypeArg>) -> TypeArg {
+        match self {
+            TypeArgTemplate::Type(tt) => TypeArg::Type(tt.substitute(exts, vars)),
+            TypeArgTemplate::USize(i) => TypeArg::USize(*i),
+            TypeArgTemplate::Opaque(cust) => TypeArg::Opaque(cust.clone()),
+            TypeArgTemplate::Sequence(elems) => {
+                TypeArg::Sequence(elems.iter().map(|tat| tat.substitute(exts, vars)).collect())
+            }
+            TypeArgTemplate::Extensions(es) => TypeArg::Extensions(es.clone()),
+            TypeArgTemplate::TypeVar(VariableRef(i)) => vars.get(*i).unwrap().clone(),
+        }
+    }
+
+    fn validate(
+        &self,
+        exts: &HashMap<SmolStr, Extension>,
+        binders: &Vec<TypeParam>,
+    ) -> Result<(), ()> {
+        match self {
+            TypeArgTemplate::Type(tt) => tt.validate(exts, binders),
+            TypeArgTemplate::USize(_) => Ok(()),
+            TypeArgTemplate::Opaque(_) => Ok(()),
+            TypeArgTemplate::Sequence(elems) => {
+                elems.iter().try_for_each(|tat| tat.validate(exts, binders))
+            }
+            TypeArgTemplate::Extensions(_) => Ok(()),
+            TypeArgTemplate::TypeVar(VariableRef(i)) => {
+                if binders.get(*i).is_some() {
+                    Ok(())
+                } else {
+                    Err(())
+                }
+            }
+        }
+    }
+}

--- a/src/extension/type_template.rs
+++ b/src/extension/type_template.rs
@@ -278,7 +278,8 @@ impl TypeArgTemplate {
         }
     }
 
-    fn validate(
+    // TODO ensure we make all these checks in will_fit
+    /*fn validate(
         &self,
         exts: &HashMap<SmolStr, Extension>,
         binders: &Vec<TypeParam>,
@@ -299,5 +300,5 @@ impl TypeArgTemplate {
                 }
             }
         }
-    }
+    }*/
 }

--- a/src/extension/type_template.rs
+++ b/src/extension/type_template.rs
@@ -118,13 +118,10 @@ impl TypeTemplate {
             TypeTemplate::Sum(elems) => elems
                 .iter()
                 .try_for_each(|tt| tt.validate(exts, binders, bound))?,
-            TypeTemplate::TypeVar(VariableRef(i)) => {
-                match binders.get(*i) {
-                    Some(TypeParam::Type(decl_bound)) if bound.contains(*decl_bound) => (),
-                    _ => return Err(()),
-                }
-                return Err(());
-            }
+            TypeTemplate::TypeVar(VariableRef(i)) => match binders.get(*i) {
+                Some(TypeParam::Type(decl_bound)) if bound.contains(*decl_bound) => (),
+                _ => return Err(()),
+            },
         };
         Ok(())
     }

--- a/src/extension/type_template.rs
+++ b/src/extension/type_template.rs
@@ -112,10 +112,7 @@ impl TypeTemplate {
                 };
                 ftt.validate(exts, binders)?;
             }
-            TypeTemplate::Tuple(elems) => elems
-                .iter()
-                .try_for_each(|tt| tt.validate(exts, binders, bound))?,
-            TypeTemplate::Sum(elems) => elems
+            TypeTemplate::Tuple(elems) | TypeTemplate::Sum(elems) => elems
                 .iter()
                 .try_for_each(|tt| tt.validate(exts, binders, bound))?,
             TypeTemplate::TypeVar(VariableRef(i)) => match binders.get(*i) {

--- a/src/extension/type_template.rs
+++ b/src/extension/type_template.rs
@@ -317,8 +317,8 @@ impl TypeArgTemplate {
 impl SignatureTemplate {
     /// Validates the definition, i.e. that every set of arguments passing [SignatureTemplate::check_args]
     /// will produce a valid type in [SignatureTemplate::instantiate_concrete]
-    pub fn validate(&self, exts: &HashMap<SmolStr, Extension>) -> Result<(), ()> {
-        self.1.validate(exts, &self.0)
+    pub fn validate(&self, exts: &HashMap<SmolStr, Extension>) -> Result<(), &str> {
+        self.1.validate(exts, &self.0).map_err(|()| "invalid")
     }
 
     /// Check some [TypeArg]s are legal arguments.

--- a/src/extension/type_template.rs
+++ b/src/extension/type_template.rs
@@ -217,7 +217,7 @@ impl CustomTypeTemplate {
                         return Err(()) // Index says to compute CustomType bound from non-type parameter!
                     };
                     // so require the corresponding arg to meet the bound (intersect with existing bound on arg)
-                    if b.contains(bound) {
+                    if !bound.contains(b) {
                         params[*i] = TypeParam::Type(bound);
                     }
                 }

--- a/src/types/type_param.rs
+++ b/src/types/type_param.rs
@@ -56,7 +56,7 @@ pub enum TypeArg {
 pub struct CustomTypeArg {
     /// The type of the constant.
     /// (Exact matches only - the constant is exactly this type.)
-    typ: CustomType,
+    pub(crate) typ: CustomType,
     /// Serialized representation.
     pub value: serde_yaml::Value,
 }


### PR DESCRIPTION
No tests and I expect bugs (especially true/false inversions) but I hope this demonstrates what the code will look like. In particular if you `validate` the definition and `check_args` the args then substitution should be guaranteed to be ok.

Note the passing in of the `HashMap<SmolStr, Extension>` requested more widely in validation and needed here. Also note how this repeats bits of code from type checking, custom type bound computation, etc. etc. - if we integrated type variables properly into Hugr we would not need two copies of the code (one which deals with variables and one which does not), the version that knows about variables would be the only one we need.

[ ] Needs proper error reporting not just `Err(())` / "invalid"
[ ] tests!!
[ ] Possibly we can avoid duplicating struct/enum defs by representing type variables as opaque types (but unlikely to avoid duplicating code, these opaque types would have to be treated very differently to standard)
[ ] Also you can represent a type variable as a `TypeArgTemplate::TypeVar` or a `TypeArgTemplate::Type(TypeTemplate::TypeVar)`....reminiscent of the old `SimpleType::Classic(ClassicType::Container(...` situation. Here I think all representations just work, but they will be falsely declared as different (by PartialEq), I have an idea for a representation that avoids this
