### PR TITLE
fix: HugrView::get_function_type

### DIFF
--- a/src/hugr/views.rs
+++ b/src/hugr/views.rs
@@ -179,7 +179,15 @@ pub trait HugrView: sealed::HugrInternals {
 
     /// For function-like HUGRs (DFG, FuncDefn, FuncDecl), report the function
     /// type. Otherwise return None.
-    fn get_function_type(&self) -> Option<&FunctionType>;
+    fn get_function_type(&self) -> Option<&FunctionType> {
+        let op = self.get_nodetype(self.root());
+        match &op.op {
+            OpType::DFG(DFG { signature })
+            | OpType::FuncDecl(FuncDecl { signature, .. })
+            | OpType::FuncDefn(FuncDefn { signature, .. }) => Some(signature),
+            _ => None,
+        }
+    }
 
     /// Return a wrapper over the view that can be used in petgraph algorithms.
     #[inline]
@@ -379,15 +387,6 @@ where
         }
     }
 
-    fn get_function_type(&self) -> Option<&FunctionType> {
-        let op = self.get_nodetype(self.root());
-        match &op.op {
-            OpType::DFG(DFG { signature })
-            | OpType::FuncDecl(FuncDecl { signature, .. })
-            | OpType::FuncDefn(FuncDefn { signature, .. }) => Some(signature),
-            _ => None,
-        }
-    }
     #[inline]
     fn get_metadata(&self, node: Node) -> &NodeMetadata {
         self.as_ref().metadata.get(node.index)

--- a/src/hugr/views/descendants.rs
+++ b/src/hugr/views/descendants.rs
@@ -194,10 +194,6 @@ where
     fn get_io(&self, node: Node) -> Option<[Node; 2]> {
         self.base_hugr().get_io(node)
     }
-
-    fn get_function_type(&self) -> Option<&crate::types::FunctionType> {
-        self.base_hugr().get_function_type()
-    }
 }
 
 impl<'a, Root, Base> HierarchyView<'a> for DescendantsGraph<'a, Root, Base>

--- a/src/hugr/views/descendants.rs
+++ b/src/hugr/views/descendants.rs
@@ -307,6 +307,16 @@ pub(super) mod test {
             || hugr.get_parent(n) == Some(inner)));
         assert_eq!(region.children(inner).count(), 2);
 
+        assert_eq!(
+            region.get_function_type(),
+            Some(&FunctionType::new(type_row![NAT, QB], type_row![NAT, QB]))
+        );
+        let inner_region: DescendantsGraph = DescendantsGraph::new(&hugr, inner);
+        assert_eq!(
+            inner_region.get_function_type(),
+            Some(&FunctionType::new(type_row![NAT], type_row![NAT]))
+        );
+
         Ok(())
     }
 }

--- a/src/hugr/views/sibling.rs
+++ b/src/hugr/views/sibling.rs
@@ -204,10 +204,6 @@ where
             None
         }
     }
-
-    fn get_function_type(&self) -> Option<&crate::types::FunctionType> {
-        self.base_hugr().get_function_type()
-    }
 }
 
 impl<'a, Root, Base> HierarchyView<'a> for SiblingGraph<'a, Root, Base>


### PR DESCRIPTION
Previously this was implemented separately for Hugr (correctly, according to the doc), and for the other two HugrViews SiblingGraph/DescendantsGraph (by deferring to the get_function_type of the whole Hugr).

This is incorrect - the latter two should (surely?) return the function type of the portion of the Hugr which they view.

However, we can both fix this and delete code, by moving the impl-Hugr version to be the trait default, and removing the other two. See test added (previously both were returning None).