### PR TITLE
refactor: Add extension info to `Conditional` and `Case`

### DIFF
--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -408,6 +408,7 @@ pub trait Dataflow: Container {
         (predicate_inputs, predicate_wire): (impl IntoIterator<Item = TypeRow>, Wire),
         other_inputs: impl IntoIterator<Item = (Type, Wire)>,
         output_types: TypeRow,
+        extension_delta: ExtensionSet,
     ) -> Result<ConditionalBuilder<&mut Hugr>, BuildError> {
         let mut input_wires = vec![predicate_wire];
         let (input_types, rest_input_wires): (Vec<Type>, Vec<Wire>) =
@@ -424,6 +425,7 @@ pub trait Dataflow: Container {
                 predicate_inputs,
                 other_inputs: inputs,
                 outputs: output_types,
+                extension_delta,
             },
             input_wires,
         )?;

--- a/src/builder/conditional.rs
+++ b/src/builder/conditional.rs
@@ -1,8 +1,8 @@
 use crate::hugr::views::HugrView;
 use crate::types::{FunctionType, TypeRow};
 
-use crate::ops;
 use crate::ops::handle::CaseID;
+use crate::ops::{self, OpTrait};
 
 use super::build_traits::SubContainer;
 use super::handle::BuildHandle;
@@ -15,6 +15,7 @@ use super::{
 
 use crate::Node;
 use crate::{
+    extension::ExtensionSet,
     hugr::{HugrMut, NodeType},
     Hugr,
 };
@@ -102,6 +103,7 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> ConditionalBuilder<B> {
     pub fn case_builder(&mut self, case: usize) -> Result<CaseBuilder<&mut Hugr>, BuildError> {
         let conditional = self.conditional_node;
         let control_op = self.hugr().get_optype(self.conditional_node);
+        let extension_delta = control_op.signature().extension_reqs;
 
         let cond: ops::Conditional = control_op
             .clone()
@@ -117,7 +119,8 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> ConditionalBuilder<B> {
 
         let outputs = cond.outputs;
         let case_op = ops::Case {
-            signature: FunctionType::new(inputs.clone(), outputs.clone()),
+            signature: FunctionType::new(inputs.clone(), outputs.clone())
+                .with_extension_delta(&extension_delta),
         };
         let case_node =
             // add case before any existing subsequent cases
@@ -134,7 +137,7 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> ConditionalBuilder<B> {
         let dfg_builder = DFGBuilder::create_with_io(
             self.hugr_mut(),
             case_node,
-            FunctionType::new(inputs, outputs),
+            FunctionType::new(inputs, outputs).with_extension_delta(&extension_delta),
             None,
         )?;
 
@@ -143,7 +146,8 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> ConditionalBuilder<B> {
 }
 
 impl HugrBuilder for ConditionalBuilder<Hugr> {
-    fn finish_hugr(self) -> Result<Hugr, crate::hugr::ValidationError> {
+    fn finish_hugr(mut self) -> Result<Hugr, crate::hugr::ValidationError> {
+        self.base.infer_extensions()?;
         self.base.validate()?;
         Ok(self.base)
     }
@@ -155,6 +159,7 @@ impl ConditionalBuilder<Hugr> {
         predicate_inputs: impl IntoIterator<Item = TypeRow>,
         other_inputs: impl Into<TypeRow>,
         outputs: impl Into<TypeRow>,
+        extension_delta: ExtensionSet,
     ) -> Result<Self, BuildError> {
         let predicate_inputs: Vec<_> = predicate_inputs.into_iter().collect();
         let other_inputs = other_inputs.into();
@@ -167,6 +172,7 @@ impl ConditionalBuilder<Hugr> {
             predicate_inputs,
             other_inputs,
             outputs,
+            extension_delta,
         };
         // TODO: Allow input extensions to be specified
         let base = Hugr::new(NodeType::pure(op));
@@ -183,10 +189,7 @@ impl ConditionalBuilder<Hugr> {
 
 impl CaseBuilder<Hugr> {
     /// Initialize a Case rooted HUGR
-    pub fn new(input: impl Into<TypeRow>, output: impl Into<TypeRow>) -> Result<Self, BuildError> {
-        let input = input.into();
-        let output = output.into();
-        let signature = FunctionType::new(input, output);
+    pub fn new(signature: FunctionType) -> Result<Self, BuildError> {
         let op = ops::Case {
             signature: signature.clone(),
         };
@@ -209,6 +212,7 @@ mod test {
             test::{n_identity, NAT},
             Dataflow,
         },
+        extension::ExtensionSet,
         ops::Const,
         type_row,
     };
@@ -218,8 +222,12 @@ mod test {
     #[test]
     fn basic_conditional() -> Result<(), BuildError> {
         let predicate_inputs = vec![type_row![]; 2];
-        let mut conditional_b =
-            ConditionalBuilder::new(predicate_inputs, type_row![NAT], type_row![NAT])?;
+        let mut conditional_b = ConditionalBuilder::new(
+            predicate_inputs,
+            type_row![NAT],
+            type_row![NAT],
+            ExtensionSet::new(),
+        )?;
 
         n_identity(conditional_b.case_builder(1)?)?;
         n_identity(conditional_b.case_builder(0)?)?;
@@ -246,6 +254,7 @@ mod test {
                         (predicate_inputs, const_wire),
                         other_inputs,
                         outputs,
+                        ExtensionSet::new(),
                     )?;
 
                     n_identity(conditional_b.case_builder(0)?)?;
@@ -267,7 +276,12 @@ mod test {
     #[test]
     fn test_not_all_cases() -> Result<(), BuildError> {
         let predicate_inputs = vec![type_row![]; 2];
-        let mut builder = ConditionalBuilder::new(predicate_inputs, type_row![], type_row![])?;
+        let mut builder = ConditionalBuilder::new(
+            predicate_inputs,
+            type_row![],
+            type_row![],
+            ExtensionSet::new(),
+        )?;
         n_identity(builder.case_builder(0)?)?;
         assert_matches!(
             builder.finish_sub_container().map(|_| ()),
@@ -281,7 +295,12 @@ mod test {
     #[test]
     fn test_case_already_built() -> Result<(), BuildError> {
         let predicate_inputs = vec![type_row![]; 2];
-        let mut builder = ConditionalBuilder::new(predicate_inputs, type_row![], type_row![])?;
+        let mut builder = ConditionalBuilder::new(
+            predicate_inputs,
+            type_row![],
+            type_row![],
+            ExtensionSet::new(),
+        )?;
         n_identity(builder.case_builder(0)?)?;
         assert_matches!(
             builder.case_builder(0).map(|_| ()),

--- a/src/builder/tail_loop.rs
+++ b/src/builder/tail_loop.rs
@@ -98,6 +98,7 @@ mod test {
             DataflowSubContainer, HugrBuilder, ModuleBuilder,
         },
         extension::prelude::{ConstUsize, USIZE_T},
+        extension::ExtensionSet,
         hugr::ValidationError,
         ops::Const,
         type_row, Hugr,
@@ -143,6 +144,7 @@ mod test {
                             (predicate_inputs, const_wire),
                             vec![(BIT, b1)],
                             output_row,
+                            ExtensionSet::new(),
                         )?;
 
                         let mut branch_0 = conditional_b.case_builder(0)?;

--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -857,21 +857,28 @@ mod test {
         let [w] = mult.outputs_arr();
 
         builder.set_outputs([w])?;
-        let hugr = builder.base;
-        // TODO: when we put new extensions onto the graph after inference, we
-        // can call `finish_hugr` and just look at the graph
-        let (solution, extra) = infer_extensions(&hugr)?;
-        assert!(extra.is_empty());
+        let mut hugr = builder.base;
+        let closure = hugr.infer_extensions()?;
+        assert!(closure.is_empty());
         assert_eq!(
-            *solution.get(&(src.node(), Direction::Outgoing)).unwrap(),
+            hugr.get_nodetype(src.node())
+                .signature()
+                .unwrap()
+                .output_extensions(),
             rs
         );
         assert_eq!(
-            *solution.get(&(mult.node(), Direction::Incoming)).unwrap(),
+            hugr.get_nodetype(mult.node())
+                .signature()
+                .unwrap()
+                .input_extensions,
             rs
         );
         assert_eq!(
-            *solution.get(&(mult.node(), Direction::Outgoing)).unwrap(),
+            hugr.get_nodetype(mult.node())
+                .signature()
+                .unwrap()
+                .output_extensions(),
             rs
         );
         Ok(())

--- a/src/ops/controlflow.rs
+++ b/src/ops/controlflow.rs
@@ -2,6 +2,7 @@
 
 use smol_str::SmolStr;
 
+use crate::extension::ExtensionSet;
 use crate::types::{EdgeKind, FunctionType, Type, TypeRow};
 
 use super::dataflow::DataflowOpTrait;
@@ -59,6 +60,8 @@ pub struct Conditional {
     pub other_inputs: TypeRow,
     /// Output types
     pub outputs: TypeRow,
+    /// Extensions used to produce the outputs
+    pub extension_delta: ExtensionSet,
 }
 impl_op_name!(Conditional);
 
@@ -74,7 +77,7 @@ impl DataflowOpTrait for Conditional {
         inputs
             .to_mut()
             .insert(0, Type::new_predicate(self.predicate_inputs.clone()));
-        FunctionType::new(inputs, self.outputs.clone())
+        FunctionType::new(inputs, self.outputs.clone()).with_extension_delta(&self.extension_delta)
     }
 }
 
@@ -208,6 +211,10 @@ impl OpTrait for Case {
 
     fn tag(&self) -> OpTag {
         <Self as StaticTag>::TAG
+    }
+
+    fn signature(&self) -> FunctionType {
+        self.signature.clone()
     }
 }
 


### PR DESCRIPTION
N.B. this does nothing with `input_extensions`
`Conditional` ops can now have a set of extension reqs which are added by their child `Case` ops. It's expected that the difference is the same set for the `Conditional` and all of its children