### PR TITLE
refactor: `ExtensionSolution` only consists of input extensions

### DIFF
--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -209,10 +209,7 @@ impl Hugr {
     fn instantiate_extensions(&mut self, solution: ExtensionSolution) {
         // We only care about inferred _input_ extensions, because `NodeType`
         // uses those to infer the output extensions
-        for ((node, _), input_extensions) in solution
-            .iter()
-            .filter(|((_, dir), _)| *dir == Direction::Incoming)
-        {
+        for (node, input_extensions) in solution.iter() {
             let nodetype = self.op_types.try_get_mut(node.index).unwrap();
             match &nodetype.input_extensions {
                 None => nodetype.input_extensions = Some(input_extensions.clone()),
@@ -504,16 +501,14 @@ mod test {
         hugr.infer_extensions()?;
 
         assert_eq!(
-            hugr.op_types
-                .get(lift.index)
+            hugr.get_nodetype(lift)
                 .signature()
                 .unwrap()
                 .input_extensions,
             ExtensionSet::new()
         );
         assert_eq!(
-            hugr.op_types
-                .get(output.index)
+            hugr.get_nodetype(output)
                 .signature()
                 .unwrap()
                 .input_extensions,

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -15,7 +15,7 @@ use pyo3::prelude::*;
 use crate::extension::SignatureError;
 use crate::extension::{
     validate::{ExtensionError, ExtensionValidator},
-    ExtensionRegistry, ExtensionSet, InferExtensionError,
+    ExtensionRegistry, ExtensionSolution, InferExtensionError,
 };
 use crate::ops::validate::{ChildrenEdgeData, ChildrenValidationError, EdgeValidationError};
 use crate::ops::{OpTag, OpTrait, OpType, ValidateOp};
@@ -53,7 +53,7 @@ impl Hugr {
     /// free extension variables
     pub fn validate_with_extension_closure(
         &self,
-        closure: HashMap<(Node, Direction), ExtensionSet>,
+        closure: ExtensionSolution,
         extension_registry: &ExtensionRegistry,
     ) -> Result<(), ValidationError> {
         let mut validator = ValidationContext::new(self, closure, extension_registry);
@@ -65,7 +65,7 @@ impl<'a, 'b> ValidationContext<'a, 'b> {
     /// Create a new validation context.
     pub fn new(
         hugr: &'a Hugr,
-        extension_closure: HashMap<(Node, Direction), ExtensionSet>,
+        extension_closure: ExtensionSolution,
         extension_registry: &'b ExtensionRegistry,
     ) -> Self {
         Self {


### PR DESCRIPTION
Only input extensions need to be inferred. From the values of the input extensions, the outputs can always be calculated