### PR TITLE
feat: Extension validation can take a closure of solutions

### DIFF
--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -97,7 +97,8 @@ impl DFGBuilder<Hugr> {
 
 impl HugrBuilder for DFGBuilder<Hugr> {
     fn finish_hugr(mut self) -> Result<Hugr, ValidationError> {
-        self.base.infer_extensions()?;
+        let closure = self.base.infer_extensions()?;
+        self.base.validate_with_extension_closure(closure)?;
         Ok(self.base)
     }
 }

--- a/src/extension/validate.rs
+++ b/src/extension/validate.rs
@@ -20,9 +20,12 @@ pub struct ExtensionValidator {
 impl ExtensionValidator {
     /// Initialise a new extension validator, pre-computing the extension
     /// requirements for each node in the Hugr.
-    pub fn new(hugr: &Hugr) -> Self {
+    ///
+    /// The `closure` argument is a set of extensions which doesn't actually
+    /// live on the graph, but is used to close the graph for validation
+    pub fn new(hugr: &Hugr, closure: HashMap<(Node, Direction), ExtensionSet>) -> Self {
         let mut validator = ExtensionValidator {
-            extensions: HashMap::new(),
+            extensions: closure,
         };
 
         for node in hugr.nodes() {

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -7,7 +7,7 @@ pub mod serialize;
 pub mod validate;
 pub mod views;
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::iter;
 
 pub(crate) use self::hugrmut::HugrInternalsMut;
@@ -194,10 +194,12 @@ impl Hugr {
     }
 
     /// Infer extension requirements
-    pub fn infer_extensions(&mut self) -> Result<(), InferExtensionError> {
-        let solution = infer_extensions(self)?;
+    pub fn infer_extensions(
+        &mut self,
+    ) -> Result<HashMap<(Node, Direction), ExtensionSet>, InferExtensionError> {
+        let (solution, extension_closure) = infer_extensions(self)?;
         self.instantiate_extensions(solution);
-        Ok(())
+        Ok(extension_closure)
     }
 
     /// TODO: Write this

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -38,7 +38,10 @@ struct ValidationContext<'a> {
 }
 
 impl Hugr {
-    /// Check the validity of the HUGR.
+    /// Check the validity of the HUGR, assuming that it has no open extension
+    /// variables.
+    /// TODO: Add a version of validation which allows for open extension
+    /// variables (see github issue #457)
     pub fn validate(&self) -> Result<(), ValidationError> {
         self.validate_with_extension_closure(HashMap::new())
     }

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -14,7 +14,7 @@ use pyo3::prelude::*;
 
 use crate::extension::{
     validate::{ExtensionError, ExtensionValidator},
-    InferExtensionError,
+    ExtensionSet, InferExtensionError,
 };
 use crate::ops::validate::{ChildrenEdgeData, ChildrenValidationError, EdgeValidationError};
 use crate::ops::{OpTag, OpTrait, OpType, ValidateOp};
@@ -40,18 +40,30 @@ struct ValidationContext<'a> {
 impl Hugr {
     /// Check the validity of the HUGR.
     pub fn validate(&self) -> Result<(), ValidationError> {
-        let mut validator = ValidationContext::new(self);
+        self.validate_with_extension_closure(HashMap::new())
+    }
+
+    /// Check the validity of a hugr, taking an argument of a closure for the
+    /// free extension variables
+    pub fn validate_with_extension_closure(
+        &self,
+        closure: HashMap<(Node, Direction), ExtensionSet>,
+    ) -> Result<(), ValidationError> {
+        let mut validator = ValidationContext::new(self, closure);
         validator.validate()
     }
 }
 
 impl<'a> ValidationContext<'a> {
     /// Create a new validation context.
-    pub fn new(hugr: &'a Hugr) -> Self {
+    pub fn new(
+        hugr: &'a Hugr,
+        extension_closure: HashMap<(Node, Direction), ExtensionSet>,
+    ) -> Self {
         Self {
             hugr,
             dominators: HashMap::new(),
-            extension_validator: ExtensionValidator::new(hugr),
+            extension_validator: ExtensionValidator::new(hugr, extension_closure),
         }
     }
 


### PR DESCRIPTION
Fixes #454.
Return from extension inference an extra solution set, which instantiates all of the inference variables to the empty set, meaning metavariables which depend on them can be solved