### PR TITLE
refactor!: Use named struct for float constants

### DIFF
--- a/src/std_extensions/arithmetic/float_types.rs
+++ b/src/std_extensions/arithmetic/float_types.rs
@@ -23,20 +23,23 @@ pub const FLOAT64_TYPE: Type = Type::new_extension(FLOAT64_CUSTOM_TYPE);
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 /// A floating-point value.
-pub struct ConstF64(f64);
+pub struct ConstF64 {
+    #[allow(missing_docs)]
+    value: f64,
+}
 
 impl std::ops::Deref for ConstF64 {
     type Target = f64;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.value
     }
 }
 
 impl ConstF64 {
     /// Create a new [`ConstF64`]
     pub fn new(value: f64) -> Self {
-        Self(value)
+        Self { value }
     }
 }
 
@@ -47,7 +50,7 @@ impl KnownTypeConst for ConstF64 {
 #[typetag::serde]
 impl CustomConst for ConstF64 {
     fn name(&self) -> SmolStr {
-        format!("f64({})", self.0).into()
+        format!("f64({})", self.value).into()
     }
 
     fn check_custom_type(&self, typ: &CustomType) -> Result<(), CustomCheckFailure> {

--- a/src/std_extensions/arithmetic/float_types.rs
+++ b/src/std_extensions/arithmetic/float_types.rs
@@ -24,7 +24,7 @@ pub const FLOAT64_TYPE: Type = Type::new_extension(FLOAT64_CUSTOM_TYPE);
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 /// A floating-point value.
 pub struct ConstF64 {
-    #[allow(missing_docs)]
+    /// The value.
     value: f64,
 }
 


### PR DESCRIPTION
This simplifies serialisation with pydantic