### PR TITLE
Refactor: move apply_rewrite from Hugr to HugrMut

### DIFF
--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -206,14 +206,6 @@ pub type Direction = portgraph::Direction;
 
 /// Public API for HUGRs.
 impl Hugr {
-    /// Applies a rewrite to the graph.
-    pub fn apply_rewrite<R, E>(
-        &mut self,
-        rw: impl Rewrite<ApplyResult = R, Error = E>,
-    ) -> Result<R, E> {
-        rw.apply(self)
-    }
-
     /// Run resource inference and pass the closure into validation
     pub fn infer_and_validate(
         &mut self,

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -12,7 +12,7 @@ use crate::{Hugr, Port};
 
 use self::sealed::HugrMutInternals;
 
-use super::NodeMetadata;
+use super::{NodeMetadata, Rewrite};
 
 /// Functions for low-level building of a HUGR.
 pub trait HugrMut: HugrView + HugrMutInternals {
@@ -143,6 +143,14 @@ pub trait HugrMut: HugrView + HugrMutInternals {
     fn insert_from_view(&mut self, root: Node, other: &impl HugrView) -> Result<Node, HugrError> {
         self.valid_node(root)?;
         self.hugr_mut().insert_from_view(root, other)
+    }
+
+    /// Applies a rewrite to the graph.
+    fn apply_rewrite<R, E>(&mut self, rw: impl Rewrite<ApplyResult = R, Error = E>) -> Result<R, E>
+    where
+        Self: Sized,
+    {
+        rw.apply(self)
     }
 }
 

--- a/src/hugr/rewrite/outline_cfg.rs
+++ b/src/hugr/rewrite/outline_cfg.rs
@@ -230,6 +230,7 @@ mod test {
         build_cond_then_loop_cfg, build_conditional_in_loop_cfg,
     };
     use crate::extension::PRELUDE_REGISTRY;
+    use crate::hugr::HugrMut;
     use crate::ops::handle::NodeHandle;
     use crate::{HugrView, Node};
     use cool_asserts::assert_matches;
@@ -283,7 +284,7 @@ mod test {
         //            |  \-> right -/             |
         //             \---<---<---<---<---<--<---/
         // merge is unique predecessor of tail
-        let merge = h.input_neighbours(tail).exactly_one().unwrap();
+        let merge = h.input_neighbours(tail).exactly_one().ok().unwrap();
         let [left, right]: [Node; 2] = h.output_neighbours(head).collect_vec().try_into().unwrap();
         for n in [head, tail, merge] {
             assert_eq!(depth(&h, n), 1);
@@ -295,11 +296,14 @@ mod test {
         for n in blocks {
             assert_eq!(depth(&h, n), 3);
         }
-        let new_block = h.output_neighbours(entry).exactly_one().unwrap();
+        let new_block = h.output_neighbours(entry).exactly_one().ok().unwrap();
         for n in [entry, exit, tail, new_block] {
             assert_eq!(depth(&h, n), 1);
         }
-        assert_eq!(h.input_neighbours(tail).exactly_one().unwrap(), new_block);
+        assert_eq!(
+            h.input_neighbours(tail).exactly_one().ok().unwrap(),
+            new_block
+        );
         assert_eq!(
             h.output_neighbours(tail).take(2).collect::<HashSet<Node>>(),
             HashSet::from([exit, new_block])

--- a/src/hugr/rewrite/outline_cfg.rs
+++ b/src/hugr/rewrite/outline_cfg.rs
@@ -284,7 +284,7 @@ mod test {
         //            |  \-> right -/             |
         //             \---<---<---<---<---<--<---/
         // merge is unique predecessor of tail
-        let merge = h.input_neighbours(tail).exactly_one().ok().unwrap();
+        let merge = h.input_neighbours(tail).exactly_one().unwrap();
         let [left, right]: [Node; 2] = h.output_neighbours(head).collect_vec().try_into().unwrap();
         for n in [head, tail, merge] {
             assert_eq!(depth(&h, n), 1);
@@ -296,14 +296,11 @@ mod test {
         for n in blocks {
             assert_eq!(depth(&h, n), 3);
         }
-        let new_block = h.output_neighbours(entry).exactly_one().ok().unwrap();
+        let new_block = h.output_neighbours(entry).exactly_one().unwrap();
         for n in [entry, exit, tail, new_block] {
             assert_eq!(depth(&h, n), 1);
         }
-        assert_eq!(
-            h.input_neighbours(tail).exactly_one().ok().unwrap(),
-            new_block
-        );
+        assert_eq!(h.input_neighbours(tail).exactly_one().unwrap(), new_block);
         assert_eq!(
             h.output_neighbours(tail).take(2).collect::<HashSet<Node>>(),
             HashSet::from([exit, new_block])

--- a/src/hugr/rewrite/simple_replace.rs
+++ b/src/hugr/rewrite/simple_replace.rs
@@ -205,7 +205,7 @@ pub(in crate::hugr::rewrite) mod test {
     use crate::extension::prelude::BOOL_T;
     use crate::extension::{EMPTY_REG, PRELUDE_REGISTRY};
     use crate::hugr::views::HugrView;
-    use crate::hugr::{Hugr, Node};
+    use crate::hugr::{Hugr, HugrMut, Node};
     use crate::ops::OpTag;
     use crate::ops::{OpTrait, OpType};
     use crate::std_extensions::logic::test::and_op;

--- a/src/hugr/views/sibling_subgraph.rs
+++ b/src/hugr/views/sibling_subgraph.rs
@@ -506,6 +506,7 @@ mod tests {
             EMPTY_REG,
         },
         hugr::views::{HierarchyView, SiblingGraph},
+        hugr::HugrMut,
         ops::{
             handle::{FuncID, NodeHandle},
             OpType,


### PR DESCRIPTION
Given `apply_rewrite` just does a bounce dispatch to `Rewrite::apply`, rather than any actual work, this seems the right place to put it! (The alternative might be to drop `apply_rewrite` altogether but I think it's kinda nice and aids discovery)