### PR TITLE
feat: TKET2 compatibility requirements 

### DIFF
--- a/src/extension/prelude.rs
+++ b/src/extension/prelude.rs
@@ -60,8 +60,11 @@ pub(crate) const QB_CUSTOM_T: CustomType = CustomType::new_simple(
     TypeBound::Any,
 );
 
+/// Qubit type.
 pub const QB_T: Type = Type::new_extension(QB_CUSTOM_T);
+/// Unsigned size type.
 pub const USIZE_T: Type = Type::new_extension(USIZE_CUSTOM_T);
+/// Boolean type - Sum of two units.
 pub const BOOL_T: Type = Type::new_simple_predicate(2);
 
 /// Initialize a new array of type `typ` of length `size`

--- a/src/extension/prelude.rs
+++ b/src/extension/prelude.rs
@@ -60,9 +60,9 @@ pub(crate) const QB_CUSTOM_T: CustomType = CustomType::new_simple(
     TypeBound::Any,
 );
 
-pub(crate) const QB_T: Type = Type::new_extension(QB_CUSTOM_T);
-pub(crate) const USIZE_T: Type = Type::new_extension(USIZE_CUSTOM_T);
-pub(crate) const BOOL_T: Type = Type::new_simple_predicate(2);
+pub const QB_T: Type = Type::new_extension(QB_CUSTOM_T);
+pub const USIZE_T: Type = Type::new_extension(USIZE_CUSTOM_T);
+pub const BOOL_T: Type = Type::new_simple_predicate(2);
 
 /// Initialize a new array of type `typ` of length `size`
 pub fn new_array(typ: Type, size: u64) -> Type {

--- a/src/ops/custom.rs
+++ b/src/ops/custom.rs
@@ -118,6 +118,11 @@ impl ExtensionOp {
     pub fn args(&self) -> &[TypeArg] {
         &self.args
     }
+
+    /// Returns a reference to the [`OpDef`] of this [`ExtensionOp`].
+    pub fn def(&self) -> &OpDef {
+        self.def.as_ref()
+    }
 }
 
 impl From<ExtensionOp> for OpaqueOp {

--- a/src/std_extensions/arithmetic/float_types.rs
+++ b/src/std_extensions/arithmetic/float_types.rs
@@ -24,6 +24,14 @@ pub const FLOAT64_TYPE: Type = Type::new_extension(FLOAT64_CUSTOM_TYPE);
 /// A floating-point value.
 pub struct ConstF64(f64);
 
+impl std::ops::Deref for ConstF64 {
+    type Target = f64;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 impl ConstF64 {
     /// Create a new [`ConstF64`]
     pub fn new(value: f64) -> Self {

--- a/src/std_extensions/quantum.rs
+++ b/src/std_extensions/quantum.rs
@@ -4,6 +4,7 @@ use smol_str::SmolStr;
 
 use crate::extension::prelude::{BOOL_T, QB_T};
 use crate::extension::{ExtensionSet, SignatureError};
+use crate::std_extensions::arithmetic::float_types::FLOAT64_TYPE;
 use crate::type_row;
 use crate::types::type_param::TypeArg;
 use crate::types::TypeRow;
@@ -34,6 +35,20 @@ fn extension() -> Extension {
             "Hadamard".into(),
             vec![],
             one_qb_func,
+        )
+        .unwrap();
+    extension
+        .add_op_custom_sig_simple(
+            SmolStr::new_inline("RzF64"),
+            "Rotation specified by float".into(),
+            vec![],
+            |_: &[_]| {
+                Ok((
+                    type_row![QB_T, FLOAT64_TYPE],
+                    type_row![QB_T],
+                    ExtensionSet::new(),
+                ))
+            },
         )
         .unwrap();
 


### PR DESCRIPTION
* make prelude types pub
* getter for ExtensionOp::def
* Deref ConstF64 to float (should this be replicated for other CustomConst values?)
* Add rzf64 op to quantum resource. (This is likely to be a recurring problem though - perhaps the quantum resource should move to tket2 and become a test dependency here?)

