### PR TITLE
fix: Serialise custom constants with internal tag

### DIFF
--- a/src/values.rs
+++ b/src/values.rs
@@ -139,7 +139,7 @@ impl<T: CustomConst> From<T> for Value {
 ///
 /// When implementing this trait, include the `#[typetag::serde]` attribute to
 /// enable serialization.
-#[typetag::serde]
+#[typetag::serde(tag = "c")]
 pub trait CustomConst:
     Send + Sync + std::fmt::Debug + CustomConstBoxClone + Any + Downcast
 {


### PR DESCRIPTION
Enables internal tagging for `typetag::serde` serialisation of `CustomConst`