### PR TITLE
feat: Port is serializable

### DIFF
--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -179,8 +179,21 @@ pub struct Node {
 }
 
 /// A handle to a port for a node in the HUGR.
+#[derive(
+    Clone,
+    Copy,
+    PartialEq,
+    PartialOrd,
+    Eq,
+    Ord,
+    Hash,
+    Default,
+    Debug,
+    From,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 #[serde(transparent)]
-#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash, Default, Debug, From)]
 #[cfg_attr(feature = "pyo3", pyclass)]
 pub struct Port {
     offset: portgraph::PortOffset,

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -179,6 +179,7 @@ pub struct Node {
 }
 
 /// A handle to a port for a node in the HUGR.
+#[serde(transparent)]
 #[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash, Default, Debug, From)]
 #[cfg_attr(feature = "pyo3", pyclass)]
 pub struct Port {


### PR DESCRIPTION
I need something like this to be able to serialize pattern matcher in TKET2 (more specifically: to serialize predicates for matching). I'm not sure this is the right approach or you'd rather I expose a different serialization API in HUGR for this purpose.
