### PR TITLE
[fix] Use internal tag for SumType enum serialisation

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -94,6 +94,7 @@ pub(crate) fn least_upper_bound(mut tags: impl Iterator<Item = TypeBound>) -> Ty
 }
 
 #[derive(Clone, PartialEq, Debug, Eq, derive_more::Display, Serialize, Deserialize)]
+#[serde(tag = "s")]
 /// Representation of a Sum type.
 /// Either store the types of the variants, or in the special (but common) case
 /// of a "simple predicate" (sum over empty tuples), store only the size of the predicate.


### PR DESCRIPTION
This makes it easier to handle the serialised format with pydantic.