### PR TITLE
refactor: use SiblingSubgraph in SimpleReplacement

### DIFF
--- a/src/hugr/rewrite/simple_replace.rs
+++ b/src/hugr/rewrite/simple_replace.rs
@@ -51,6 +51,11 @@ impl SimpleReplacement {
     pub fn node_count_delta(&self) -> isize {
         (self.replacement.node_count() - 3) as isize - self.subgraph.nodes().len() as isize
     }
+
+    /// Subgraph to be replaced.
+    pub fn subgraph(&self) -> &SiblingSubgraph {
+        &self.subgraph
+    }
 }
 
 impl Rewrite for SimpleReplacement {

--- a/src/hugr/rewrite/simple_replace.rs
+++ b/src/hugr/rewrite/simple_replace.rs
@@ -17,15 +17,15 @@ use thiserror::Error;
 #[derive(Debug, Clone)]
 pub struct SimpleReplacement {
     /// The subgraph of the hugr to be replaced.
-    pub subgraph: SiblingSubgraph,
+    subgraph: SiblingSubgraph,
     /// A hugr with DFG root (consisting of replacement nodes).
-    pub replacement: Hugr,
+    replacement: Hugr,
     /// A map from (target ports of edges from the Input node of `replacement`) to (target ports of
     /// edges from nodes not in `removal` to nodes in `removal`).
-    pub nu_inp: HashMap<(Node, Port), (Node, Port)>,
+    nu_inp: HashMap<(Node, Port), (Node, Port)>,
     /// A map from (target ports of edges from nodes in `removal` to nodes not in `removal`) to
     /// (input ports of the Output node of `replacement`).
-    pub nu_out: HashMap<(Node, Port), Port>,
+    nu_out: HashMap<(Node, Port), Port>,
 }
 
 impl SimpleReplacement {
@@ -44,12 +44,9 @@ impl SimpleReplacement {
         }
     }
 
-    /// Number of nodes added to the hugr by this replacement.
-    ///
-    /// This will be negative if the replacement is a reduction in node count and
-    /// positive otherwise.
-    pub fn node_count_delta(&self) -> isize {
-        (self.replacement.node_count() - 3) as isize - self.subgraph.nodes().len() as isize
+    /// The replacement hugr.
+    pub fn replacement(&self) -> &Hugr {
+        &self.replacement
     }
 
     /// Subgraph to be replaced.

--- a/src/hugr/views/sibling_subgraph.rs
+++ b/src/hugr/views/sibling_subgraph.rs
@@ -256,6 +256,11 @@ impl SiblingSubgraph {
         &self.nodes
     }
 
+    /// The number of nodes in the subgraph.
+    pub fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+
     /// The signature of the subgraph.
     pub fn signature(&self, hugr: &impl HugrView) -> FunctionType {
         let input = self


### PR DESCRIPTION
I have added a TODO on line 234 in `sibling_subgraph.rs`, I suspect there is a bug here that I will look into now.

EDIT: I've opened #518 but I won't have time to fix it until next sprint. This can be merged in independently of that bug.