### PR TITLE
New/validate types

### DIFF
--- a/src/algorithm/nest_cfgs.rs
+++ b/src/algorithm/nest_cfgs.rs
@@ -399,7 +399,7 @@ pub(crate) mod test {
     use super::*;
     use crate::builder::{BuildError, CFGBuilder, Container, DataflowSubContainer, HugrBuilder};
     use crate::extension::prelude::USIZE_T;
-    use crate::extension::ExtensionRegistry;
+    use crate::extension::EMPTY_REG;
     use crate::hugr::views::{HierarchyView, SiblingGraph};
     use crate::ops::handle::{BasicBlockID, ConstID, NodeHandle};
     use crate::ops::Const;
@@ -443,7 +443,7 @@ pub(crate) mod test {
         let exit = cfg_builder.exit_block();
         cfg_builder.branch(&tail, 0, &exit)?;
 
-        let h = cfg_builder.finish_hugr(&ExtensionRegistry::new())?;
+        let h = cfg_builder.finish_hugr(&EMPTY_REG)?;
 
         let (entry, exit) = (entry.node(), exit.node());
         let (split, merge, head, tail) = (split.node(), merge.node(), head.node(), tail.node());
@@ -698,7 +698,7 @@ pub(crate) mod test {
         let exit = cfg_builder.exit_block();
         cfg_builder.branch(&tail, 0, &exit)?;
 
-        let h = cfg_builder.finish_hugr(&ExtensionRegistry::new())?;
+        let h = cfg_builder.finish_hugr(&EMPTY_REG)?;
         Ok((h, merge, tail))
     }
 
@@ -735,7 +735,7 @@ pub(crate) mod test {
         cfg_builder.branch(&entry, 0, &head)?;
         cfg_builder.branch(&tail, 0, &exit)?;
 
-        let h = cfg_builder.finish_hugr(&ExtensionRegistry::new())?;
+        let h = cfg_builder.finish_hugr(&EMPTY_REG)?;
         Ok((h, head, tail))
     }
 }

--- a/src/algorithm/nest_cfgs.rs
+++ b/src/algorithm/nest_cfgs.rs
@@ -398,13 +398,13 @@ impl<T: Copy + Clone + PartialEq + Eq + Hash> EdgeClassifier<T> {
 pub(crate) mod test {
     use super::*;
     use crate::builder::{BuildError, CFGBuilder, Container, DataflowSubContainer, HugrBuilder};
+    use crate::extension::prelude::USIZE_T;
     use crate::hugr::views::{HierarchyView, SiblingGraph};
     use crate::ops::handle::{BasicBlockID, ConstID, NodeHandle};
     use crate::ops::Const;
-    use crate::types::test::EQ_T;
     use crate::types::Type;
     use crate::{type_row, Hugr};
-    const NAT: Type = EQ_T;
+    const NAT: Type = USIZE_T;
 
     pub fn group_by<E: Eq + Hash + Ord, V: Eq + Hash>(h: HashMap<E, V>) -> HashSet<Vec<E>> {
         let mut res = HashMap::new();

--- a/src/algorithm/nest_cfgs.rs
+++ b/src/algorithm/nest_cfgs.rs
@@ -399,7 +399,7 @@ pub(crate) mod test {
     use super::*;
     use crate::builder::{BuildError, CFGBuilder, Container, DataflowSubContainer, HugrBuilder};
     use crate::extension::prelude::USIZE_T;
-    use crate::extension::prelude_registry;
+
     use crate::hugr::views::{HierarchyView, SiblingGraph};
     use crate::ops::handle::{BasicBlockID, ConstID, NodeHandle};
     use crate::ops::Const;
@@ -443,7 +443,7 @@ pub(crate) mod test {
         let exit = cfg_builder.exit_block();
         cfg_builder.branch(&tail, 0, &exit)?;
 
-        let h = cfg_builder.finish_hugr(&prelude_registry())?;
+        let h = cfg_builder.finish_prelude_hugr()?;
 
         let (entry, exit) = (entry.node(), exit.node());
         let (split, merge, head, tail) = (split.node(), merge.node(), head.node(), tail.node());
@@ -698,7 +698,7 @@ pub(crate) mod test {
         let exit = cfg_builder.exit_block();
         cfg_builder.branch(&tail, 0, &exit)?;
 
-        let h = cfg_builder.finish_hugr(&prelude_registry())?;
+        let h = cfg_builder.finish_prelude_hugr()?;
         Ok((h, merge, tail))
     }
 
@@ -735,7 +735,7 @@ pub(crate) mod test {
         cfg_builder.branch(&entry, 0, &head)?;
         cfg_builder.branch(&tail, 0, &exit)?;
 
-        let h = cfg_builder.finish_hugr(&prelude_registry())?;
+        let h = cfg_builder.finish_prelude_hugr()?;
         Ok((h, head, tail))
     }
 }

--- a/src/algorithm/nest_cfgs.rs
+++ b/src/algorithm/nest_cfgs.rs
@@ -399,7 +399,7 @@ pub(crate) mod test {
     use super::*;
     use crate::builder::{BuildError, CFGBuilder, Container, DataflowSubContainer, HugrBuilder};
     use crate::extension::prelude::USIZE_T;
-    use crate::extension::EMPTY_REG;
+    use crate::extension::prelude_registry;
     use crate::hugr::views::{HierarchyView, SiblingGraph};
     use crate::ops::handle::{BasicBlockID, ConstID, NodeHandle};
     use crate::ops::Const;
@@ -443,7 +443,7 @@ pub(crate) mod test {
         let exit = cfg_builder.exit_block();
         cfg_builder.branch(&tail, 0, &exit)?;
 
-        let h = cfg_builder.finish_hugr(&EMPTY_REG)?;
+        let h = cfg_builder.finish_hugr(&prelude_registry())?;
 
         let (entry, exit) = (entry.node(), exit.node());
         let (split, merge, head, tail) = (split.node(), merge.node(), head.node(), tail.node());
@@ -698,7 +698,7 @@ pub(crate) mod test {
         let exit = cfg_builder.exit_block();
         cfg_builder.branch(&tail, 0, &exit)?;
 
-        let h = cfg_builder.finish_hugr(&EMPTY_REG)?;
+        let h = cfg_builder.finish_hugr(&prelude_registry())?;
         Ok((h, merge, tail))
     }
 
@@ -735,7 +735,7 @@ pub(crate) mod test {
         cfg_builder.branch(&entry, 0, &head)?;
         cfg_builder.branch(&tail, 0, &exit)?;
 
-        let h = cfg_builder.finish_hugr(&EMPTY_REG)?;
+        let h = cfg_builder.finish_hugr(&prelude_registry())?;
         Ok((h, head, tail))
     }
 }

--- a/src/algorithm/nest_cfgs.rs
+++ b/src/algorithm/nest_cfgs.rs
@@ -399,6 +399,7 @@ pub(crate) mod test {
     use super::*;
     use crate::builder::{BuildError, CFGBuilder, Container, DataflowSubContainer, HugrBuilder};
     use crate::extension::prelude::USIZE_T;
+    use crate::extension::ExtensionRegistry;
     use crate::hugr::views::{HierarchyView, SiblingGraph};
     use crate::ops::handle::{BasicBlockID, ConstID, NodeHandle};
     use crate::ops::Const;
@@ -442,7 +443,7 @@ pub(crate) mod test {
         let exit = cfg_builder.exit_block();
         cfg_builder.branch(&tail, 0, &exit)?;
 
-        let h = cfg_builder.finish_hugr()?;
+        let h = cfg_builder.finish_hugr(&ExtensionRegistry::new())?;
 
         let (entry, exit) = (entry.node(), exit.node());
         let (split, merge, head, tail) = (split.node(), merge.node(), head.node(), tail.node());
@@ -697,7 +698,7 @@ pub(crate) mod test {
         let exit = cfg_builder.exit_block();
         cfg_builder.branch(&tail, 0, &exit)?;
 
-        let h = cfg_builder.finish_hugr()?;
+        let h = cfg_builder.finish_hugr(&ExtensionRegistry::new())?;
         Ok((h, merge, tail))
     }
 
@@ -734,7 +735,7 @@ pub(crate) mod test {
         cfg_builder.branch(&entry, 0, &head)?;
         cfg_builder.branch(&tail, 0, &exit)?;
 
-        let h = cfg_builder.finish_hugr()?;
+        let h = cfg_builder.finish_hugr(&ExtensionRegistry::new())?;
         Ok((h, head, tail))
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -90,7 +90,6 @@ impl From<BuildError> for PyErr {
 pub(crate) mod test {
     use rstest::fixture;
 
-    use crate::extension::prelude_registry;
     use crate::types::{FunctionType, Signature, Type};
     use crate::{type_row, Hugr};
 
@@ -129,8 +128,6 @@ pub(crate) mod test {
         let dfg_builder =
             DFGBuilder::new(FunctionType::new(type_row![BIT], type_row![BIT])).unwrap();
         let [i1] = dfg_builder.input_wires_arr();
-        dfg_builder
-            .finish_hugr_with_outputs([i1], &prelude_registry())
-            .unwrap()
+        dfg_builder.finish_prelude_hugr_with_outputs([i1]).unwrap()
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -90,7 +90,7 @@ impl From<BuildError> for PyErr {
 pub(crate) mod test {
     use rstest::fixture;
 
-    use crate::extension::ExtensionRegistry;
+    use crate::extension::EMPTY_REG;
     use crate::types::{FunctionType, Signature, Type};
     use crate::{type_row, Hugr};
 
@@ -121,7 +121,7 @@ pub(crate) mod test {
         let f_builder = module_builder.define_function("main", signature)?;
 
         f(f_builder)?;
-        Ok(module_builder.finish_hugr(&ExtensionRegistry::new())?)
+        Ok(module_builder.finish_hugr(&EMPTY_REG)?)
     }
 
     #[fixture]
@@ -130,7 +130,7 @@ pub(crate) mod test {
             DFGBuilder::new(FunctionType::new(type_row![BIT], type_row![BIT])).unwrap();
         let [i1] = dfg_builder.input_wires_arr();
         dfg_builder
-            .finish_hugr_with_outputs([i1], &ExtensionRegistry::new())
+            .finish_hugr_with_outputs([i1], &EMPTY_REG)
             .unwrap()
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -101,7 +101,7 @@ pub(crate) mod test {
     use super::{DataflowSubContainer, HugrBuilder};
 
     pub(super) const NAT: Type = crate::extension::prelude::USIZE_T;
-    pub(super) const BIT: Type = crate::extension::prelude::USIZE_T;
+    pub(super) const BIT: Type = crate::extension::prelude::BOOL_T;
     pub(super) const QB: Type = crate::extension::prelude::QB_T;
 
     /// Wire up inputs of a Dataflow container to the outputs.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -90,7 +90,7 @@ impl From<BuildError> for PyErr {
 pub(crate) mod test {
     use rstest::fixture;
 
-    use crate::extension::EMPTY_REG;
+    use crate::extension::prelude_registry;
     use crate::types::{FunctionType, Signature, Type};
     use crate::{type_row, Hugr};
 
@@ -121,7 +121,7 @@ pub(crate) mod test {
         let f_builder = module_builder.define_function("main", signature)?;
 
         f(f_builder)?;
-        Ok(module_builder.finish_hugr(&EMPTY_REG)?)
+        Ok(module_builder.finish_hugr(&prelude_registry())?)
     }
 
     #[fixture]
@@ -130,7 +130,7 @@ pub(crate) mod test {
             DFGBuilder::new(FunctionType::new(type_row![BIT], type_row![BIT])).unwrap();
         let [i1] = dfg_builder.input_wires_arr();
         dfg_builder
-            .finish_hugr_with_outputs([i1], &EMPTY_REG)
+            .finish_hugr_with_outputs([i1], &prelude_registry())
             .unwrap()
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -90,6 +90,7 @@ impl From<BuildError> for PyErr {
 pub(crate) mod test {
     use rstest::fixture;
 
+    use crate::extension::ExtensionRegistry;
     use crate::types::{FunctionType, Signature, Type};
     use crate::{type_row, Hugr};
 
@@ -120,7 +121,7 @@ pub(crate) mod test {
         let f_builder = module_builder.define_function("main", signature)?;
 
         f(f_builder)?;
-        Ok(module_builder.finish_hugr()?)
+        Ok(module_builder.finish_hugr(&ExtensionRegistry::new())?)
     }
 
     #[fixture]
@@ -128,6 +129,8 @@ pub(crate) mod test {
         let dfg_builder =
             DFGBuilder::new(FunctionType::new(type_row![BIT], type_row![BIT])).unwrap();
         let [i1] = dfg_builder.input_wires_arr();
-        dfg_builder.finish_hugr_with_outputs([i1]).unwrap()
+        dfg_builder
+            .finish_hugr_with_outputs([i1], &ExtensionRegistry::new())
+            .unwrap()
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -121,7 +121,7 @@ pub(crate) mod test {
         let f_builder = module_builder.define_function("main", signature)?;
 
         f(f_builder)?;
-        Ok(module_builder.finish_hugr(&prelude_registry())?)
+        Ok(module_builder.finish_prelude_hugr()?)
     }
 
     #[fixture]

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -17,7 +17,7 @@ use crate::{
     types::EdgeKind,
 };
 
-use crate::extension::{ExtensionRegistry, ExtensionSet};
+use crate::extension::{prelude_registry, ExtensionRegistry, ExtensionSet};
 use crate::types::{FunctionType, Signature, Type, TypeRow};
 
 use itertools::Itertools;
@@ -129,6 +129,17 @@ pub trait Container {
 pub trait HugrBuilder: Container {
     /// Finish building the HUGR, perform any validation checks and return it.
     fn finish_hugr(self, extension_registry: &ExtensionRegistry) -> Result<Hugr, ValidationError>;
+
+    /// Finish building the HUGR (as [HugrBuilder::finish_hugr]),
+    /// validating against the [prelude] extension only
+    ///
+    /// [prelude]: crate::extension::prelude
+    fn finish_prelude_hugr(self) -> Result<Hugr, ValidationError>
+    where
+        Self: Sized,
+    {
+        self.finish_hugr(&prelude_registry())
+    }
 }
 
 /// Types implementing this trait build a container graph region by borrowing a HUGR

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -17,7 +17,7 @@ use crate::{
     types::EdgeKind,
 };
 
-use crate::extension::ExtensionSet;
+use crate::extension::{ExtensionRegistry, ExtensionSet};
 use crate::types::{FunctionType, Signature, Type, TypeRow};
 
 use itertools::Itertools;
@@ -128,7 +128,7 @@ pub trait Container {
 /// (with varying root node types)
 pub trait HugrBuilder: Container {
     /// Finish building the HUGR, perform any validation checks and return it.
-    fn finish_hugr(self) -> Result<Hugr, ValidationError>;
+    fn finish_hugr(self, extension_registry: &ExtensionRegistry) -> Result<Hugr, ValidationError>;
 }
 
 /// Types implementing this trait build a container graph region by borrowing a HUGR
@@ -720,12 +720,13 @@ pub trait DataflowHugr: HugrBuilder + Dataflow {
     fn finish_hugr_with_outputs(
         mut self,
         outputs: impl IntoIterator<Item = Wire>,
+        extension_registry: &ExtensionRegistry,
     ) -> Result<Hugr, BuildError>
     where
         Self: Sized,
     {
         self.set_outputs(outputs)?;
-        Ok(self.finish_hugr()?)
+        Ok(self.finish_hugr(extension_registry)?)
     }
 }
 

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -724,10 +724,11 @@ fn wire_up<T: Dataflow + ?Sized>(
 
 /// Trait implemented by builders of Dataflow Hugrs
 pub trait DataflowHugr: HugrBuilder + Dataflow {
-    /// Set outputs of dataflow HUGR and return HUGR
+    /// Set outputs of dataflow HUGR and return validated HUGR
     /// # Errors
     ///
-    /// This function will return an error if there is an error when setting outputs.
+    /// * if there is an error when setting outputs
+    /// * if the Hugr does not validate
     fn finish_hugr_with_outputs(
         mut self,
         outputs: impl IntoIterator<Item = Wire>,
@@ -738,6 +739,20 @@ pub trait DataflowHugr: HugrBuilder + Dataflow {
     {
         self.set_outputs(outputs)?;
         Ok(self.finish_hugr(extension_registry)?)
+    }
+
+    /// Sets the outputs of a dataflow Hugr, validates against
+    /// the [prelude] extension only, and return the Hugr
+    ///
+    /// [prelude]: crate::extension::prelude
+    fn finish_prelude_hugr_with_outputs(
+        self,
+        outputs: impl IntoIterator<Item = Wire>,
+    ) -> Result<Hugr, BuildError>
+    where
+        Self: Sized,
+    {
+        self.finish_hugr_with_outputs(outputs, &prelude_registry())
     }
 }
 

--- a/src/builder/cfg.rs
+++ b/src/builder/cfg.rs
@@ -5,11 +5,8 @@ use super::{
     BasicBlockID, BuildError, CfgID, Container, Dataflow, HugrBuilder, Wire,
 };
 
-use crate::types::FunctionType;
-use crate::{
-    extension::ExtensionRegistry,
-    ops::{self, BasicBlock, OpType},
-};
+use crate::ops::{self, BasicBlock, OpType};
+use crate::{extension::ExtensionRegistry, types::FunctionType};
 use crate::{hugr::views::HugrView, types::TypeRow};
 use crate::{ops::handle::NodeHandle, types::Type};
 
@@ -305,7 +302,7 @@ impl BlockBuilder<Hugr> {
 mod test {
     use crate::builder::build_traits::HugrBuilder;
     use crate::builder::{DataflowSubContainer, ModuleBuilder};
-    use crate::extension::ExtensionRegistry;
+    use crate::extension::EMPTY_REG;
     use crate::{builder::test::NAT, type_row};
     use cool_asserts::assert_matches;
 
@@ -329,7 +326,7 @@ mod test {
 
                 func_builder.finish_with_outputs(cfg_id.outputs())?
             };
-            module_builder.finish_hugr(&ExtensionRegistry::new())
+            module_builder.finish_hugr(&EMPTY_REG)
         };
 
         assert_eq!(build_result.err(), None);
@@ -340,7 +337,7 @@ mod test {
     fn basic_cfg_hugr() -> Result<(), BuildError> {
         let mut cfg_builder = CFGBuilder::new(type_row![NAT], type_row![NAT])?;
         build_basic_cfg(&mut cfg_builder)?;
-        assert_matches!(cfg_builder.finish_hugr(&ExtensionRegistry::new()), Ok(_));
+        assert_matches!(cfg_builder.finish_hugr(&EMPTY_REG), Ok(_));
 
         Ok(())
     }

--- a/src/builder/cfg.rs
+++ b/src/builder/cfg.rs
@@ -302,7 +302,7 @@ impl BlockBuilder<Hugr> {
 mod test {
     use crate::builder::build_traits::HugrBuilder;
     use crate::builder::{DataflowSubContainer, ModuleBuilder};
-    use crate::extension::EMPTY_REG;
+    use crate::extension::prelude_registry;
     use crate::{builder::test::NAT, type_row};
     use cool_asserts::assert_matches;
 
@@ -326,7 +326,7 @@ mod test {
 
                 func_builder.finish_with_outputs(cfg_id.outputs())?
             };
-            module_builder.finish_hugr(&EMPTY_REG)
+            module_builder.finish_hugr(&prelude_registry())
         };
 
         assert_eq!(build_result.err(), None);
@@ -337,7 +337,7 @@ mod test {
     fn basic_cfg_hugr() -> Result<(), BuildError> {
         let mut cfg_builder = CFGBuilder::new(type_row![NAT], type_row![NAT])?;
         build_basic_cfg(&mut cfg_builder)?;
-        assert_matches!(cfg_builder.finish_hugr(&EMPTY_REG), Ok(_));
+        assert_matches!(cfg_builder.finish_hugr(&prelude_registry()), Ok(_));
 
         Ok(())
     }

--- a/src/builder/cfg.rs
+++ b/src/builder/cfg.rs
@@ -302,7 +302,7 @@ impl BlockBuilder<Hugr> {
 mod test {
     use crate::builder::build_traits::HugrBuilder;
     use crate::builder::{DataflowSubContainer, ModuleBuilder};
-    use crate::extension::prelude_registry;
+
     use crate::{builder::test::NAT, type_row};
     use cool_asserts::assert_matches;
 
@@ -326,7 +326,7 @@ mod test {
 
                 func_builder.finish_with_outputs(cfg_id.outputs())?
             };
-            module_builder.finish_hugr(&prelude_registry())
+            module_builder.finish_prelude_hugr()
         };
 
         assert_eq!(build_result.err(), None);
@@ -337,7 +337,7 @@ mod test {
     fn basic_cfg_hugr() -> Result<(), BuildError> {
         let mut cfg_builder = CFGBuilder::new(type_row![NAT], type_row![NAT])?;
         build_basic_cfg(&mut cfg_builder)?;
-        assert_matches!(cfg_builder.finish_hugr(&prelude_registry()), Ok(_));
+        assert_matches!(cfg_builder.finish_prelude_hugr(), Ok(_));
 
         Ok(())
     }

--- a/src/builder/cfg.rs
+++ b/src/builder/cfg.rs
@@ -5,8 +5,11 @@ use super::{
     BasicBlockID, BuildError, CfgID, Container, Dataflow, HugrBuilder, Wire,
 };
 
-use crate::ops::{self, BasicBlock, OpType};
 use crate::types::FunctionType;
+use crate::{
+    extension::ExtensionRegistry,
+    ops::{self, BasicBlock, OpType},
+};
 use crate::{hugr::views::HugrView, types::TypeRow};
 use crate::{ops::handle::NodeHandle, types::Type};
 
@@ -70,8 +73,11 @@ impl CFGBuilder<Hugr> {
 }
 
 impl HugrBuilder for CFGBuilder<Hugr> {
-    fn finish_hugr(self) -> Result<Hugr, crate::hugr::ValidationError> {
-        self.base.validate()?;
+    fn finish_hugr(
+        self,
+        extension_registry: &ExtensionRegistry,
+    ) -> Result<Hugr, crate::hugr::ValidationError> {
+        self.base.validate(extension_registry)?;
         Ok(self.base)
     }
 }
@@ -287,9 +293,11 @@ impl BlockBuilder<Hugr> {
         mut self,
         branch_wire: Wire,
         outputs: impl IntoIterator<Item = Wire>,
+        extension_registry: &ExtensionRegistry,
     ) -> Result<Hugr, BuildError> {
         self.set_outputs(branch_wire, outputs)?;
-        self.finish_hugr().map_err(BuildError::InvalidHUGR)
+        self.finish_hugr(extension_registry)
+            .map_err(BuildError::InvalidHUGR)
     }
 }
 
@@ -297,6 +305,7 @@ impl BlockBuilder<Hugr> {
 mod test {
     use crate::builder::build_traits::HugrBuilder;
     use crate::builder::{DataflowSubContainer, ModuleBuilder};
+    use crate::extension::ExtensionRegistry;
     use crate::{builder::test::NAT, type_row};
     use cool_asserts::assert_matches;
 
@@ -320,7 +329,7 @@ mod test {
 
                 func_builder.finish_with_outputs(cfg_id.outputs())?
             };
-            module_builder.finish_hugr()
+            module_builder.finish_hugr(&ExtensionRegistry::new())
         };
 
         assert_eq!(build_result.err(), None);
@@ -331,7 +340,7 @@ mod test {
     fn basic_cfg_hugr() -> Result<(), BuildError> {
         let mut cfg_builder = CFGBuilder::new(type_row![NAT], type_row![NAT])?;
         build_basic_cfg(&mut cfg_builder)?;
-        assert_matches!(cfg_builder.finish_hugr(), Ok(_));
+        assert_matches!(cfg_builder.finish_hugr(&ExtensionRegistry::new()), Ok(_));
 
         Ok(())
     }

--- a/src/builder/conditional.rs
+++ b/src/builder/conditional.rs
@@ -208,7 +208,7 @@ mod test {
 
     use crate::builder::{DataflowSubContainer, HugrBuilder, ModuleBuilder};
 
-    use crate::extension::ExtensionRegistry;
+    use crate::extension::EMPTY_REG;
     use crate::{
         builder::{
             test::{n_identity, NAT},
@@ -261,7 +261,7 @@ mod test {
                 let [int] = conditional_id.outputs_arr();
                 fbuild.finish_with_outputs([int])?
             };
-            Ok(module_builder.finish_hugr(&ExtensionRegistry::new())?)
+            Ok(module_builder.finish_hugr(&EMPTY_REG)?)
         };
 
         assert_matches!(build_result, Ok(_));

--- a/src/builder/conditional.rs
+++ b/src/builder/conditional.rs
@@ -1,3 +1,4 @@
+use crate::extension::ExtensionRegistry;
 use crate::hugr::views::HugrView;
 use crate::types::{FunctionType, TypeRow};
 
@@ -143,8 +144,11 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> ConditionalBuilder<B> {
 }
 
 impl HugrBuilder for ConditionalBuilder<Hugr> {
-    fn finish_hugr(self) -> Result<Hugr, crate::hugr::ValidationError> {
-        self.base.validate()?;
+    fn finish_hugr(
+        self,
+        extension_registry: &ExtensionRegistry,
+    ) -> Result<Hugr, crate::hugr::ValidationError> {
+        self.base.validate(extension_registry)?;
         Ok(self.base)
     }
 }
@@ -204,6 +208,7 @@ mod test {
 
     use crate::builder::{DataflowSubContainer, HugrBuilder, ModuleBuilder};
 
+    use crate::extension::ExtensionRegistry;
     use crate::{
         builder::{
             test::{n_identity, NAT},
@@ -256,7 +261,7 @@ mod test {
                 let [int] = conditional_id.outputs_arr();
                 fbuild.finish_with_outputs([int])?
             };
-            Ok(module_builder.finish_hugr()?)
+            Ok(module_builder.finish_hugr(&ExtensionRegistry::new())?)
         };
 
         assert_matches!(build_result, Ok(_));

--- a/src/builder/conditional.rs
+++ b/src/builder/conditional.rs
@@ -208,7 +208,7 @@ mod test {
 
     use crate::builder::{DataflowSubContainer, HugrBuilder, ModuleBuilder};
 
-    use crate::extension::EMPTY_REG;
+    use crate::extension::prelude_registry;
     use crate::{
         builder::{
             test::{n_identity, NAT},
@@ -261,7 +261,7 @@ mod test {
                 let [int] = conditional_id.outputs_arr();
                 fbuild.finish_with_outputs([int])?
             };
-            Ok(module_builder.finish_hugr(&EMPTY_REG)?)
+            Ok(module_builder.finish_hugr(&prelude_registry())?)
         };
 
         assert_matches!(build_result, Ok(_));

--- a/src/builder/conditional.rs
+++ b/src/builder/conditional.rs
@@ -208,7 +208,6 @@ mod test {
 
     use crate::builder::{DataflowSubContainer, HugrBuilder, ModuleBuilder};
 
-    use crate::extension::prelude_registry;
     use crate::{
         builder::{
             test::{n_identity, NAT},
@@ -261,7 +260,7 @@ mod test {
                 let [int] = conditional_id.outputs_arr();
                 fbuild.finish_with_outputs([int])?
             };
-            Ok(module_builder.finish_hugr(&prelude_registry())?)
+            Ok(module_builder.finish_prelude_hugr()?)
         };
 
         assert_matches!(build_result, Ok(_));

--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -225,7 +225,7 @@ pub(crate) mod test {
     use crate::builder::build_traits::DataflowHugr;
     use crate::builder::{DataflowSubContainer, ModuleBuilder};
     use crate::extension::prelude::BOOL_T;
-    use crate::extension::{prelude_registry, EMPTY_REG};
+    use crate::extension::EMPTY_REG;
     use crate::hugr::validate::InterGraphEdgeError;
     use crate::ops::{handle::NodeHandle, LeafOp, OpTag};
 
@@ -267,7 +267,7 @@ pub(crate) mod test {
 
                 func_builder.finish_with_outputs(inner_id.outputs().chain(q_out.outputs()))?
             };
-            module_builder.finish_hugr(&prelude_registry())
+            module_builder.finish_prelude_hugr()
         };
 
         assert_eq!(build_result.err(), None);
@@ -341,7 +341,7 @@ pub(crate) mod test {
             let [q1] = f_build.input_wires_arr();
             f_build.finish_with_outputs([q1, q1])?;
 
-            Ok(module_builder.finish_hugr(&prelude_registry())?)
+            Ok(module_builder.finish_prelude_hugr()?)
         };
 
         assert_eq!(builder(), Err(BuildError::NoCopyLinear(QB)));

--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -225,7 +225,7 @@ pub(crate) mod test {
     use crate::builder::build_traits::DataflowHugr;
     use crate::builder::{DataflowSubContainer, ModuleBuilder};
     use crate::extension::prelude::BOOL_T;
-    use crate::extension::EMPTY_REG;
+    use crate::extension::{prelude_registry, EMPTY_REG};
     use crate::hugr::validate::InterGraphEdgeError;
     use crate::ops::{handle::NodeHandle, LeafOp, OpTag};
 
@@ -267,7 +267,7 @@ pub(crate) mod test {
 
                 func_builder.finish_with_outputs(inner_id.outputs().chain(q_out.outputs()))?
             };
-            module_builder.finish_hugr(&EMPTY_REG)
+            module_builder.finish_hugr(&prelude_registry())
         };
 
         assert_eq!(build_result.err(), None);
@@ -341,7 +341,7 @@ pub(crate) mod test {
             let [q1] = f_build.input_wires_arr();
             f_build.finish_with_outputs([q1, q1])?;
 
-            Ok(module_builder.finish_hugr(&EMPTY_REG)?)
+            Ok(module_builder.finish_hugr(&prelude_registry())?)
         };
 
         assert_eq!(builder(), Err(BuildError::NoCopyLinear(QB)));
@@ -428,7 +428,12 @@ pub(crate) mod test {
             f_build.finish_with_outputs([id.out_wire(0)])?;
         }
 
-        assert_eq!(module_builder.finish_hugr(&EMPTY_REG)?.node_count(), 7);
+        assert_eq!(
+            module_builder
+                .finish_hugr(&EMPTY_REG)?
+                .node_count(),
+            7
+        );
 
         Ok(())
     }

--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -428,12 +428,7 @@ pub(crate) mod test {
             f_build.finish_with_outputs([id.out_wire(0)])?;
         }
 
-        assert_eq!(
-            module_builder
-                .finish_hugr(&EMPTY_REG)?
-                .node_count(),
-            7
-        );
+        assert_eq!(module_builder.finish_hugr(&EMPTY_REG)?.node_count(), 7);
 
         Ok(())
     }

--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -225,7 +225,7 @@ pub(crate) mod test {
     use crate::builder::build_traits::DataflowHugr;
     use crate::builder::{DataflowSubContainer, ModuleBuilder};
     use crate::extension::prelude::BOOL_T;
-    use crate::extension::ExtensionRegistry;
+    use crate::extension::EMPTY_REG;
     use crate::hugr::validate::InterGraphEdgeError;
     use crate::ops::{handle::NodeHandle, LeafOp, OpTag};
 
@@ -267,7 +267,7 @@ pub(crate) mod test {
 
                 func_builder.finish_with_outputs(inner_id.outputs().chain(q_out.outputs()))?
             };
-            module_builder.finish_hugr(&ExtensionRegistry::new())
+            module_builder.finish_hugr(&EMPTY_REG)
         };
 
         assert_eq!(build_result.err(), None);
@@ -290,7 +290,7 @@ pub(crate) mod test {
 
             f(f_build)?;
 
-            module_builder.finish_hugr(&ExtensionRegistry::new())
+            module_builder.finish_hugr(&EMPTY_REG)
         };
         assert_matches!(build_result, Ok(_), "Failed on example: {}", msg);
 
@@ -341,7 +341,7 @@ pub(crate) mod test {
             let [q1] = f_build.input_wires_arr();
             f_build.finish_with_outputs([q1, q1])?;
 
-            Ok(module_builder.finish_hugr(&ExtensionRegistry::new())?)
+            Ok(module_builder.finish_hugr(&EMPTY_REG)?)
         };
 
         assert_eq!(builder(), Err(BuildError::NoCopyLinear(QB)));
@@ -366,7 +366,7 @@ pub(crate) mod test {
 
             let nested = nested.finish_with_outputs([id.out_wire(0)])?;
 
-            f_build.finish_hugr_with_outputs([nested.out_wire(0)], &ExtensionRegistry::new())
+            f_build.finish_hugr_with_outputs([nested.out_wire(0)], &EMPTY_REG)
         };
 
         assert_matches!(builder(), Ok(_));
@@ -412,7 +412,7 @@ pub(crate) mod test {
         let mut dfg_builder = DFGBuilder::new(FunctionType::new(type_row![BIT], type_row![BIT]))?;
         let [i1] = dfg_builder.input_wires_arr();
         dfg_builder.set_metadata(json!(42));
-        let dfg_hugr = dfg_builder.finish_hugr_with_outputs([i1], &ExtensionRegistry::new())?;
+        let dfg_hugr = dfg_builder.finish_hugr_with_outputs([i1], &EMPTY_REG)?;
 
         // Create a module, and insert the DFG into it
         let mut module_builder = ModuleBuilder::new();
@@ -428,12 +428,7 @@ pub(crate) mod test {
             f_build.finish_with_outputs([id.out_wire(0)])?;
         }
 
-        assert_eq!(
-            module_builder
-                .finish_hugr(&ExtensionRegistry::new())?
-                .node_count(),
-            7
-        );
+        assert_eq!(module_builder.finish_hugr(&EMPTY_REG)?.node_count(), 7);
 
         Ok(())
     }
@@ -504,7 +499,7 @@ pub(crate) mod test {
 
         let add_c = add_c.finish_with_outputs(wires)?;
         let [w] = add_c.outputs_arr();
-        parent.finish_hugr_with_outputs([w], &ExtensionRegistry::new())?;
+        parent.finish_hugr_with_outputs([w], &EMPTY_REG)?;
 
         Ok(())
     }

--- a/src/builder/module.rs
+++ b/src/builder/module.rs
@@ -174,7 +174,7 @@ mod test {
             test::{n_identity, NAT},
             Dataflow, DataflowSubContainer,
         },
-        extension::{prelude_registry, EMPTY_REG},
+        extension::EMPTY_REG,
         type_row,
         types::FunctionType,
     };
@@ -194,7 +194,7 @@ mod test {
             let call = f_build.call(&f_id, f_build.input_wires())?;
 
             f_build.finish_with_outputs(call.outputs())?;
-            module_builder.finish_hugr(&prelude_registry())
+            module_builder.finish_prelude_hugr()
         };
         assert_matches!(build_result, Ok(_));
         Ok(())
@@ -242,7 +242,7 @@ mod test {
             let call = f_build.call(f_id.handle(), f_build.input_wires())?;
 
             f_build.finish_with_outputs(call.outputs())?;
-            module_builder.finish_hugr(&prelude_registry())
+            module_builder.finish_prelude_hugr()
         };
         assert_matches!(build_result, Ok(_));
         Ok(())

--- a/src/builder/module.rs
+++ b/src/builder/module.rs
@@ -4,9 +4,9 @@ use super::{
     BuildError, Container,
 };
 
-use crate::{extension::ExtensionRegistry, hugr::hugrmut::sealed::HugrMutInternals};
 use crate::{
-    hugr::{views::HugrView, ValidationError},
+    extension::ExtensionRegistry,
+    hugr::{hugrmut::sealed::HugrMutInternals, views::HugrView, ValidationError},
     ops,
     types::{Type, TypeBound},
 };
@@ -174,7 +174,7 @@ mod test {
             test::{n_identity, NAT},
             Dataflow, DataflowSubContainer,
         },
-        extension::ExtensionRegistry,
+        extension::EMPTY_REG,
         type_row,
         types::FunctionType,
     };
@@ -194,7 +194,7 @@ mod test {
             let call = f_build.call(&f_id, f_build.input_wires())?;
 
             f_build.finish_with_outputs(call.outputs())?;
-            module_builder.finish_hugr(&ExtensionRegistry::new())
+            module_builder.finish_hugr(&EMPTY_REG)
         };
         assert_matches!(build_result, Ok(_));
         Ok(())
@@ -217,7 +217,7 @@ mod test {
                 .pure(),
             )?;
             n_identity(f_build)?;
-            module_builder.finish_hugr(&ExtensionRegistry::new())
+            module_builder.finish_hugr(&EMPTY_REG)
         };
         assert_matches!(build_result, Ok(_));
         Ok(())
@@ -242,7 +242,7 @@ mod test {
             let call = f_build.call(f_id.handle(), f_build.input_wires())?;
 
             f_build.finish_with_outputs(call.outputs())?;
-            module_builder.finish_hugr(&ExtensionRegistry::new())
+            module_builder.finish_hugr(&EMPTY_REG)
         };
         assert_matches!(build_result, Ok(_));
         Ok(())

--- a/src/builder/module.rs
+++ b/src/builder/module.rs
@@ -4,7 +4,7 @@ use super::{
     BuildError, Container,
 };
 
-use crate::hugr::hugrmut::sealed::HugrMutInternals;
+use crate::{extension::ExtensionRegistry, hugr::hugrmut::sealed::HugrMutInternals};
 use crate::{
     hugr::{views::HugrView, ValidationError},
     ops,
@@ -56,8 +56,8 @@ impl Default for ModuleBuilder<Hugr> {
 }
 
 impl HugrBuilder for ModuleBuilder<Hugr> {
-    fn finish_hugr(self) -> Result<Hugr, ValidationError> {
-        self.0.validate()?;
+    fn finish_hugr(self, extension_registry: &ExtensionRegistry) -> Result<Hugr, ValidationError> {
+        self.0.validate(extension_registry)?;
         Ok(self.0)
     }
 }
@@ -174,6 +174,7 @@ mod test {
             test::{n_identity, NAT},
             Dataflow, DataflowSubContainer,
         },
+        extension::ExtensionRegistry,
         type_row,
         types::FunctionType,
     };
@@ -193,7 +194,7 @@ mod test {
             let call = f_build.call(&f_id, f_build.input_wires())?;
 
             f_build.finish_with_outputs(call.outputs())?;
-            module_builder.finish_hugr()
+            module_builder.finish_hugr(&ExtensionRegistry::new())
         };
         assert_matches!(build_result, Ok(_));
         Ok(())
@@ -216,7 +217,7 @@ mod test {
                 .pure(),
             )?;
             n_identity(f_build)?;
-            module_builder.finish_hugr()
+            module_builder.finish_hugr(&ExtensionRegistry::new())
         };
         assert_matches!(build_result, Ok(_));
         Ok(())
@@ -241,7 +242,7 @@ mod test {
             let call = f_build.call(f_id.handle(), f_build.input_wires())?;
 
             f_build.finish_with_outputs(call.outputs())?;
-            module_builder.finish_hugr()
+            module_builder.finish_hugr(&ExtensionRegistry::new())
         };
         assert_matches!(build_result, Ok(_));
         Ok(())

--- a/src/builder/module.rs
+++ b/src/builder/module.rs
@@ -174,7 +174,7 @@ mod test {
             test::{n_identity, NAT},
             Dataflow, DataflowSubContainer,
         },
-        extension::EMPTY_REG,
+        extension::{prelude_registry, EMPTY_REG},
         type_row,
         types::FunctionType,
     };
@@ -194,7 +194,7 @@ mod test {
             let call = f_build.call(&f_id, f_build.input_wires())?;
 
             f_build.finish_with_outputs(call.outputs())?;
-            module_builder.finish_hugr(&EMPTY_REG)
+            module_builder.finish_hugr(&prelude_registry())
         };
         assert_matches!(build_result, Ok(_));
         Ok(())
@@ -242,7 +242,7 @@ mod test {
             let call = f_build.call(f_id.handle(), f_build.input_wires())?;
 
             f_build.finish_with_outputs(call.outputs())?;
-            module_builder.finish_hugr(&EMPTY_REG)
+            module_builder.finish_hugr(&prelude_registry())
         };
         assert_matches!(build_result, Ok(_));
         Ok(())

--- a/src/builder/tail_loop.rs
+++ b/src/builder/tail_loop.rs
@@ -99,7 +99,7 @@ mod test {
         },
         extension::{
             prelude::{ConstUsize, USIZE_T},
-            EMPTY_REG,
+            prelude_registry,
         },
         hugr::ValidationError,
         ops::Const,
@@ -116,7 +116,7 @@ mod test {
 
             let break_wire = loop_b.make_break(loop_b.loop_signature()?.clone(), [const_wire])?;
             loop_b.set_outputs(break_wire, [i1])?;
-            loop_b.finish_hugr(&EMPTY_REG)
+            loop_b.finish_hugr(&prelude_registry())
         };
 
         assert_matches!(build_result, Ok(_));
@@ -169,7 +169,7 @@ mod test {
 
                 fbuild.finish_with_outputs(loop_id.outputs())?
             };
-            module_builder.finish_hugr(&EMPTY_REG)
+            module_builder.finish_hugr(&prelude_registry())
         };
 
         assert_matches!(build_result, Ok(_));

--- a/src/builder/tail_loop.rs
+++ b/src/builder/tail_loop.rs
@@ -132,7 +132,7 @@ mod test {
                 let [b1] = fbuild.input_wires_arr();
                 let loop_id = {
                     let mut loop_b =
-                        fbuild.tail_loop_builder(vec![(USIZE_T, b1)], vec![], type_row![NAT])?;
+                        fbuild.tail_loop_builder(vec![(BIT, b1)], vec![], type_row![NAT])?;
                     let signature = loop_b.loop_signature()?.clone();
                     let const_wire = loop_b.add_load_const(Const::true_val())?;
                     let [b1] = loop_b.input_wires_arr();

--- a/src/builder/tail_loop.rs
+++ b/src/builder/tail_loop.rs
@@ -97,10 +97,7 @@ mod test {
             test::{BIT, NAT},
             DataflowSubContainer, HugrBuilder, ModuleBuilder,
         },
-        extension::{
-            prelude::{ConstUsize, USIZE_T},
-            prelude_registry,
-        },
+        extension::prelude::{ConstUsize, USIZE_T},
         hugr::ValidationError,
         ops::Const,
         type_row, Hugr,
@@ -116,7 +113,7 @@ mod test {
 
             let break_wire = loop_b.make_break(loop_b.loop_signature()?.clone(), [const_wire])?;
             loop_b.set_outputs(break_wire, [i1])?;
-            loop_b.finish_hugr(&prelude_registry())
+            loop_b.finish_prelude_hugr()
         };
 
         assert_matches!(build_result, Ok(_));
@@ -169,7 +166,7 @@ mod test {
 
                 fbuild.finish_with_outputs(loop_id.outputs())?
             };
-            module_builder.finish_hugr(&prelude_registry())
+            module_builder.finish_prelude_hugr()
         };
 
         assert_matches!(build_result, Ok(_));

--- a/src/builder/tail_loop.rs
+++ b/src/builder/tail_loop.rs
@@ -99,7 +99,7 @@ mod test {
         },
         extension::{
             prelude::{ConstUsize, USIZE_T},
-            ExtensionRegistry,
+            EMPTY_REG,
         },
         hugr::ValidationError,
         ops::Const,
@@ -116,7 +116,7 @@ mod test {
 
             let break_wire = loop_b.make_break(loop_b.loop_signature()?.clone(), [const_wire])?;
             loop_b.set_outputs(break_wire, [i1])?;
-            loop_b.finish_hugr(&ExtensionRegistry::new())
+            loop_b.finish_hugr(&EMPTY_REG)
         };
 
         assert_matches!(build_result, Ok(_));
@@ -169,7 +169,7 @@ mod test {
 
                 fbuild.finish_with_outputs(loop_id.outputs())?
             };
-            module_builder.finish_hugr(&ExtensionRegistry::new())
+            module_builder.finish_hugr(&EMPTY_REG)
         };
 
         assert_matches!(build_result, Ok(_));

--- a/src/builder/tail_loop.rs
+++ b/src/builder/tail_loop.rs
@@ -97,7 +97,10 @@ mod test {
             test::{BIT, NAT},
             DataflowSubContainer, HugrBuilder, ModuleBuilder,
         },
-        extension::prelude::{ConstUsize, USIZE_T},
+        extension::{
+            prelude::{ConstUsize, USIZE_T},
+            ExtensionRegistry,
+        },
         hugr::ValidationError,
         ops::Const,
         type_row, Hugr,
@@ -113,7 +116,7 @@ mod test {
 
             let break_wire = loop_b.make_break(loop_b.loop_signature()?.clone(), [const_wire])?;
             loop_b.set_outputs(break_wire, [i1])?;
-            loop_b.finish_hugr()
+            loop_b.finish_hugr(&ExtensionRegistry::new())
         };
 
         assert_matches!(build_result, Ok(_));
@@ -166,7 +169,7 @@ mod test {
 
                 fbuild.finish_with_outputs(loop_id.outputs())?
             };
-            module_builder.finish_hugr()
+            module_builder.finish_hugr(&ExtensionRegistry::new())
         };
 
         assert_matches!(build_result, Ok(_));

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -29,6 +29,17 @@ pub mod validate;
 
 pub use prelude::PRELUDE;
 
+/// Type of Extension Registries.
+pub struct ExtensionRegistry(HashMap<SmolStr, Extension>);
+
+impl ExtensionRegistry {
+    /// Makes a new (empty) registry.
+    /// Ideally this would be `const` but HashMap doesn't have a const constructor.
+    pub fn new() -> Self {
+        Self(HashMap::default())
+    }
+}
+
 /// An error that can occur in computing the signature of a node.
 /// TODO: decide on failure modes
 #[derive(Debug, Clone, Error, PartialEq, Eq)]

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -52,7 +52,9 @@ impl<T: IntoIterator<Item = Extension>> From<T> for ExtensionRegistry {
         let mut reg = Self::new();
         for ext in value.into_iter() {
             let prev = reg.0.insert(ext.name.clone(), ext);
-            assert!(prev.is_none());
+            if let Some(prev) = prev {
+                panic!("Multiple extensions with same name: {}", prev.name)
+            };
         }
         reg
     }

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -82,7 +82,7 @@ pub enum SignatureError {
     #[error("Extension '{exn}' did not contain expected TypeDef '{typ}'")]
     ExtensionTypeNotFound { exn: SmolStr, typ: SmolStr },
     /// The bound recorded for a CustomType doesn't match what the TypeDef would compute
-    #[error("Bound on CustomType did not match TypeDef")]
+    #[error("Bound on CustomType ({actual}) did not match TypeDef ({expected})")]
     WrongBound {
         actual: TypeBound,
         expected: TypeBound,

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -4,7 +4,7 @@
 //! system (outside the `types` module), which also parses nested [`OpDef`]s.
 
 use std::collections::hash_map::Entry;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::{Debug, Display, Formatter};
 use std::sync::Arc;
 
@@ -29,16 +29,18 @@ pub mod validate;
 
 pub use prelude::PRELUDE;
 
-/// Type of Extension Registries.
-pub struct ExtensionRegistry(HashMap<SmolStr, Extension>);
+/// Extension Registries store extensions to be looked up e.g. during validation.
+pub struct ExtensionRegistry(BTreeMap<SmolStr, Extension>);
 
 impl ExtensionRegistry {
     /// Makes a new (empty) registry.
-    /// Ideally this would be `const` but HashMap doesn't have a const constructor.
-    pub fn new() -> Self {
-        Self(HashMap::default())
+    pub const fn new() -> Self {
+        Self(BTreeMap::new())
     }
 }
+
+/// An Extension Registry containing no extensions.
+pub const EMPTY_REG: ExtensionRegistry = ExtensionRegistry::new();
 
 /// An error that can occur in computing the signature of a node.
 /// TODO: decide on failure modes

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -37,6 +37,11 @@ impl ExtensionRegistry {
     pub const fn new() -> Self {
         Self(BTreeMap::new())
     }
+
+    /// Gets the Extension with the given name
+    pub fn get(&self, name: &SmolStr) -> Option<&Extension> {
+        self.0.get(name)
+    }
 }
 
 /// An Extension Registry containing no extensions.
@@ -45,6 +50,7 @@ pub const EMPTY_REG: ExtensionRegistry = ExtensionRegistry::new();
 /// An error that can occur in computing the signature of a node.
 /// TODO: decide on failure modes
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
+#[allow(missing_docs)]
 pub enum SignatureError {
     /// Name mismatch
     #[error("Definition name ({0}) and instantiation name ({1}) do not match.")]
@@ -58,6 +64,12 @@ pub enum SignatureError {
     /// Invalid type arguments
     #[error("Invalid type arguments for operation")]
     InvalidTypeArgs,
+    /// The Extension Registry did not contain an Extension referenced by the Signature
+    #[error("Extension '{0}' not found")]
+    ExtensionNotFound(SmolStr),
+    /// The Extension was found in the registry, but did not contain the Type(Def) referenced in the Signature
+    #[error("Extension '{exn}' did not contain expected TypeDef '{typ}'")]
+    ExtensionTypeNotFound { exn: SmolStr, typ: SmolStr },
 }
 
 /// Concrete instantiations of types and operations defined in extensions.

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -15,7 +15,7 @@ use crate::ops;
 use crate::ops::custom::{ExtensionOp, OpaqueOp};
 use crate::types::type_param::{check_type_arg, TypeArgError};
 use crate::types::type_param::{TypeArg, TypeParam};
-use crate::types::CustomType;
+use crate::types::{CustomType, TypeBound};
 
 mod infer;
 pub use infer::{infer_extensions, ExtensionSolution, InferExtensionError};
@@ -81,6 +81,12 @@ pub enum SignatureError {
     /// The Extension was found in the registry, but did not contain the Type(Def) referenced in the Signature
     #[error("Extension '{exn}' did not contain expected TypeDef '{typ}'")]
     ExtensionTypeNotFound { exn: SmolStr, typ: SmolStr },
+    /// The bound recorded for a CustomType doesn't match what the TypeDef would compute
+    #[error("Bound on CustomType did not match TypeDef")]
+    WrongBound {
+        actual: TypeBound,
+        expected: TypeBound,
+    },
 }
 
 /// Concrete instantiations of types and operations defined in extensions.

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -27,7 +27,7 @@ pub use type_def::{TypeDef, TypeDefBound};
 pub mod prelude;
 pub mod validate;
 
-pub use prelude::PRELUDE;
+pub use prelude::{prelude_registry, PRELUDE};
 
 /// Extension Registries store extensions to be looked up e.g. during validation.
 pub struct ExtensionRegistry(BTreeMap<SmolStr, Extension>);
@@ -46,6 +46,17 @@ impl ExtensionRegistry {
 
 /// An Extension Registry containing no extensions.
 pub const EMPTY_REG: ExtensionRegistry = ExtensionRegistry::new();
+
+impl<T: IntoIterator<Item = Extension>> From<T> for ExtensionRegistry {
+    fn from(value: T) -> Self {
+        let mut reg = Self::new();
+        for ext in value.into_iter() {
+            let prev = reg.0.insert(ext.name.clone(), ext);
+            assert!(prev.is_none());
+        }
+        reg
+    }
+}
 
 /// An error that can occur in computing the signature of a node.
 /// TODO: decide on failure modes

--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -625,7 +625,7 @@ mod test {
 
     use super::*;
     use crate::builder::{BuildError, DFGBuilder, Dataflow, DataflowHugr};
-    use crate::extension::ExtensionSet;
+    use crate::extension::{ExtensionRegistry, ExtensionSet};
     use crate::hugr::HugrMut;
     use crate::hugr::{validate::ValidationError, Hugr, HugrView, NodeType};
     use crate::ops::{self, dataflow::IOTrait, handle::NodeHandle};
@@ -779,7 +779,7 @@ mod test {
                 .with_extension_delta(&ExtensionSet::singleton(&"R".into())),
         )?;
         let [w] = builder.input_wires_arr();
-        let hugr = builder.finish_hugr_with_outputs([w]);
+        let hugr = builder.finish_hugr_with_outputs([w], &ExtensionRegistry::new());
 
         // Fail to catch the actual error because it's a difference between I/O
         // nodes and their parents and `report_mismatch` isn't yet smart enough

--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -941,7 +941,7 @@ mod test {
         let lift_node = hugr.add_node_with_parent(
             child,
             NodeType::open_extensions(ops::LeafOp::Lift {
-                type_row: just_bool.clone(),
+                type_row: just_bool,
                 new_extension: "C".into(),
             }),
         )?;

--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -625,7 +625,7 @@ mod test {
 
     use super::*;
     use crate::builder::{BuildError, DFGBuilder, Dataflow, DataflowHugr};
-    use crate::extension::{ExtensionRegistry, ExtensionSet};
+    use crate::extension::{ExtensionSet, EMPTY_REG};
     use crate::hugr::HugrMut;
     use crate::hugr::{validate::ValidationError, Hugr, HugrView, NodeType};
     use crate::ops::{self, dataflow::IOTrait, handle::NodeHandle};
@@ -779,7 +779,7 @@ mod test {
                 .with_extension_delta(&ExtensionSet::singleton(&"R".into())),
         )?;
         let [w] = builder.input_wires_arr();
-        let hugr = builder.finish_hugr_with_outputs([w], &ExtensionRegistry::new());
+        let hugr = builder.finish_hugr_with_outputs([w], &EMPTY_REG);
 
         // Fail to catch the actual error because it's a difference between I/O
         // nodes and their parents and `report_mismatch` isn't yet smart enough

--- a/src/extension/prelude.rs
+++ b/src/extension/prelude.rs
@@ -13,6 +13,8 @@ use crate::{
     Extension,
 };
 
+use super::ExtensionRegistry;
+
 lazy_static! {
     /// Prelude extension
     pub static ref PRELUDE: Extension = {
@@ -46,6 +48,11 @@ lazy_static! {
             .unwrap();
         prelude
     };
+}
+
+/// An extension registry containing only the prelude
+pub fn prelude_registry() -> ExtensionRegistry {
+    [PRELUDE.to_owned()].into()
 }
 
 pub(crate) const USIZE_CUSTOM_T: CustomType = CustomType::new_simple(

--- a/src/extension/type_def.rs
+++ b/src/extension/type_def.rs
@@ -61,7 +61,16 @@ impl TypeDef {
     /// This function will return an error if the type of the instance does not
     /// match the definition.
     pub fn check_custom(&self, custom: &CustomType) -> Result<(), SignatureError> {
-        self.check_concrete_impl(custom)
+        self.check_concrete_impl(custom)?;
+        let calc_bound = self.bound(custom.args());
+        if calc_bound == custom.bound() {
+            Ok(())
+        } else {
+            Err(SignatureError::WrongBound {
+                expected: calc_bound,
+                actual: custom.bound(),
+            })
+        }
     }
 
     /// Instantiate a concrete [`CustomType`] by providing type arguments.

--- a/src/extension/type_def.rs
+++ b/src/extension/type_def.rs
@@ -158,7 +158,7 @@ impl Extension {
 mod test {
     use crate::extension::prelude::{QB_T, USIZE_T};
     use crate::extension::SignatureError;
-    use crate::types::test::COPYABLE_T;
+    use crate::std_extensions::arithmetic::float_types::FLOAT64_TYPE;
     use crate::types::type_param::{TypeArg, TypeArgError, TypeParam};
     use crate::types::{FunctionType, Type, TypeBound};
 
@@ -201,7 +201,7 @@ mod test {
         );
         // Too many arguments:
         assert_eq!(
-            def.instantiate_concrete([TypeArg::Type(COPYABLE_T), TypeArg::Type(COPYABLE_T),])
+            def.instantiate_concrete([TypeArg::Type(FLOAT64_TYPE), TypeArg::Type(FLOAT64_TYPE),])
                 .unwrap_err(),
             SignatureError::TypeArgMismatch(TypeArgError::WrongNumberArgs(2, 1))
         );

--- a/src/extension/type_def.rs
+++ b/src/extension/type_def.rs
@@ -147,8 +147,9 @@ impl Extension {
 
 #[cfg(test)]
 mod test {
+    use crate::extension::prelude::{QB_T, USIZE_T};
     use crate::extension::SignatureError;
-    use crate::types::test::{ANY_T, COPYABLE_T, EQ_T};
+    use crate::types::test::COPYABLE_T;
     use crate::types::type_param::{TypeArg, TypeArgError, TypeParam};
     use crate::types::{FunctionType, Type, TypeBound};
 
@@ -171,15 +172,15 @@ mod test {
             .unwrap(),
         );
         assert_eq!(typ.least_upper_bound(), TypeBound::Copyable);
-        let typ2 = Type::new_extension(def.instantiate_concrete([TypeArg::Type(EQ_T)]).unwrap());
+        let typ2 = Type::new_extension(def.instantiate_concrete([TypeArg::Type(USIZE_T)]).unwrap());
         assert_eq!(typ2.least_upper_bound(), TypeBound::Eq);
 
         // And some bad arguments...firstly, wrong kind of TypeArg:
         assert_eq!(
-            def.instantiate_concrete([TypeArg::Type(ANY_T)]),
+            def.instantiate_concrete([TypeArg::Type(QB_T)]),
             Err(SignatureError::TypeArgMismatch(
                 TypeArgError::TypeMismatch {
-                    arg: TypeArg::Type(ANY_T),
+                    arg: TypeArg::Type(QB_T),
                     param: TypeParam::Type(TypeBound::Copyable)
                 }
             ))

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -473,15 +473,16 @@ pub(crate) mod sealed {
 #[cfg(test)]
 mod test {
     use crate::{
+        extension::prelude::USIZE_T,
         hugr::HugrView,
         macros::type_row,
         ops::{self, dataflow::IOTrait, LeafOp},
-        types::{test::COPYABLE_T, FunctionType, Type},
+        types::{FunctionType, Type},
     };
 
     use super::*;
 
-    const NAT: Type = COPYABLE_T;
+    const NAT: Type = USIZE_T;
 
     #[test]
     fn simple_function() {
@@ -512,7 +513,7 @@ mod test {
                 .add_op_with_parent(f, ops::Output::new(type_row![NAT, NAT]))
                 .unwrap();
             let noop = builder
-                .add_op_with_parent(f, LeafOp::Noop { ty: COPYABLE_T })
+                .add_op_with_parent(f, LeafOp::Noop { ty: NAT })
                 .unwrap();
 
             assert!(builder.connect(f_in, 0, noop, 0).is_ok());

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -474,7 +474,7 @@ pub(crate) mod sealed {
 mod test {
     use crate::{
         extension::prelude::USIZE_T,
-        extension::EMPTY_REG,
+        extension::prelude_registry,
         hugr::HugrView,
         macros::type_row,
         ops::{self, dataflow::IOTrait, LeafOp},
@@ -523,6 +523,6 @@ mod test {
         }
 
         // Finish the construction and create the HUGR
-        builder.validate(&EMPTY_REG).unwrap();
+        builder.validate(&prelude_registry()).unwrap();
     }
 }

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -474,7 +474,7 @@ pub(crate) mod sealed {
 mod test {
     use crate::{
         extension::prelude::USIZE_T,
-        extension::ExtensionRegistry,
+        extension::EMPTY_REG,
         hugr::HugrView,
         macros::type_row,
         ops::{self, dataflow::IOTrait, LeafOp},
@@ -523,6 +523,6 @@ mod test {
         }
 
         // Finish the construction and create the HUGR
-        builder.validate(&ExtensionRegistry::new()).unwrap();
+        builder.validate(&EMPTY_REG).unwrap();
     }
 }

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -474,6 +474,7 @@ pub(crate) mod sealed {
 mod test {
     use crate::{
         extension::prelude::USIZE_T,
+        extension::ExtensionRegistry,
         hugr::HugrView,
         macros::type_row,
         ops::{self, dataflow::IOTrait, LeafOp},
@@ -522,6 +523,6 @@ mod test {
         }
 
         // Finish the construction and create the HUGR
-        builder.validate().unwrap();
+        builder.validate(&ExtensionRegistry::new()).unwrap();
     }
 }

--- a/src/hugr/rewrite/outline_cfg.rs
+++ b/src/hugr/rewrite/outline_cfg.rs
@@ -5,6 +5,7 @@ use itertools::Itertools;
 use thiserror::Error;
 
 use crate::builder::{BlockBuilder, Container, Dataflow, SubContainer};
+use crate::extension::ExtensionRegistry;
 use crate::hugr::hugrmut::sealed::HugrMutInternals;
 use crate::hugr::rewrite::Rewrite;
 use crate::hugr::{HugrMut, HugrView};
@@ -115,7 +116,7 @@ impl Rewrite for OutlineCfg {
                 .unwrap();
             let pred_wire = new_block_bldr.load_const(&predicate).unwrap();
             let new_block_hugr = new_block_bldr
-                .finish_hugr_with_outputs(pred_wire, cfg_outputs)
+                .finish_hugr_with_outputs(pred_wire, cfg_outputs, &ExtensionRegistry::new())
                 .unwrap();
             h.insert_hugr(outer_cfg, new_block_hugr).unwrap()
         };
@@ -208,6 +209,7 @@ mod test {
     use crate::algorithm::nest_cfgs::test::{
         build_cond_then_loop_cfg, build_conditional_in_loop_cfg,
     };
+    use crate::extension::ExtensionRegistry;
     use crate::ops::handle::NodeHandle;
     use crate::{HugrView, Node};
     use cool_asserts::assert_matches;
@@ -233,7 +235,7 @@ mod test {
         //             \---<---<---<---<---<--<---/
         // merge is unique predecessor of tail
         let merge = h.input_neighbours(tail).exactly_one().unwrap();
-        h.validate().unwrap();
+        h.validate(&ExtensionRegistry::new()).unwrap();
         let backup = h.clone();
         let r = h.apply_rewrite(OutlineCfg::new([merge, tail]));
         assert_matches!(r, Err(OutlineCfgError::MultipleExitEdges(_, _)));
@@ -266,10 +268,10 @@ mod test {
         for n in [head, tail, merge] {
             assert_eq!(depth(&h, n), 1);
         }
-        h.validate().unwrap();
+        h.validate(&ExtensionRegistry::new()).unwrap();
         let blocks = [head, left, right, merge];
         h.apply_rewrite(OutlineCfg::new(blocks)).unwrap();
-        h.validate().unwrap();
+        h.validate(&ExtensionRegistry::new()).unwrap();
         for n in blocks {
             assert_eq!(depth(&h, n), 3);
         }
@@ -296,7 +298,7 @@ mod test {
         let (merge, tail) = (merge.node(), tail.node());
         let head = h.output_neighbours(merge).exactly_one().unwrap();
 
-        h.validate().unwrap();
+        h.validate(&ExtensionRegistry::new()).unwrap();
         let blocks_to_move = [entry, left, right, merge];
         let other_blocks = [head, tail, exit];
         for &n in blocks_to_move.iter().chain(other_blocks.iter()) {
@@ -304,7 +306,7 @@ mod test {
         }
         h.apply_rewrite(OutlineCfg::new(blocks_to_move.iter().copied()))
             .unwrap();
-        h.validate().unwrap();
+        h.validate(&ExtensionRegistry::new()).unwrap();
         let new_entry = h.children(h.root()).next().unwrap();
         for n in other_blocks {
             assert_eq!(depth(&h, n), 1);

--- a/src/hugr/rewrite/outline_cfg.rs
+++ b/src/hugr/rewrite/outline_cfg.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use thiserror::Error;
 
 use crate::builder::{BlockBuilder, Container, Dataflow, SubContainer};
-use crate::extension::EMPTY_REG;
+use crate::extension::prelude_registry;
 use crate::hugr::hugrmut::sealed::HugrMutInternals;
 use crate::hugr::rewrite::Rewrite;
 use crate::hugr::{HugrMut, HugrView};
@@ -116,7 +116,7 @@ impl Rewrite for OutlineCfg {
                 .unwrap();
             let pred_wire = new_block_bldr.load_const(&predicate).unwrap();
             let new_block_hugr = new_block_bldr
-                .finish_hugr_with_outputs(pred_wire, cfg_outputs, &EMPTY_REG)
+                .finish_hugr_with_outputs(pred_wire, cfg_outputs, &prelude_registry())
                 .unwrap();
             h.insert_hugr(outer_cfg, new_block_hugr).unwrap()
         };
@@ -209,7 +209,7 @@ mod test {
     use crate::algorithm::nest_cfgs::test::{
         build_cond_then_loop_cfg, build_conditional_in_loop_cfg,
     };
-    use crate::extension::EMPTY_REG;
+    use crate::extension::prelude_registry;
     use crate::ops::handle::NodeHandle;
     use crate::{HugrView, Node};
     use cool_asserts::assert_matches;
@@ -235,7 +235,7 @@ mod test {
         //             \---<---<---<---<---<--<---/
         // merge is unique predecessor of tail
         let merge = h.input_neighbours(tail).exactly_one().unwrap();
-        h.validate(&EMPTY_REG).unwrap();
+        h.validate(&prelude_registry()).unwrap();
         let backup = h.clone();
         let r = h.apply_rewrite(OutlineCfg::new([merge, tail]));
         assert_matches!(r, Err(OutlineCfgError::MultipleExitEdges(_, _)));
@@ -268,10 +268,10 @@ mod test {
         for n in [head, tail, merge] {
             assert_eq!(depth(&h, n), 1);
         }
-        h.validate(&EMPTY_REG).unwrap();
+        h.validate(&prelude_registry()).unwrap();
         let blocks = [head, left, right, merge];
         h.apply_rewrite(OutlineCfg::new(blocks)).unwrap();
-        h.validate(&EMPTY_REG).unwrap();
+        h.validate(&prelude_registry()).unwrap();
         for n in blocks {
             assert_eq!(depth(&h, n), 3);
         }
@@ -298,7 +298,7 @@ mod test {
         let (merge, tail) = (merge.node(), tail.node());
         let head = h.output_neighbours(merge).exactly_one().unwrap();
 
-        h.validate(&EMPTY_REG).unwrap();
+        h.validate(&prelude_registry()).unwrap();
         let blocks_to_move = [entry, left, right, merge];
         let other_blocks = [head, tail, exit];
         for &n in blocks_to_move.iter().chain(other_blocks.iter()) {
@@ -306,7 +306,7 @@ mod test {
         }
         h.apply_rewrite(OutlineCfg::new(blocks_to_move.iter().copied()))
             .unwrap();
-        h.validate(&EMPTY_REG).unwrap();
+        h.validate(&prelude_registry()).unwrap();
         let new_entry = h.children(h.root()).next().unwrap();
         for n in other_blocks {
             assert_eq!(depth(&h, n), 1);

--- a/src/hugr/rewrite/outline_cfg.rs
+++ b/src/hugr/rewrite/outline_cfg.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use thiserror::Error;
 
 use crate::builder::{BlockBuilder, Container, Dataflow, SubContainer};
-use crate::extension::ExtensionRegistry;
+use crate::extension::EMPTY_REG;
 use crate::hugr::hugrmut::sealed::HugrMutInternals;
 use crate::hugr::rewrite::Rewrite;
 use crate::hugr::{HugrMut, HugrView};
@@ -116,7 +116,7 @@ impl Rewrite for OutlineCfg {
                 .unwrap();
             let pred_wire = new_block_bldr.load_const(&predicate).unwrap();
             let new_block_hugr = new_block_bldr
-                .finish_hugr_with_outputs(pred_wire, cfg_outputs, &ExtensionRegistry::new())
+                .finish_hugr_with_outputs(pred_wire, cfg_outputs, &EMPTY_REG)
                 .unwrap();
             h.insert_hugr(outer_cfg, new_block_hugr).unwrap()
         };
@@ -209,7 +209,7 @@ mod test {
     use crate::algorithm::nest_cfgs::test::{
         build_cond_then_loop_cfg, build_conditional_in_loop_cfg,
     };
-    use crate::extension::ExtensionRegistry;
+    use crate::extension::EMPTY_REG;
     use crate::ops::handle::NodeHandle;
     use crate::{HugrView, Node};
     use cool_asserts::assert_matches;
@@ -235,7 +235,7 @@ mod test {
         //             \---<---<---<---<---<--<---/
         // merge is unique predecessor of tail
         let merge = h.input_neighbours(tail).exactly_one().unwrap();
-        h.validate(&ExtensionRegistry::new()).unwrap();
+        h.validate(&EMPTY_REG).unwrap();
         let backup = h.clone();
         let r = h.apply_rewrite(OutlineCfg::new([merge, tail]));
         assert_matches!(r, Err(OutlineCfgError::MultipleExitEdges(_, _)));
@@ -268,10 +268,10 @@ mod test {
         for n in [head, tail, merge] {
             assert_eq!(depth(&h, n), 1);
         }
-        h.validate(&ExtensionRegistry::new()).unwrap();
+        h.validate(&EMPTY_REG).unwrap();
         let blocks = [head, left, right, merge];
         h.apply_rewrite(OutlineCfg::new(blocks)).unwrap();
-        h.validate(&ExtensionRegistry::new()).unwrap();
+        h.validate(&EMPTY_REG).unwrap();
         for n in blocks {
             assert_eq!(depth(&h, n), 3);
         }
@@ -298,7 +298,7 @@ mod test {
         let (merge, tail) = (merge.node(), tail.node());
         let head = h.output_neighbours(merge).exactly_one().unwrap();
 
-        h.validate(&ExtensionRegistry::new()).unwrap();
+        h.validate(&EMPTY_REG).unwrap();
         let blocks_to_move = [entry, left, right, merge];
         let other_blocks = [head, tail, exit];
         for &n in blocks_to_move.iter().chain(other_blocks.iter()) {
@@ -306,7 +306,7 @@ mod test {
         }
         h.apply_rewrite(OutlineCfg::new(blocks_to_move.iter().copied()))
             .unwrap();
-        h.validate(&ExtensionRegistry::new()).unwrap();
+        h.validate(&EMPTY_REG).unwrap();
         let new_entry = h.children(h.root()).next().unwrap();
         for n in other_blocks {
             assert_eq!(depth(&h, n), 1);

--- a/src/hugr/rewrite/simple_replace.rs
+++ b/src/hugr/rewrite/simple_replace.rs
@@ -199,7 +199,7 @@ mod test {
         HugrBuilder, ModuleBuilder,
     };
     use crate::extension::prelude::BOOL_T;
-    use crate::extension::EMPTY_REG;
+    use crate::extension::{prelude_registry, EMPTY_REG};
     use crate::hugr::views::HugrView;
     use crate::hugr::{Hugr, Node};
     use crate::ops::OpTag;
@@ -253,7 +253,7 @@ mod test {
 
             func_builder.finish_with_outputs(inner_graph.outputs().chain(q_out.outputs()))?
         };
-        Ok(module_builder.finish_hugr(&EMPTY_REG)?)
+        Ok(module_builder.finish_hugr(&prelude_registry())?)
     }
 
     /// Creates a hugr with a DFG root like the following:
@@ -270,7 +270,7 @@ mod test {
         let wire3 = dfg_builder.add_dataflow_op(h_gate(), vec![wire1])?;
         let wire45 =
             dfg_builder.add_dataflow_op(cx_gate(), wire2.outputs().chain(wire3.outputs()))?;
-        dfg_builder.finish_hugr_with_outputs(wire45.outputs(), &EMPTY_REG)
+        dfg_builder.finish_hugr_with_outputs(wire45.outputs(), &prelude_registry())
     }
 
     /// Creates a hugr with a DFG root like the following:
@@ -285,7 +285,7 @@ mod test {
         let wire2 = dfg_builder.add_dataflow_op(h_gate(), vec![wire1])?;
         let wire2out = wire2.outputs().exactly_one().unwrap();
         let wireoutvec = vec![wire0, wire2out];
-        dfg_builder.finish_hugr_with_outputs(wireoutvec, &EMPTY_REG)
+        dfg_builder.finish_hugr_with_outputs(wireoutvec, &prelude_registry())
     }
 
     #[test]
@@ -372,7 +372,7 @@ mod test {
         // ├───┤├───┤┌─┴─┐
         // ┤ H ├┤ H ├┤ X ├
         // └───┘└───┘└───┘
-        assert_eq!(h.validate(&EMPTY_REG), Ok(()));
+        assert_eq!(h.validate(&prelude_registry()), Ok(()));
     }
 
     #[test]
@@ -449,7 +449,7 @@ mod test {
         // ├───┤├───┤┌───┐
         // ┤ H ├┤ H ├┤ H ├
         // └───┘└───┘└───┘
-        assert_eq!(h.validate(&EMPTY_REG), Ok(()));
+        assert_eq!(h.validate(&prelude_registry()), Ok(()));
     }
 
     #[test]
@@ -461,7 +461,9 @@ mod test {
         circ.append(cx_gate(), [1, 0]).unwrap();
         let wires = circ.finish();
         let [input, output] = builder.io();
-        let mut h = builder.finish_hugr_with_outputs(wires, &EMPTY_REG).unwrap();
+        let mut h = builder
+            .finish_hugr_with_outputs(wires, &prelude_registry())
+            .unwrap();
         let replacement = h.clone();
         let orig = h.clone();
 

--- a/src/hugr/rewrite/simple_replace.rs
+++ b/src/hugr/rewrite/simple_replace.rs
@@ -253,7 +253,7 @@ mod test {
 
             func_builder.finish_with_outputs(inner_graph.outputs().chain(q_out.outputs()))?
         };
-        Ok(module_builder.finish_hugr(&prelude_registry())?)
+        Ok(module_builder.finish_prelude_hugr()?)
     }
 
     /// Creates a hugr with a DFG root like the following:

--- a/src/hugr/rewrite/simple_replace.rs
+++ b/src/hugr/rewrite/simple_replace.rs
@@ -270,7 +270,7 @@ mod test {
         let wire3 = dfg_builder.add_dataflow_op(h_gate(), vec![wire1])?;
         let wire45 =
             dfg_builder.add_dataflow_op(cx_gate(), wire2.outputs().chain(wire3.outputs()))?;
-        dfg_builder.finish_hugr_with_outputs(wire45.outputs(), &prelude_registry())
+        dfg_builder.finish_prelude_hugr_with_outputs(wire45.outputs())
     }
 
     /// Creates a hugr with a DFG root like the following:
@@ -285,7 +285,7 @@ mod test {
         let wire2 = dfg_builder.add_dataflow_op(h_gate(), vec![wire1])?;
         let wire2out = wire2.outputs().exactly_one().unwrap();
         let wireoutvec = vec![wire0, wire2out];
-        dfg_builder.finish_hugr_with_outputs(wireoutvec, &prelude_registry())
+        dfg_builder.finish_prelude_hugr_with_outputs(wireoutvec)
     }
 
     #[test]
@@ -461,9 +461,7 @@ mod test {
         circ.append(cx_gate(), [1, 0]).unwrap();
         let wires = circ.finish();
         let [input, output] = builder.io();
-        let mut h = builder
-            .finish_hugr_with_outputs(wires, &prelude_registry())
-            .unwrap();
+        let mut h = builder.finish_prelude_hugr_with_outputs(wires).unwrap();
         let replacement = h.clone();
         let orig = h.clone();
 

--- a/src/hugr/rewrite/simple_replace.rs
+++ b/src/hugr/rewrite/simple_replace.rs
@@ -199,7 +199,7 @@ mod test {
         HugrBuilder, ModuleBuilder,
     };
     use crate::extension::prelude::BOOL_T;
-    use crate::extension::ExtensionRegistry;
+    use crate::extension::EMPTY_REG;
     use crate::hugr::views::HugrView;
     use crate::hugr::{Hugr, Node};
     use crate::ops::OpTag;
@@ -253,7 +253,7 @@ mod test {
 
             func_builder.finish_with_outputs(inner_graph.outputs().chain(q_out.outputs()))?
         };
-        Ok(module_builder.finish_hugr(&ExtensionRegistry::new())?)
+        Ok(module_builder.finish_hugr(&EMPTY_REG)?)
     }
 
     /// Creates a hugr with a DFG root like the following:
@@ -270,7 +270,7 @@ mod test {
         let wire3 = dfg_builder.add_dataflow_op(h_gate(), vec![wire1])?;
         let wire45 =
             dfg_builder.add_dataflow_op(cx_gate(), wire2.outputs().chain(wire3.outputs()))?;
-        dfg_builder.finish_hugr_with_outputs(wire45.outputs(), &ExtensionRegistry::new())
+        dfg_builder.finish_hugr_with_outputs(wire45.outputs(), &EMPTY_REG)
     }
 
     /// Creates a hugr with a DFG root like the following:
@@ -285,7 +285,7 @@ mod test {
         let wire2 = dfg_builder.add_dataflow_op(h_gate(), vec![wire1])?;
         let wire2out = wire2.outputs().exactly_one().unwrap();
         let wireoutvec = vec![wire0, wire2out];
-        dfg_builder.finish_hugr_with_outputs(wireoutvec, &ExtensionRegistry::new())
+        dfg_builder.finish_hugr_with_outputs(wireoutvec, &EMPTY_REG)
     }
 
     #[test]
@@ -372,7 +372,7 @@ mod test {
         // ├───┤├───┤┌─┴─┐
         // ┤ H ├┤ H ├┤ X ├
         // └───┘└───┘└───┘
-        assert_eq!(h.validate(&ExtensionRegistry::new()), Ok(()));
+        assert_eq!(h.validate(&EMPTY_REG), Ok(()));
     }
 
     #[test]
@@ -449,7 +449,7 @@ mod test {
         // ├───┤├───┤┌───┐
         // ┤ H ├┤ H ├┤ H ├
         // └───┘└───┘└───┘
-        assert_eq!(h.validate(&ExtensionRegistry::new()), Ok(()));
+        assert_eq!(h.validate(&EMPTY_REG), Ok(()));
     }
 
     #[test]
@@ -461,9 +461,7 @@ mod test {
         circ.append(cx_gate(), [1, 0]).unwrap();
         let wires = circ.finish();
         let [input, output] = builder.io();
-        let mut h = builder
-            .finish_hugr_with_outputs(wires, &ExtensionRegistry::new())
-            .unwrap();
+        let mut h = builder.finish_hugr_with_outputs(wires, &EMPTY_REG).unwrap();
         let replacement = h.clone();
         let orig = h.clone();
 
@@ -511,17 +509,13 @@ mod test {
             .unwrap()
             .outputs();
         let [input, _] = builder.io();
-        let mut h = builder
-            .finish_hugr_with_outputs(outw, &ExtensionRegistry::new())
-            .unwrap();
+        let mut h = builder.finish_hugr_with_outputs(outw, &EMPTY_REG).unwrap();
 
         let mut builder = DFGBuilder::new(FunctionType::new(two_bit, one_bit)).unwrap();
         let inw = builder.input_wires();
         let outw = builder.add_dataflow_op(and_op(), inw).unwrap().outputs();
         let [repl_input, repl_output] = builder.io();
-        let repl = builder
-            .finish_hugr_with_outputs(outw, &ExtensionRegistry::new())
-            .unwrap();
+        let repl = builder.finish_hugr_with_outputs(outw, &EMPTY_REG).unwrap();
 
         let orig = h.clone();
 

--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -458,9 +458,7 @@ pub mod test {
         let dfg = DFGBuilder::new(FunctionType::new(vec![QB], vec![QB])).unwrap();
         let [old_in, out] = dfg.io();
         let w = dfg.input_wires();
-        let mut hugr = dfg
-            .finish_hugr_with_outputs(w, &prelude_registry())
-            .unwrap();
+        let mut hugr = dfg.finish_prelude_hugr_with_outputs(w).unwrap();
 
         // Now add a new input
         let new_in = hugr.add_op(Input::new([QB].to_vec()));

--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -267,7 +267,7 @@ impl TryFrom<SerHugrV0> for Hugr {
 pub mod test {
 
     use super::*;
-    use crate::extension::EMPTY_REG;
+    use crate::extension::{prelude_registry, EMPTY_REG};
     use crate::hugr::hugrmut::sealed::HugrMutInternals;
     use crate::{
         builder::{
@@ -382,7 +382,7 @@ pub mod test {
             f_build.set_metadata(json!(42));
             f_build.finish_with_outputs(outputs).unwrap();
 
-            module_builder.finish_hugr(&EMPTY_REG).unwrap()
+            module_builder.finish_hugr(&prelude_registry()).unwrap()
         };
 
         let ser_hugr: SerHugrV0 = (&hugr).try_into().unwrap();
@@ -416,7 +416,7 @@ pub mod test {
                 .collect_vec();
 
             f_build.finish_with_outputs(outputs).unwrap();
-            module_builder.finish_hugr(&EMPTY_REG).unwrap()
+            module_builder.finish_hugr(&prelude_registry()).unwrap()
         };
 
         let ser_hugr: SerHugrV0 = (&hugr).try_into().unwrap();
@@ -458,7 +458,9 @@ pub mod test {
         let dfg = DFGBuilder::new(FunctionType::new(vec![QB], vec![QB])).unwrap();
         let [old_in, out] = dfg.io();
         let w = dfg.input_wires();
-        let mut hugr = dfg.finish_hugr_with_outputs(w, &EMPTY_REG).unwrap();
+        let mut hugr = dfg
+            .finish_hugr_with_outputs(w, &prelude_registry())
+            .unwrap();
 
         // Now add a new input
         let new_in = hugr.add_op(Input::new([QB].to_vec()));
@@ -466,11 +468,12 @@ pub mod test {
         hugr.connect(new_in, 0, out, 0).unwrap();
         hugr.move_before_sibling(new_in, old_in).unwrap();
         hugr.remove_node(old_in).unwrap();
-        hugr.validate(&EMPTY_REG).unwrap();
+        hugr.validate(&prelude_registry()).unwrap();
 
         let ser = serde_json::to_vec(&hugr).unwrap();
         let new_hugr: Hugr = serde_json::from_slice(&ser).unwrap();
-        new_hugr.validate(&EMPTY_REG).unwrap();
+        new_hugr.validate(&EMPTY_REG).unwrap_err();
+        new_hugr.validate(&prelude_registry()).unwrap();
 
         // Check the canonicalization works
         let mut h_canon = hugr.clone();

--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -382,7 +382,7 @@ pub mod test {
             f_build.set_metadata(json!(42));
             f_build.finish_with_outputs(outputs).unwrap();
 
-            module_builder.finish_hugr(&prelude_registry()).unwrap()
+            module_builder.finish_prelude_hugr().unwrap()
         };
 
         let ser_hugr: SerHugrV0 = (&hugr).try_into().unwrap();
@@ -416,7 +416,7 @@ pub mod test {
                 .collect_vec();
 
             f_build.finish_with_outputs(outputs).unwrap();
-            module_builder.finish_hugr(&prelude_registry()).unwrap()
+            module_builder.finish_prelude_hugr().unwrap()
         };
 
         let ser_hugr: SerHugrV0 = (&hugr).try_into().unwrap();

--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -267,6 +267,7 @@ impl TryFrom<SerHugrV0> for Hugr {
 pub mod test {
 
     use super::*;
+    use crate::extension::ExtensionRegistry;
     use crate::hugr::hugrmut::sealed::HugrMutInternals;
     use crate::{
         builder::{
@@ -381,7 +382,9 @@ pub mod test {
             f_build.set_metadata(json!(42));
             f_build.finish_with_outputs(outputs).unwrap();
 
-            module_builder.finish_hugr().unwrap()
+            module_builder
+                .finish_hugr(&ExtensionRegistry::new())
+                .unwrap()
         };
 
         let ser_hugr: SerHugrV0 = (&hugr).try_into().unwrap();
@@ -415,7 +418,9 @@ pub mod test {
                 .collect_vec();
 
             f_build.finish_with_outputs(outputs).unwrap();
-            module_builder.finish_hugr().unwrap()
+            module_builder
+                .finish_hugr(&ExtensionRegistry::new())
+                .unwrap()
         };
 
         let ser_hugr: SerHugrV0 = (&hugr).try_into().unwrap();
@@ -435,7 +440,7 @@ pub mod test {
                 .unwrap()
                 .out_wire(0);
         }
-        let h = dfg.finish_hugr_with_outputs(params)?;
+        let h = dfg.finish_hugr_with_outputs(params, &ExtensionRegistry::new())?;
 
         let ser = serde_json::to_string(&h)?;
         let h_deser: Hugr = serde_json::from_str(&ser)?;
@@ -457,7 +462,9 @@ pub mod test {
         let dfg = DFGBuilder::new(FunctionType::new(vec![QB], vec![QB])).unwrap();
         let [old_in, out] = dfg.io();
         let w = dfg.input_wires();
-        let mut hugr = dfg.finish_hugr_with_outputs(w).unwrap();
+        let mut hugr = dfg
+            .finish_hugr_with_outputs(w, &ExtensionRegistry::new())
+            .unwrap();
 
         // Now add a new input
         let new_in = hugr.add_op(Input::new([QB].to_vec()));
@@ -465,11 +472,11 @@ pub mod test {
         hugr.connect(new_in, 0, out, 0).unwrap();
         hugr.move_before_sibling(new_in, old_in).unwrap();
         hugr.remove_node(old_in).unwrap();
-        hugr.validate().unwrap();
+        hugr.validate(&ExtensionRegistry::new()).unwrap();
 
         let ser = serde_json::to_vec(&hugr).unwrap();
         let new_hugr: Hugr = serde_json::from_slice(&ser).unwrap();
-        new_hugr.validate().unwrap();
+        new_hugr.validate(&ExtensionRegistry::new()).unwrap();
 
         // Check the canonicalization works
         let mut h_canon = hugr.clone();

--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -267,7 +267,7 @@ impl TryFrom<SerHugrV0> for Hugr {
 pub mod test {
 
     use super::*;
-    use crate::extension::ExtensionRegistry;
+    use crate::extension::EMPTY_REG;
     use crate::hugr::hugrmut::sealed::HugrMutInternals;
     use crate::{
         builder::{
@@ -382,9 +382,7 @@ pub mod test {
             f_build.set_metadata(json!(42));
             f_build.finish_with_outputs(outputs).unwrap();
 
-            module_builder
-                .finish_hugr(&ExtensionRegistry::new())
-                .unwrap()
+            module_builder.finish_hugr(&EMPTY_REG).unwrap()
         };
 
         let ser_hugr: SerHugrV0 = (&hugr).try_into().unwrap();
@@ -418,9 +416,7 @@ pub mod test {
                 .collect_vec();
 
             f_build.finish_with_outputs(outputs).unwrap();
-            module_builder
-                .finish_hugr(&ExtensionRegistry::new())
-                .unwrap()
+            module_builder.finish_hugr(&EMPTY_REG).unwrap()
         };
 
         let ser_hugr: SerHugrV0 = (&hugr).try_into().unwrap();
@@ -440,7 +436,7 @@ pub mod test {
                 .unwrap()
                 .out_wire(0);
         }
-        let h = dfg.finish_hugr_with_outputs(params, &ExtensionRegistry::new())?;
+        let h = dfg.finish_hugr_with_outputs(params, &EMPTY_REG)?;
 
         let ser = serde_json::to_string(&h)?;
         let h_deser: Hugr = serde_json::from_str(&ser)?;
@@ -462,9 +458,7 @@ pub mod test {
         let dfg = DFGBuilder::new(FunctionType::new(vec![QB], vec![QB])).unwrap();
         let [old_in, out] = dfg.io();
         let w = dfg.input_wires();
-        let mut hugr = dfg
-            .finish_hugr_with_outputs(w, &ExtensionRegistry::new())
-            .unwrap();
+        let mut hugr = dfg.finish_hugr_with_outputs(w, &EMPTY_REG).unwrap();
 
         // Now add a new input
         let new_in = hugr.add_op(Input::new([QB].to_vec()));
@@ -472,11 +466,11 @@ pub mod test {
         hugr.connect(new_in, 0, out, 0).unwrap();
         hugr.move_before_sibling(new_in, old_in).unwrap();
         hugr.remove_node(old_in).unwrap();
-        hugr.validate(&ExtensionRegistry::new()).unwrap();
+        hugr.validate(&EMPTY_REG).unwrap();
 
         let ser = serde_json::to_vec(&hugr).unwrap();
         let new_hugr: Hugr = serde_json::from_slice(&ser).unwrap();
-        new_hugr.validate(&ExtensionRegistry::new()).unwrap();
+        new_hugr.validate(&EMPTY_REG).unwrap();
 
         // Check the canonicalization works
         let mut h_canon = hugr.clone();

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -692,7 +692,7 @@ mod test {
         BuildError, Container, DFGBuilder, Dataflow, DataflowSubContainer, HugrBuilder,
         ModuleBuilder,
     };
-    use crate::extension::prelude::BOOL_T;
+    use crate::extension::prelude::{BOOL_T, USIZE_T};
     use crate::extension::ExtensionSet;
     use crate::hugr::hugrmut::sealed::HugrMutInternals;
     use crate::hugr::{HugrError, HugrMut, NodeType};
@@ -816,10 +816,7 @@ mod test {
 
     #[test]
     fn leaf_root() {
-        let leaf_op: OpType = LeafOp::Noop {
-            ty: crate::types::test::EQ_T,
-        }
-        .into();
+        let leaf_op: OpType = LeafOp::Noop { ty: USIZE_T }.into();
 
         let b = Hugr::new(NodeType::pure(leaf_op));
         assert_eq!(b.validate(), Ok(()));

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -12,6 +12,7 @@ use thiserror::Error;
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 
+use crate::extension::SignatureError;
 use crate::extension::{
     validate::{ExtensionError, ExtensionValidator},
     ExtensionRegistry, ExtensionSet, InferExtensionError,
@@ -619,6 +620,9 @@ pub enum ValidationError {
     ExtensionError(#[from] ExtensionError),
     #[error(transparent)]
     CantInfer(#[from] InferExtensionError),
+    /// Error in a node signature
+    #[error("Error in signature of node {node:?}: {cause}")]
+    SignatureError { node: Node, cause: SignatureError },
 }
 
 #[cfg(feature = "pyo3")]

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -19,7 +19,8 @@ use crate::extension::{
 };
 use crate::ops::validate::{ChildrenEdgeData, ChildrenValidationError, EdgeValidationError};
 use crate::ops::{OpTag, OpTrait, OpType, ValidateOp};
-use crate::types::{EdgeKind, Type};
+use crate::types::type_param::TypeArg;
+use crate::types::{CustomType, EdgeKind, PrimType, Type};
 use crate::{Direction, Hugr, Node, Port};
 
 use super::views::{HierarchyView, HugrView, SiblingGraph};
@@ -209,6 +210,13 @@ impl<'a, 'b> ValidationContext<'a, 'b> {
             return Ok(());
         }
 
+        match &port_kind {
+            EdgeKind::Value(ty) | EdgeKind::Static(ty) => self
+                .validate_type(ty)
+                .map_err(|cause| ValidationError::SignatureError { node, cause })?,
+            _ => (),
+        }
+
         let mut link_cnt = 0;
         for (_, link) in links {
             link_cnt += 1;
@@ -248,6 +256,56 @@ impl<'a, 'b> ValidationContext<'a, 'b> {
         }
 
         Ok(())
+    }
+
+    fn validate_type(&self, ty: &Type) -> Result<(), SignatureError> {
+        for prim in ty.iter_prims() {
+            match prim {
+                PrimType::Alias(_) => (),
+                PrimType::Extension(custy) => self.validate_custom_type(custy)?,
+                PrimType::Function(ft) => (**ft)
+                    .input
+                    .iter()
+                    .chain((**ft).output.iter())
+                    .try_for_each(|t| self.validate_type(t))?,
+            };
+        }
+        Ok(())
+    }
+
+    fn validate_custom_type(&self, ty: &CustomType) -> Result<(), SignatureError> {
+        // Check the args are individually ok
+        ty.args()
+            .iter()
+            .try_for_each(|a| self.validate_type_arg(a))?;
+        // And check they fit into the TypeParams declared by the TypeDef
+        let exn = ty.extension();
+        let ex = self.extension_registry.get(exn);
+        // Even if OpDef's (+binaries) are not available, the part of the Extension definition
+        // describing the TypeDefs can easily be passed around (serialized), so should be available.
+        let ex = ex.ok_or(SignatureError::ExtensionNotFound(exn.clone()))?;
+        let def = ex
+            .get_type(&ty.name())
+            .ok_or(SignatureError::ExtensionTypeNotFound {
+                exn: exn.clone(),
+                typ: ty.name().clone(),
+            })?;
+        def.check_custom(ty)
+    }
+
+    fn validate_type_arg(&self, arg: &TypeArg) -> Result<(), SignatureError> {
+        match arg {
+            TypeArg::Type(ty) => self.validate_type(ty),
+            TypeArg::BoundedNat(_) => Ok(()),
+            TypeArg::Opaque(custarg) =>
+            // We could also add a facility to Extension to validate that the constant *value*
+            // here is a valid instance of the type.
+            {
+                self.validate_custom_type(&custarg.typ)
+            }
+            TypeArg::Sequence(args) => args.iter().try_for_each(|a| self.validate_type_arg(a)),
+            TypeArg::Extensions(_) => Ok(()),
+        }
     }
 
     /// Check operation-specific constraints.

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -709,7 +709,7 @@ mod test {
         ModuleBuilder,
     };
     use crate::extension::prelude::{BOOL_T, USIZE_T};
-    use crate::extension::{ExtensionSet, EMPTY_REG};
+    use crate::extension::{prelude_registry, ExtensionSet, EMPTY_REG};
     use crate::hugr::hugrmut::sealed::HugrMutInternals;
     use crate::hugr::{HugrError, HugrMut, NodeType};
     use crate::ops::dataflow::IOTrait;
@@ -1148,7 +1148,7 @@ mod test {
         let f_handle = f_builder.finish_with_outputs(f_inputs)?;
         let [f_output] = f_handle.outputs_arr();
         main.finish_with_outputs([f_output])?;
-        let handle = module_builder.finish_hugr(&EMPTY_REG);
+        let handle = module_builder.finish_hugr(&prelude_registry());
 
         assert_matches!(
             handle,
@@ -1185,7 +1185,7 @@ mod test {
         let f_handle = f_builder.finish_with_outputs(f_inputs)?;
         let [f_output] = f_handle.outputs_arr();
         main.finish_with_outputs([f_output])?;
-        let handle = module_builder.finish_hugr(&EMPTY_REG);
+        let handle = module_builder.finish_hugr(&prelude_registry());
         assert_matches!(
             handle,
             Err(ValidationError::ExtensionError(
@@ -1247,7 +1247,7 @@ mod test {
         let [output] = builder.finish_with_outputs([])?.outputs_arr();
 
         main.finish_with_outputs([output])?;
-        let handle = module_builder.finish_hugr(&EMPTY_REG);
+        let handle = module_builder.finish_hugr(&prelude_registry());
         assert_matches!(
             handle,
             Err(ValidationError::ExtensionError(
@@ -1265,7 +1265,7 @@ mod test {
         let mut builder = DFGBuilder::new(main_signature)?;
         let [w] = builder.input_wires_arr();
         builder.set_outputs([w])?;
-        let hugr = builder.base.validate(&EMPTY_REG); // finish_hugr_with_outputs([w]);
+        let hugr = builder.base.validate(&prelude_registry()); // finish_hugr_with_outputs([w]);
 
         assert_matches!(
             hugr,

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -1148,7 +1148,7 @@ mod test {
         let f_handle = f_builder.finish_with_outputs(f_inputs)?;
         let [f_output] = f_handle.outputs_arr();
         main.finish_with_outputs([f_output])?;
-        let handle = module_builder.finish_hugr(&prelude_registry());
+        let handle = module_builder.finish_prelude_hugr();
 
         assert_matches!(
             handle,
@@ -1185,7 +1185,7 @@ mod test {
         let f_handle = f_builder.finish_with_outputs(f_inputs)?;
         let [f_output] = f_handle.outputs_arr();
         main.finish_with_outputs([f_output])?;
-        let handle = module_builder.finish_hugr(&prelude_registry());
+        let handle = module_builder.finish_prelude_hugr();
         assert_matches!(
             handle,
             Err(ValidationError::ExtensionError(
@@ -1247,7 +1247,7 @@ mod test {
         let [output] = builder.finish_with_outputs([])?.outputs_arr();
 
         main.finish_with_outputs([output])?;
-        let handle = module_builder.finish_hugr(&prelude_registry());
+        let handle = module_builder.finish_prelude_hugr();
         assert_matches!(
             handle,
             Err(ValidationError::ExtensionError(

--- a/src/hugr/views/hierarchy.rs
+++ b/src/hugr/views/hierarchy.rs
@@ -528,7 +528,6 @@ where
 mod test {
     use crate::{
         builder::{Container, Dataflow, DataflowSubContainer, HugrBuilder, ModuleBuilder},
-        extension::prelude_registry,
         ops::handle::NodeHandle,
         std_extensions::quantum::test::h_gate,
         type_row,
@@ -570,7 +569,7 @@ mod test {
                 func_builder.finish_with_outputs(inner_id.outputs().chain(q_out.outputs()))?;
             (f_id, inner_id)
         };
-        let hugr = module_builder.finish_hugr(&prelude_registry())?;
+        let hugr = module_builder.finish_prelude_hugr()?;
         Ok((hugr, f_id.handle().node(), inner_id.handle().node()))
     }
 

--- a/src/hugr/views/hierarchy.rs
+++ b/src/hugr/views/hierarchy.rs
@@ -528,6 +528,7 @@ where
 mod test {
     use crate::{
         builder::{Container, Dataflow, DataflowSubContainer, HugrBuilder, ModuleBuilder},
+        extension::ExtensionRegistry,
         ops::handle::NodeHandle,
         std_extensions::quantum::test::h_gate,
         type_row,
@@ -569,7 +570,7 @@ mod test {
                 func_builder.finish_with_outputs(inner_id.outputs().chain(q_out.outputs()))?;
             (f_id, inner_id)
         };
-        let hugr = module_builder.finish_hugr()?;
+        let hugr = module_builder.finish_hugr(&ExtensionRegistry::new())?;
         Ok((hugr, f_id.handle().node(), inner_id.handle().node()))
     }
 

--- a/src/hugr/views/hierarchy.rs
+++ b/src/hugr/views/hierarchy.rs
@@ -528,7 +528,7 @@ where
 mod test {
     use crate::{
         builder::{Container, Dataflow, DataflowSubContainer, HugrBuilder, ModuleBuilder},
-        extension::EMPTY_REG,
+        extension::prelude_registry,
         ops::handle::NodeHandle,
         std_extensions::quantum::test::h_gate,
         type_row,
@@ -570,7 +570,7 @@ mod test {
                 func_builder.finish_with_outputs(inner_id.outputs().chain(q_out.outputs()))?;
             (f_id, inner_id)
         };
-        let hugr = module_builder.finish_hugr(&EMPTY_REG)?;
+        let hugr = module_builder.finish_hugr(&prelude_registry())?;
         Ok((hugr, f_id.handle().node(), inner_id.handle().node()))
     }
 

--- a/src/hugr/views/hierarchy.rs
+++ b/src/hugr/views/hierarchy.rs
@@ -528,7 +528,7 @@ where
 mod test {
     use crate::{
         builder::{Container, Dataflow, DataflowSubContainer, HugrBuilder, ModuleBuilder},
-        extension::ExtensionRegistry,
+        extension::EMPTY_REG,
         ops::handle::NodeHandle,
         std_extensions::quantum::test::h_gate,
         type_row,
@@ -570,7 +570,7 @@ mod test {
                 func_builder.finish_with_outputs(inner_id.outputs().chain(q_out.outputs()))?;
             (f_id, inner_id)
         };
-        let hugr = module_builder.finish_hugr(&ExtensionRegistry::new())?;
+        let hugr = module_builder.finish_hugr(&EMPTY_REG)?;
         Ok((hugr, f_id.handle().node(), inner_id.handle().node()))
     }
 

--- a/src/hugr/views/sibling.rs
+++ b/src/hugr/views/sibling.rs
@@ -549,7 +549,10 @@ mod tests {
             BuildError, DFGBuilder, Dataflow, DataflowHugr, DataflowSubContainer, HugrBuilder,
             ModuleBuilder,
         },
-        extension::prelude::{BOOL_T, QB_T},
+        extension::{
+            prelude::{BOOL_T, QB_T},
+            ExtensionRegistry,
+        },
         hugr::views::{HierarchyView, SiblingGraph},
         ops::{
             handle::{FuncID, NodeHandle},
@@ -601,7 +604,7 @@ mod tests {
             dfg.finish_with_outputs(outs.outputs())?
         };
         let hugr = mod_builder
-            .finish_hugr()
+            .finish_hugr(&ExtensionRegistry::new())
             .map_err(|e| -> BuildError { e.into() })?;
         Ok((hugr, func_id.node()))
     }
@@ -620,7 +623,7 @@ mod tests {
             dfg.finish_with_outputs(outs.outputs())?
         };
         let hugr = mod_builder
-            .finish_hugr()
+            .finish_hugr(&ExtensionRegistry::new())
             .map_err(|e| -> BuildError { e.into() })?;
         Ok((hugr, func_id.node()))
     }
@@ -646,7 +649,9 @@ mod tests {
         let empty_dfg = {
             let builder = DFGBuilder::new(FunctionType::new_linear(type_row![QB_T, QB_T])).unwrap();
             let inputs = builder.input_wires();
-            builder.finish_hugr_with_outputs(inputs).unwrap()
+            builder
+                .finish_hugr_with_outputs(inputs, &ExtensionRegistry::new())
+                .unwrap()
         };
 
         let rep = sub.create_simple_replacement(empty_dfg).unwrap();
@@ -681,7 +686,9 @@ mod tests {
         let empty_dfg = {
             let builder = DFGBuilder::new(FunctionType::new_linear(type_row![QB_T])).unwrap();
             let inputs = builder.input_wires();
-            builder.finish_hugr_with_outputs(inputs).unwrap()
+            builder
+                .finish_hugr_with_outputs(inputs, &ExtensionRegistry::new())
+                .unwrap()
         };
 
         assert_eq!(

--- a/src/hugr/views/sibling.rs
+++ b/src/hugr/views/sibling.rs
@@ -604,7 +604,7 @@ mod tests {
             dfg.finish_with_outputs(outs.outputs())?
         };
         let hugr = mod_builder
-            .finish_hugr(&prelude_registry())
+            .finish_prelude_hugr()
             .map_err(|e| -> BuildError { e.into() })?;
         Ok((hugr, func_id.node()))
     }

--- a/src/hugr/views/sibling.rs
+++ b/src/hugr/views/sibling.rs
@@ -551,7 +551,7 @@ mod tests {
         },
         extension::{
             prelude::{BOOL_T, QB_T},
-            prelude_registry, EMPTY_REG,
+            EMPTY_REG,
         },
         hugr::views::{HierarchyView, SiblingGraph},
         ops::{
@@ -649,9 +649,7 @@ mod tests {
         let empty_dfg = {
             let builder = DFGBuilder::new(FunctionType::new_linear(type_row![QB_T, QB_T])).unwrap();
             let inputs = builder.input_wires();
-            builder
-                .finish_hugr_with_outputs(inputs, &prelude_registry())
-                .unwrap()
+            builder.finish_prelude_hugr_with_outputs(inputs).unwrap()
         };
 
         let rep = sub.create_simple_replacement(empty_dfg).unwrap();
@@ -686,9 +684,7 @@ mod tests {
         let empty_dfg = {
             let builder = DFGBuilder::new(FunctionType::new_linear(type_row![QB_T])).unwrap();
             let inputs = builder.input_wires();
-            builder
-                .finish_hugr_with_outputs(inputs, &prelude_registry())
-                .unwrap()
+            builder.finish_prelude_hugr_with_outputs(inputs).unwrap()
         };
 
         assert_eq!(

--- a/src/hugr/views/sibling.rs
+++ b/src/hugr/views/sibling.rs
@@ -551,7 +551,7 @@ mod tests {
         },
         extension::{
             prelude::{BOOL_T, QB_T},
-            ExtensionRegistry,
+            EMPTY_REG,
         },
         hugr::views::{HierarchyView, SiblingGraph},
         ops::{
@@ -604,7 +604,7 @@ mod tests {
             dfg.finish_with_outputs(outs.outputs())?
         };
         let hugr = mod_builder
-            .finish_hugr(&ExtensionRegistry::new())
+            .finish_hugr(&EMPTY_REG)
             .map_err(|e| -> BuildError { e.into() })?;
         Ok((hugr, func_id.node()))
     }
@@ -623,7 +623,7 @@ mod tests {
             dfg.finish_with_outputs(outs.outputs())?
         };
         let hugr = mod_builder
-            .finish_hugr(&ExtensionRegistry::new())
+            .finish_hugr(&EMPTY_REG)
             .map_err(|e| -> BuildError { e.into() })?;
         Ok((hugr, func_id.node()))
     }
@@ -650,7 +650,7 @@ mod tests {
             let builder = DFGBuilder::new(FunctionType::new_linear(type_row![QB_T, QB_T])).unwrap();
             let inputs = builder.input_wires();
             builder
-                .finish_hugr_with_outputs(inputs, &ExtensionRegistry::new())
+                .finish_hugr_with_outputs(inputs, &EMPTY_REG)
                 .unwrap()
         };
 
@@ -687,7 +687,7 @@ mod tests {
             let builder = DFGBuilder::new(FunctionType::new_linear(type_row![QB_T])).unwrap();
             let inputs = builder.input_wires();
             builder
-                .finish_hugr_with_outputs(inputs, &ExtensionRegistry::new())
+                .finish_hugr_with_outputs(inputs, &EMPTY_REG)
                 .unwrap()
         };
 

--- a/src/hugr/views/sibling.rs
+++ b/src/hugr/views/sibling.rs
@@ -551,7 +551,7 @@ mod tests {
         },
         extension::{
             prelude::{BOOL_T, QB_T},
-            EMPTY_REG,
+            prelude_registry, EMPTY_REG,
         },
         hugr::views::{HierarchyView, SiblingGraph},
         ops::{
@@ -604,7 +604,7 @@ mod tests {
             dfg.finish_with_outputs(outs.outputs())?
         };
         let hugr = mod_builder
-            .finish_hugr(&EMPTY_REG)
+            .finish_hugr(&prelude_registry())
             .map_err(|e| -> BuildError { e.into() })?;
         Ok((hugr, func_id.node()))
     }
@@ -650,7 +650,7 @@ mod tests {
             let builder = DFGBuilder::new(FunctionType::new_linear(type_row![QB_T, QB_T])).unwrap();
             let inputs = builder.input_wires();
             builder
-                .finish_hugr_with_outputs(inputs, &EMPTY_REG)
+                .finish_hugr_with_outputs(inputs, &prelude_registry())
                 .unwrap()
         };
 
@@ -687,7 +687,7 @@ mod tests {
             let builder = DFGBuilder::new(FunctionType::new_linear(type_row![QB_T])).unwrap();
             let inputs = builder.input_wires();
             builder
-                .finish_hugr_with_outputs(inputs, &EMPTY_REG)
+                .finish_hugr_with_outputs(inputs, &prelude_registry())
                 .unwrap()
         };
 

--- a/src/hugr/views/tests.rs
+++ b/src/hugr/views/tests.rs
@@ -2,7 +2,7 @@ use portgraph::PortOffset;
 
 use crate::{
     builder::{BuildError, DFGBuilder, Dataflow, DataflowHugr},
-    extension::{prelude::QB_T, EMPTY_REG},
+    extension::{prelude::QB_T, prelude_registry},
     ops::handle::NodeHandle,
     std_extensions::quantum::test::cx_gate,
     type_row,
@@ -23,7 +23,7 @@ fn node_connections() -> Result<(), BuildError> {
     let [q1, q2] = n1.outputs_arr();
     let n2 = dfg.add_dataflow_op(cx_gate(), [q2, q1])?;
 
-    let h = dfg.finish_hugr_with_outputs(n2.outputs(), &EMPTY_REG)?;
+    let h = dfg.finish_hugr_with_outputs(n2.outputs(), &prelude_registry())?;
 
     let connections: Vec<_> = h.node_connections(n1.node(), n2.node()).collect();
 

--- a/src/hugr/views/tests.rs
+++ b/src/hugr/views/tests.rs
@@ -2,7 +2,7 @@ use portgraph::PortOffset;
 
 use crate::{
     builder::{BuildError, DFGBuilder, Dataflow, DataflowHugr},
-    extension::prelude::QB_T,
+    extension::{prelude::QB_T, ExtensionRegistry},
     ops::handle::NodeHandle,
     std_extensions::quantum::test::cx_gate,
     type_row,
@@ -23,7 +23,7 @@ fn node_connections() -> Result<(), BuildError> {
     let [q1, q2] = n1.outputs_arr();
     let n2 = dfg.add_dataflow_op(cx_gate(), [q2, q1])?;
 
-    let h = dfg.finish_hugr_with_outputs(n2.outputs())?;
+    let h = dfg.finish_hugr_with_outputs(n2.outputs(), &ExtensionRegistry::new())?;
 
     let connections: Vec<_> = h.node_connections(n1.node(), n2.node()).collect();
 

--- a/src/hugr/views/tests.rs
+++ b/src/hugr/views/tests.rs
@@ -2,7 +2,7 @@ use portgraph::PortOffset;
 
 use crate::{
     builder::{BuildError, DFGBuilder, Dataflow, DataflowHugr},
-    extension::{prelude::QB_T, ExtensionRegistry},
+    extension::{prelude::QB_T, EMPTY_REG},
     ops::handle::NodeHandle,
     std_extensions::quantum::test::cx_gate,
     type_row,
@@ -23,7 +23,7 @@ fn node_connections() -> Result<(), BuildError> {
     let [q1, q2] = n1.outputs_arr();
     let n2 = dfg.add_dataflow_op(cx_gate(), [q2, q1])?;
 
-    let h = dfg.finish_hugr_with_outputs(n2.outputs(), &ExtensionRegistry::new())?;
+    let h = dfg.finish_hugr_with_outputs(n2.outputs(), &EMPTY_REG)?;
 
     let connections: Vec<_> = h.node_connections(n1.node(), n2.node()).collect();
 

--- a/src/hugr/views/tests.rs
+++ b/src/hugr/views/tests.rs
@@ -2,7 +2,7 @@ use portgraph::PortOffset;
 
 use crate::{
     builder::{BuildError, DFGBuilder, Dataflow, DataflowHugr},
-    extension::{prelude::QB_T, prelude_registry},
+    extension::prelude::QB_T,
     ops::handle::NodeHandle,
     std_extensions::quantum::test::cx_gate,
     type_row,
@@ -23,7 +23,7 @@ fn node_connections() -> Result<(), BuildError> {
     let [q1, q2] = n1.outputs_arr();
     let n2 = dfg.add_dataflow_op(cx_gate(), [q2, q1])?;
 
-    let h = dfg.finish_hugr_with_outputs(n2.outputs(), &prelude_registry())?;
+    let h = dfg.finish_prelude_hugr_with_outputs(n2.outputs())?;
 
     let connections: Vec<_> = h.node_connections(n1.node(), n2.node()).collect();
 

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -122,12 +122,9 @@ mod test {
     use super::Const;
     use crate::{
         builder::{BuildError, DFGBuilder, Dataflow, DataflowHugr},
-        extension::{
-            prelude::{ConstUsize, USIZE_T},
-            EMPTY_REG,
-        },
+        extension::prelude::{ConstUsize, USIZE_T},
         type_row,
-        types::test::COPYABLE_T,
+        types::test::{test_registry, COPYABLE_T},
         types::type_param::TypeArg,
         types::{CustomCheckFailure, CustomType, FunctionType, Type, TypeBound, TypeRow},
         values::{
@@ -156,12 +153,12 @@ mod test {
             pred_rows.clone(),
         )?)?;
         let w = b.load_const(&c)?;
-        b.finish_hugr_with_outputs([w], &EMPTY_REG).unwrap();
+        b.finish_hugr_with_outputs([w], &test_registry()).unwrap();
 
         let mut b = DFGBuilder::new(FunctionType::new(type_row![], TypeRow::from(vec![pred_ty])))?;
         let c = b.add_constant(Const::predicate(1, Value::unit(), pred_rows)?)?;
         let w = b.load_const(&c)?;
-        b.finish_hugr_with_outputs([w], &EMPTY_REG).unwrap();
+        b.finish_hugr_with_outputs([w], &test_registry()).unwrap();
 
         Ok(())
     }

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -123,8 +123,9 @@ mod test {
     use crate::{
         builder::{BuildError, DFGBuilder, Dataflow, DataflowHugr},
         extension::prelude::{ConstUsize, USIZE_T},
+        std_extensions::arithmetic::float_types::FLOAT64_TYPE,
         type_row,
-        types::test::{test_registry, COPYABLE_T},
+        types::test::test_registry,
         types::type_param::TypeArg,
         types::{CustomCheckFailure, CustomType, FunctionType, Type, TypeBound, TypeRow},
         values::{
@@ -140,7 +141,7 @@ mod test {
     #[test]
     fn test_predicate() -> Result<(), BuildError> {
         use crate::builder::Container;
-        let pred_rows = vec![type_row![USIZE_T, COPYABLE_T], type_row![]];
+        let pred_rows = vec![type_row![USIZE_T, FLOAT64_TYPE], type_row![]];
         let pred_ty = Type::new_predicate(pred_rows.clone());
 
         let mut b = DFGBuilder::new(FunctionType::new(
@@ -165,7 +166,7 @@ mod test {
 
     #[test]
     fn test_bad_predicate() {
-        let pred_rows = [type_row![USIZE_T, COPYABLE_T], type_row![]];
+        let pred_rows = [type_row![USIZE_T, FLOAT64_TYPE], type_row![]];
 
         let res = Const::predicate(0, Value::tuple([]), pred_rows);
         assert_matches!(res, Err(ConstTypeError::TupleWrongLength));
@@ -175,14 +176,14 @@ mod test {
     fn test_constant_values() {
         let int_value: Value = ConstUsize::new(257).into();
         USIZE_T.check_type(&int_value).unwrap();
-        COPYABLE_T.check_type(&serialized_float(17.4)).unwrap();
+        FLOAT64_TYPE.check_type(&serialized_float(17.4)).unwrap();
         assert_matches!(
-            COPYABLE_T.check_type(&int_value),
+            FLOAT64_TYPE.check_type(&int_value),
             Err(ConstTypeError::CustomCheckFail(
                 CustomCheckFailure::TypeMismatch { .. }
             ))
         );
-        let tuple_ty = Type::new_tuple(vec![USIZE_T, COPYABLE_T]);
+        let tuple_ty = Type::new_tuple(vec![USIZE_T, FLOAT64_TYPE]);
         let tuple_val = Value::tuple([int_value.clone(), serialized_float(5.1)]);
         tuple_ty.check_type(&tuple_val).unwrap();
         let tuple_val2 = Value::tuple(vec![serialized_float(6.1), int_value.clone()]);

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -124,9 +124,9 @@ mod test {
         builder::{BuildError, DFGBuilder, Dataflow, DataflowHugr},
         extension::prelude::{ConstUsize, USIZE_T},
         type_row,
-        types::{test::COPYABLE_T, TypeRow},
-        types::{test::EQ_T, type_param::TypeArg, CustomCheckFailure},
-        types::{CustomType, FunctionType, Type, TypeBound},
+        types::test::COPYABLE_T,
+        types::type_param::TypeArg,
+        types::{CustomCheckFailure, CustomType, FunctionType, Type, TypeBound, TypeRow},
         values::{
             test::{serialized_float, CustomTestValue},
             CustomSerialized, Value,
@@ -140,7 +140,7 @@ mod test {
     #[test]
     fn test_predicate() -> Result<(), BuildError> {
         use crate::builder::Container;
-        let pred_rows = vec![type_row![EQ_T, COPYABLE_T], type_row![]];
+        let pred_rows = vec![type_row![USIZE_T, COPYABLE_T], type_row![]];
         let pred_ty = Type::new_predicate(pred_rows.clone());
 
         let mut b = DFGBuilder::new(FunctionType::new(
@@ -165,7 +165,7 @@ mod test {
 
     #[test]
     fn test_bad_predicate() {
-        let pred_rows = [type_row![EQ_T, COPYABLE_T], type_row![]];
+        let pred_rows = [type_row![USIZE_T, COPYABLE_T], type_row![]];
 
         let res = Const::predicate(0, Value::tuple([]), pred_rows);
         assert_matches!(res, Err(ConstTypeError::TupleWrongLength));

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -124,7 +124,7 @@ mod test {
         builder::{BuildError, DFGBuilder, Dataflow, DataflowHugr},
         extension::{
             prelude::{ConstUsize, USIZE_T},
-            ExtensionRegistry,
+            EMPTY_REG,
         },
         type_row,
         types::test::COPYABLE_T,
@@ -156,14 +156,12 @@ mod test {
             pred_rows.clone(),
         )?)?;
         let w = b.load_const(&c)?;
-        b.finish_hugr_with_outputs([w], &ExtensionRegistry::new())
-            .unwrap();
+        b.finish_hugr_with_outputs([w], &EMPTY_REG).unwrap();
 
         let mut b = DFGBuilder::new(FunctionType::new(type_row![], TypeRow::from(vec![pred_ty])))?;
         let c = b.add_constant(Const::predicate(1, Value::unit(), pred_rows)?)?;
         let w = b.load_const(&c)?;
-        b.finish_hugr_with_outputs([w], &ExtensionRegistry::new())
-            .unwrap();
+        b.finish_hugr_with_outputs([w], &EMPTY_REG).unwrap();
 
         Ok(())
     }

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -122,7 +122,10 @@ mod test {
     use super::Const;
     use crate::{
         builder::{BuildError, DFGBuilder, Dataflow, DataflowHugr},
-        extension::prelude::{ConstUsize, USIZE_T},
+        extension::{
+            prelude::{ConstUsize, USIZE_T},
+            ExtensionRegistry,
+        },
         type_row,
         types::test::COPYABLE_T,
         types::type_param::TypeArg,
@@ -153,12 +156,14 @@ mod test {
             pred_rows.clone(),
         )?)?;
         let w = b.load_const(&c)?;
-        b.finish_hugr_with_outputs([w]).unwrap();
+        b.finish_hugr_with_outputs([w], &ExtensionRegistry::new())
+            .unwrap();
 
         let mut b = DFGBuilder::new(FunctionType::new(type_row![], TypeRow::from(vec![pred_ty])))?;
         let c = b.add_constant(Const::predicate(1, Value::unit(), pred_rows)?)?;
         let w = b.load_const(&c)?;
-        b.finish_hugr_with_outputs([w]).unwrap();
+        b.finish_hugr_with_outputs([w], &ExtensionRegistry::new())
+            .unwrap();
 
         Ok(())
     }

--- a/src/ops/custom.rs
+++ b/src/ops/custom.rs
@@ -276,7 +276,7 @@ pub enum CustomOpError {
 #[cfg(test)]
 mod test {
 
-    use crate::types::test::EQ_T;
+    use crate::extension::prelude::USIZE_T;
 
     use super::*;
 
@@ -286,12 +286,12 @@ mod test {
             "res".into(),
             "op",
             "desc".into(),
-            vec![TypeArg::Type(EQ_T)],
+            vec![TypeArg::Type(USIZE_T)],
             None,
         );
         let op: ExternalOp = op.into();
         assert_eq!(op.name(), "res.op");
         assert_eq!(op.description(), "desc");
-        assert_eq!(op.args(), &[TypeArg::Type(EQ_T)]);
+        assert_eq!(op.args(), &[TypeArg::Type(USIZE_T)]);
     }
 }

--- a/src/std_extensions/arithmetic/float_types.rs
+++ b/src/std_extensions/arithmetic/float_types.rs
@@ -14,10 +14,11 @@ pub const EXTENSION_ID: SmolStr = SmolStr::new_inline("arithmetic.float.types");
 /// Identfier for the 64-bit IEEE 754-2019 floating-point type.
 const FLOAT_TYPE_ID: SmolStr = SmolStr::new_inline("float64");
 
-const FLOAT64_CUSTOM_TYPE: CustomType =
+/// 64-bit IEEE 754-2019 floating-point type (as [CustomType])
+pub const FLOAT64_CUSTOM_TYPE: CustomType =
     CustomType::new_simple(FLOAT_TYPE_ID, EXTENSION_ID, TypeBound::Copyable);
 
-/// 64-bit IEEE 754-2019 floating-point type
+/// 64-bit IEEE 754-2019 floating-point type (as [Type])
 pub const FLOAT64_TYPE: Type = Type::new_extension(FLOAT64_CUSTOM_TYPE);
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -291,10 +291,37 @@ where
 #[cfg(test)]
 pub(crate) mod test {
 
-    use super::{custom::test::COPYABLE_CUST, *};
-    use crate::{extension::prelude::USIZE_T, ops::AliasDecl};
+    use super::*;
+    use crate::{
+        extension::{prelude::USIZE_T, PRELUDE},
+        ops::AliasDecl,
+        Extension,
+    };
+
+    use smol_str::SmolStr;
+
+    use crate::types::TypeBound;
+
+    use super::CustomType;
+
+    pub(crate) const COPYABLE_CUST: CustomType = CustomType::new_simple(
+        SmolStr::new_inline("MyCopyableType"),
+        SmolStr::new_inline("MyRsrc"),
+        TypeBound::Copyable,
+    );
 
     pub(crate) const COPYABLE_T: Type = Type::new_extension(COPYABLE_CUST);
+    pub(crate) fn test_registry() -> ExtensionRegistry {
+        let mut ext = Extension::new(COPYABLE_CUST.extension().clone());
+        ext.add_type(
+            COPYABLE_CUST.name().clone(),
+            vec![],
+            "test typedef".into(),
+            crate::extension::TypeDefBound::Explicit(COPYABLE_CUST.bound()),
+        )
+        .unwrap();
+        vec![PRELUDE.to_owned(), ext].into()
+    }
 
     #[test]
     fn construct() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -269,15 +269,10 @@ where
 #[cfg(test)]
 pub(crate) mod test {
 
-    use super::{
-        custom::test::{ANY_CUST, COPYABLE_CUST, EQ_CUST},
-        *,
-    };
+    use super::{custom::test::COPYABLE_CUST, *};
     use crate::{extension::prelude::USIZE_T, ops::AliasDecl};
 
-    pub(crate) const EQ_T: Type = Type::new_extension(EQ_CUST);
     pub(crate) const COPYABLE_T: Type = Type::new_extension(COPYABLE_CUST);
-    pub(crate) const ANY_T: Type = Type::new_extension(ANY_CUST);
 
     #[test]
     fn construct() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -300,32 +300,13 @@ pub(crate) mod test {
     use crate::{
         extension::{prelude::USIZE_T, PRELUDE},
         ops::AliasDecl,
-        Extension,
+        std_extensions::arithmetic::float_types,
     };
-
-    use smol_str::SmolStr;
 
     use crate::types::TypeBound;
 
-    use super::CustomType;
-
-    pub(crate) const COPYABLE_CUST: CustomType = CustomType::new_simple(
-        SmolStr::new_inline("MyCopyableType"),
-        SmolStr::new_inline("MyRsrc"),
-        TypeBound::Copyable,
-    );
-
-    pub(crate) const COPYABLE_T: Type = Type::new_extension(COPYABLE_CUST);
     pub(crate) fn test_registry() -> ExtensionRegistry {
-        let mut ext = Extension::new(COPYABLE_CUST.extension().clone());
-        ext.add_type(
-            COPYABLE_CUST.name().clone(),
-            vec![],
-            "test typedef".into(),
-            crate::extension::TypeDefBound::Explicit(COPYABLE_CUST.bound()),
-        )
-        .unwrap();
-        vec![PRELUDE.to_owned(), ext].into()
+        vec![PRELUDE.to_owned(), float_types::extension()].into()
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -21,7 +21,7 @@ use crate::ops::AliasDecl;
 use crate::type_row;
 use std::fmt::Debug;
 
-use self::primitive::PrimType;
+pub use self::primitive::PrimType;
 
 /// The kinds of edges in a HUGR, excluding Hierarchy.
 //#[cfg_attr(feature = "pyo3", pyclass)] # TODO: Manually derive pyclass with non-unit variants
@@ -251,6 +251,23 @@ impl Type {
     pub const fn copyable(&self) -> bool {
         TypeBound::Copyable.contains(self.least_upper_bound())
     }
+
+    /// Returns an iterator over the [PrimType] leaves of this type.
+    /// Duplicates will be returned once per occurrence.
+    pub fn iter_prims(&self) -> impl Iterator<Item = &PrimType> + '_ {
+        itertools::unfold(vec![self], |v| {
+            while let Some(ty) = v.pop() {
+                match &ty.0 {
+                    TypeEnum::Prim(pr) => return Some(pr),
+                    TypeEnum::Sum(SumType::Simple(_)) => (), // No Prim's in there
+                    TypeEnum::Tuple(row) | TypeEnum::Sum(SumType::General(row)) => {
+                        v.extend(row.iter().rev());
+                    }
+                }
+            }
+            None
+        })
+    }
 }
 
 /// Return the type row of variants required to define a Sum of Tuples type
@@ -302,5 +319,24 @@ pub(crate) mod test {
 
         let pred_direct = SumType::Simple(2);
         assert_eq!(pred1, pred_direct.into())
+    }
+
+    #[test]
+    fn iter_prims() {
+        let ft = Type::new_function(FunctionType::new_linear(type_row![USIZE_T]));
+        let t2 = Type::new_tuple(vec![
+            USIZE_T,
+            Type::new_sum(vec![Type::new_tuple(vec![ft.clone(), EQ_T]), COPYABLE_T]),
+            Type::new_sum(type_row![EQ_T, ANY_T]),
+        ]);
+        let prims: Vec<PrimType> = t2.iter_prims().cloned().collect();
+        let expected: Vec<PrimType> = [USIZE_T, ft, EQ_T, COPYABLE_T, EQ_T, ANY_T]
+            .into_iter()
+            .map(|t| match t.0 {
+                TypeEnum::Prim(p) => p,
+                _ => panic!("Not a PrimType?!"),
+            })
+            .collect();
+        assert_eq!(prims, expected);
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -266,10 +266,10 @@ impl Type {
             TypeEnum::Sum(SumType::Simple(_)) => Ok(()), // No leaves there
             TypeEnum::Prim(PrimType::Alias(_)) => Ok(()),
             TypeEnum::Prim(PrimType::Extension(custy)) => custy.validate(extension_registry),
-            TypeEnum::Prim(PrimType::Function(ft)) => (*ft)
+            TypeEnum::Prim(PrimType::Function(ft)) => ft
                 .input
                 .iter()
-                .chain((*ft).output.iter())
+                .chain(ft.output.iter())
                 .try_for_each(|t| t.validate(extension_registry)),
         }
     }

--- a/src/types/custom.rs
+++ b/src/types/custom.rs
@@ -101,18 +101,3 @@ impl Display for CustomType {
         write!(f, "{}({:?})", self.id, self.args)
     }
 }
-
-#[cfg(test)]
-pub(crate) mod test {
-    use smol_str::SmolStr;
-
-    use crate::types::TypeBound;
-
-    use super::CustomType;
-
-    pub(crate) const COPYABLE_CUST: CustomType = CustomType::new_simple(
-        SmolStr::new_inline("MyCopyableType"),
-        SmolStr::new_inline("MyRsrc"),
-        TypeBound::Copyable,
-    );
-}

--- a/src/types/custom.rs
+++ b/src/types/custom.rs
@@ -88,21 +88,9 @@ pub(crate) mod test {
 
     use super::CustomType;
 
-    pub(crate) const EQ_CUST: CustomType = CustomType::new_simple(
-        SmolStr::new_inline("MyEqType"),
-        SmolStr::new_inline("MyRsrc"),
-        TypeBound::Eq,
-    );
-
     pub(crate) const COPYABLE_CUST: CustomType = CustomType::new_simple(
         SmolStr::new_inline("MyCopyableType"),
         SmolStr::new_inline("MyRsrc"),
         TypeBound::Copyable,
-    );
-
-    pub(crate) const ANY_CUST: CustomType = CustomType::new_simple(
-        SmolStr::new_inline("MyAnyType"),
-        SmolStr::new_inline("MyRsrc"),
-        TypeBound::Any,
     );
 }

--- a/src/types/primitive.rs
+++ b/src/types/primitive.rs
@@ -7,11 +7,7 @@ use super::{CustomType, FunctionType, TypeBound};
 #[derive(
     Clone, PartialEq, Debug, Eq, derive_more::Display, serde::Serialize, serde::Deserialize,
 )]
-
-/// Primitive leaves of a [Type]
-///
-/// [Type]: super::Type
-pub enum PrimType {
+pub(super) enum PrimType {
     // TODO optimise with Box<CustomType> ?
     // or some static version of this?
     Extension(CustomType),

--- a/src/types/primitive.rs
+++ b/src/types/primitive.rs
@@ -7,7 +7,11 @@ use super::{CustomType, FunctionType, TypeBound};
 #[derive(
     Clone, PartialEq, Debug, Eq, derive_more::Display, serde::Serialize, serde::Deserialize,
 )]
-pub(super) enum PrimType {
+
+/// Primitive leaves of a [Type]
+///
+/// [Type]: super::Type
+pub enum PrimType {
     // TODO optimise with Box<CustomType> ?
     // or some static version of this?
     Extension(CustomType),

--- a/src/types/serialize.rs
+++ b/src/types/serialize.rs
@@ -62,7 +62,7 @@ impl From<SerSimpleType> for Type {
 mod test {
     use crate::extension::prelude::USIZE_T;
     use crate::hugr::serialize::test::ser_roundtrip;
-    use crate::types::test::COPYABLE_T;
+    use crate::std_extensions::arithmetic::float_types::FLOAT64_TYPE;
     use crate::types::FunctionType;
     use crate::types::Type;
 
@@ -77,7 +77,7 @@ mod test {
         assert_eq!(ser_roundtrip(&t), t);
 
         // A Classic sum
-        let t = Type::new_sum(vec![USIZE_T, COPYABLE_T]);
+        let t = Type::new_sum(vec![USIZE_T, FLOAT64_TYPE]);
         assert_eq!(ser_roundtrip(&t), t);
 
         // A simple predicate

--- a/src/types/type_param.rs
+++ b/src/types/type_param.rs
@@ -84,7 +84,7 @@ pub enum TypeArg {
 pub struct CustomTypeArg {
     /// The type of the constant.
     /// (Exact matches only - the constant is exactly this type.)
-    typ: CustomType,
+    pub typ: CustomType,
     /// Serialized representation.
     pub value: serde_yaml::Value,
 }

--- a/src/types/type_row.rs
+++ b/src/types/type_row.rs
@@ -42,7 +42,7 @@ impl TypeRow {
     delegate! {
         to self.types {
             /// Iterator over the types in the row.
-            pub fn iter(&self) -> impl DoubleEndedIterator<Item = &Type>;
+            pub fn iter(&self) -> impl Iterator<Item = &Type>;
 
             /// Returns the number of types in the row.
             pub fn len(&self) -> usize;

--- a/src/types/type_row.rs
+++ b/src/types/type_row.rs
@@ -42,7 +42,7 @@ impl TypeRow {
     delegate! {
         to self.types {
             /// Iterator over the types in the row.
-            pub fn iter(&self) -> impl Iterator<Item = &Type>;
+            pub fn iter(&self) -> impl DoubleEndedIterator<Item = &Type>;
 
             /// Returns the number of types in the row.
             pub fn len(&self) -> usize;

--- a/src/values.rs
+++ b/src/values.rs
@@ -212,8 +212,8 @@ pub(crate) mod test {
     use super::*;
     use crate::builder::test::simple_dfg_hugr;
     use crate::type_row;
-    use crate::types::{custom::test::COPYABLE_CUST, TypeBound};
-    use crate::types::{FunctionType, Type};
+    use crate::types::test::COPYABLE_CUST;
+    use crate::types::{FunctionType, Type, TypeBound};
 
     #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 

--- a/src/values.rs
+++ b/src/values.rs
@@ -211,8 +211,8 @@ pub(crate) mod test {
 
     use super::*;
     use crate::builder::test::simple_dfg_hugr;
+    use crate::std_extensions::arithmetic::float_types::FLOAT64_CUSTOM_TYPE;
     use crate::type_row;
-    use crate::types::test::COPYABLE_CUST;
     use crate::types::{FunctionType, Type, TypeBound};
 
     #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -239,7 +239,7 @@ pub(crate) mod test {
 
     pub(crate) fn serialized_float(f: f64) -> Value {
         Value::custom(CustomSerialized {
-            typ: COPYABLE_CUST,
+            typ: FLOAT64_CUSTOM_TYPE,
             value: serde_yaml::Value::Number(f.into()),
         })
     }

--- a/src/values.rs
+++ b/src/values.rs
@@ -249,7 +249,7 @@ pub(crate) mod test {
         let v = Value::Prim(PrimValue::Function(Box::new(simple_dfg_hugr)));
 
         let correct_type = Type::new_function(FunctionType::new_linear(type_row![
-            crate::extension::prelude::USIZE_T
+            crate::extension::prelude::BOOL_T
         ]));
 
         assert!(correct_type.check_type(&v).is_ok());


### PR DESCRIPTION
* Preliminary test cleanups of various USIZE_T, EQ_T, BOOL_T etc.
* Add ExtensionRegistry, pass into validate() and finish_hugr[_with_outputs](), also add finish_prelude_hugr helper
* Add {CustomType,Type,TypeArg}::validate() methods (outside of ValidationContext but taking ExtensionRegistry)
* Extend TypeDef::check_custom to check that stored bound matches what would be computed

BREAKING CHANGE(1): Hugr::validate() and the various finish_hugr[_with_outputs] Builder methods require an ExtensionRegistry, e.g. &EMPTY_REG or &prelude_registry(). Note new Builder methods finish_prelude_hugr[_with_outputs]

BREAKING CHANGE(2): crate::types::test::{EQ_T, COPYABLE_T, ANY_T} are gone - try USIZE_T, FLOAT64_TYPE, QB_T from prelude and/or arithmetic extensions.