### PR TITLE
feat: Some helper methods

### DIFF
--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -417,6 +417,18 @@ pub enum CircuitUnit {
     Linear(usize),
 }
 
+impl CircuitUnit {
+    /// Check if this is a wire.
+    pub fn is_wire(&self) -> bool {
+        matches!(self, CircuitUnit::Wire(_))
+    }
+
+    /// Check if this is a linear unit.
+    pub fn is_linear(&self) -> bool {
+        matches!(self, CircuitUnit::Linear(_))
+    }
+}
+
 impl From<usize> for CircuitUnit {
     fn from(value: usize) -> Self {
         CircuitUnit::Linear(value)

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -132,6 +132,11 @@ impl OpType {
     pub fn output_count(&self) -> usize {
         self.port_count(Direction::Outgoing)
     }
+
+    /// Checks whether the operation can contain children nodes.
+    pub fn is_container(&self) -> bool {
+        self.validity_flags().allowed_children != OpTag::None
+    }
 }
 
 /// Macro used by operations that want their


### PR DESCRIPTION
Adds a couple of helper methods that'd be useful downstream.

- `OpType::is_container`
- `CircuitUnit::is_linear` and `is_wire`