### PR TITLE
HugrView: validate nodes, and remove Base

### DIFF
--- a/src/algorithm/nest_cfgs.rs
+++ b/src/algorithm/nest_cfgs.rs
@@ -449,7 +449,7 @@ pub(crate) mod test {
         let (split, merge, head, tail) = (split.node(), merge.node(), head.node(), tail.node());
         // There's no need to use a FlatRegionView here but we do so just to check
         // that we *can* (as we'll need to for "real" module Hugr's).
-        let v: SiblingGraph = SiblingGraph::new(&h, h.root());
+        let v: SiblingGraph = SiblingGraph::new(&h, h.root()).unwrap();
         let edge_classes = EdgeClassifier::get_edge_classes(&SimpleCfgView::new(&v));
         let [&left, &right] = edge_classes
             .keys()

--- a/src/algorithm/nest_cfgs.rs
+++ b/src/algorithm/nest_cfgs.rs
@@ -449,7 +449,7 @@ pub(crate) mod test {
         let (split, merge, head, tail) = (split.node(), merge.node(), head.node(), tail.node());
         // There's no need to use a FlatRegionView here but we do so just to check
         // that we *can* (as we'll need to for "real" module Hugr's).
-        let v: SiblingGraph = SiblingGraph::new(&h, h.root()).unwrap();
+        let v: SiblingGraph = SiblingGraph::try_new(&h, h.root()).unwrap();
         let edge_classes = EdgeClassifier::get_edge_classes(&SimpleCfgView::new(&v));
         let [&left, &right] = edge_classes
             .keys()

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -29,7 +29,7 @@ pub use self::views::HugrView;
 use crate::extension::{
     infer_extensions, ExtensionRegistry, ExtensionSet, ExtensionSolution, InferExtensionError,
 };
-use crate::ops::{OpTag, OpTrait, OpType};
+use crate::ops::{OpTag, OpTrait, OpType, DEFAULT_OPTYPE};
 use crate::types::{FunctionType, Signature};
 
 use delegate::delegate;
@@ -63,6 +63,12 @@ pub struct NodeType {
     /// The extensions that the signature has been specialised to
     input_extensions: Option<ExtensionSet>,
 }
+
+/// The default NodeType, with open extensions
+pub const DEFAULT_NODETYPE: NodeType = NodeType {
+    op: DEFAULT_OPTYPE,
+    input_extensions: None, // Default for any Option
+};
 
 impl NodeType {
     /// Create a new optype with some ExtensionSet

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -312,30 +312,6 @@ pub(crate) mod sealed {
         /// Returns the Hugr at the base of a chain of views.
         fn hugr_mut(&mut self) -> &mut Hugr;
 
-        /// Validates that a node is valid in the graph.
-        ///
-        /// Returns a [`HugrError::InvalidNode`] otherwise.
-        #[inline]
-        fn valid_node(&self, node: Node) -> Result<(), HugrError> {
-            match self.contains_node(node) {
-                true => Ok(()),
-                false => Err(HugrError::InvalidNode(node)),
-            }
-        }
-
-        /// Validates that a node is a valid root descendant in the graph.
-        ///
-        /// To include the root node use [`HugrMutInternals::valid_node`] instead.
-        ///
-        /// Returns a [`HugrError::InvalidNode`] otherwise.
-        #[inline]
-        fn valid_non_root(&self, node: Node) -> Result<(), HugrError> {
-            match self.root() == node {
-                true => Err(HugrError::InvalidNode(node)),
-                false => self.valid_node(node),
-            }
-        }
-
         /// Add a node to the graph, with the default conversion from OpType to NodeType
         fn add_op(&mut self, op: impl Into<OpType>) -> Node {
             self.hugr_mut().add_op(op)

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -100,7 +100,7 @@ impl<'a, 'b> ValidationContext<'a, 'b> {
     /// The results of this computation should be cached in `self.dominators`.
     /// We don't do it here to avoid mutable borrows.
     fn compute_dominator(&self, parent: Node) -> Dominators<Node> {
-        let region: SiblingGraph = SiblingGraph::new(self.hugr, parent);
+        let region: SiblingGraph = SiblingGraph::new(self.hugr, parent).unwrap();
         let entry_node = self.hugr.children(parent).next().unwrap();
         dominators::simple_fast(&region.as_petgraph(), entry_node)
     }
@@ -374,7 +374,7 @@ impl<'a, 'b> ValidationContext<'a, 'b> {
             return Ok(());
         };
 
-        let region: SiblingGraph = SiblingGraph::new(self.hugr, parent);
+        let region: SiblingGraph = SiblingGraph::new(self.hugr, parent).unwrap();
         let postorder = Topo::new(&region.as_petgraph());
         let nodes_visited = postorder
             .iter(&region.as_petgraph())

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -100,7 +100,7 @@ impl<'a, 'b> ValidationContext<'a, 'b> {
     /// The results of this computation should be cached in `self.dominators`.
     /// We don't do it here to avoid mutable borrows.
     fn compute_dominator(&self, parent: Node) -> Dominators<Node> {
-        let region: SiblingGraph = SiblingGraph::new(self.hugr, parent).unwrap();
+        let region: SiblingGraph = SiblingGraph::try_new(self.hugr, parent).unwrap();
         let entry_node = self.hugr.children(parent).next().unwrap();
         dominators::simple_fast(&region.as_petgraph(), entry_node)
     }
@@ -374,7 +374,7 @@ impl<'a, 'b> ValidationContext<'a, 'b> {
             return Ok(());
         };
 
-        let region: SiblingGraph = SiblingGraph::new(self.hugr, parent).unwrap();
+        let region: SiblingGraph = SiblingGraph::try_new(self.hugr, parent).unwrap();
         let postorder = Topo::new(&region.as_petgraph());
         let nodes_visited = postorder
             .iter(&region.as_petgraph())

--- a/src/hugr/views.rs
+++ b/src/hugr/views.rs
@@ -300,7 +300,7 @@ pub trait HierarchyView<'a>: HugrView + Sized {
     ///
     /// # Errors
     /// Returns [`HugrError::InvalidNode`] if the root isn't a node of the required [OpTag]
-    fn new(hugr: &'a impl HugrView, root: Node) -> Result<Self, HugrError>;
+    fn try_new(hugr: &'a impl HugrView, root: Node) -> Result<Self, HugrError>;
 }
 
 impl<T> HugrView for T

--- a/src/hugr/views.rs
+++ b/src/hugr/views.rs
@@ -300,11 +300,8 @@ pub trait HugrView: sealed::HugrInternals {
 
 /// A common trait for views of a HUGR hierarchical subgraph.
 pub trait HierarchyView<'a>: HugrView {
-    /// The base from which the subgraph is derived.
-    type Base;
-
     /// Create a hierarchical view of a HUGR given a root node.
-    fn new(hugr: &'a Self::Base, root: Node) -> Self;
+    fn new(hugr: &'a impl HugrView, root: Node) -> Self;
 }
 
 impl<T> HugrView for T

--- a/src/hugr/views.rs
+++ b/src/hugr/views.rs
@@ -132,14 +132,10 @@ pub trait HugrView: sealed::HugrInternals {
     /// Returns the metadata associated with a node.
     #[inline]
     fn get_metadata(&self, node: Node) -> &NodeMetadata {
-        // The other way to do it - exploit the UnmanagedDenseMap's get() returning &default
-        let md = &self.base_hugr().metadata;
-
-        let idx = match self.contains_node(node) {
-            true => node.index,
-            false => portgraph::NodeIndex::new(md.capacity() + 1),
-        };
-        md.get(idx)
+        match self.contains_node(node) {
+            true => self.base_hugr().metadata.get(node.index),
+            false => &NodeMetadata::Null,
+        }
     }
 
     /// Returns the number of nodes in the hugr.

--- a/src/hugr/views.rs
+++ b/src/hugr/views.rs
@@ -299,9 +299,12 @@ pub trait HugrView: sealed::HugrInternals {
 }
 
 /// A common trait for views of a HUGR hierarchical subgraph.
-pub trait HierarchyView<'a>: HugrView {
+pub trait HierarchyView<'a>: HugrView + Sized {
     /// Create a hierarchical view of a HUGR given a root node.
-    fn new(hugr: &'a impl HugrView, root: Node) -> Self;
+    ///
+    /// # Errors
+    /// Returns [`HugrError::InvalidNode`] if the root isn't a node of the required [OpTag]
+    fn new(hugr: &'a impl HugrView, root: Node) -> Result<Self, HugrError>;
 }
 
 impl<T> HugrView for T

--- a/src/hugr/views/descendants.rs
+++ b/src/hugr/views/descendants.rs
@@ -7,9 +7,9 @@ use portgraph::{LinkView, MultiPortGraph, PortIndex, PortView};
 
 use crate::ops::handle::NodeHandle;
 use crate::ops::OpTrait;
-use crate::{hugr::NodeType, hugr::OpType, Direction, Hugr, Node, Port};
+use crate::{Direction, Hugr, Node, Port};
 
-use super::{sealed::HugrInternals, HierarchyView, HugrView, NodeMetadata};
+use super::{sealed::HugrInternals, HierarchyView, HugrView};
 
 type RegionGraph<'g> = portgraph::view::Region<'g, &'g MultiPortGraph>;
 
@@ -92,29 +92,6 @@ where
     #[inline]
     fn contains_node(&self, node: Node) -> bool {
         self.graph.contains_node(node.index)
-    }
-
-    #[inline]
-    fn get_parent(&self, node: Node) -> Option<Node> {
-        self.hugr
-            .get_parent(node)
-            .filter(|&parent| self.graph.contains_node(parent.index))
-            .map(Into::into)
-    }
-
-    #[inline]
-    fn get_optype(&self, node: Node) -> &OpType {
-        self.hugr.get_optype(node)
-    }
-
-    #[inline]
-    fn get_nodetype(&self, node: Node) -> &NodeType {
-        self.hugr.get_nodetype(node)
-    }
-
-    #[inline]
-    fn get_metadata(&self, node: Node) -> &NodeMetadata {
-        self.hugr.get_metadata(node)
     }
 
     #[inline]

--- a/src/hugr/views/descendants.rs
+++ b/src/hugr/views/descendants.rs
@@ -165,7 +165,7 @@ impl<'a, Root> HierarchyView<'a> for DescendantsGraph<'a, Root>
 where
     Root: NodeHandle,
 {
-    fn new(hugr: &'a impl HugrView, root: Node) -> Result<Self, HugrError> {
+    fn try_new(hugr: &'a impl HugrView, root: Node) -> Result<Self, HugrError> {
         hugr.valid_node(root)?;
         let root_tag = hugr.get_optype(root).tag();
         if !Root::TAG.is_superset(root_tag) {
@@ -257,7 +257,7 @@ pub(super) mod test {
     fn full_region() -> Result<(), Box<dyn std::error::Error>> {
         let (hugr, def, inner) = make_module_hgr()?;
 
-        let region: DescendantsGraph = DescendantsGraph::new(&hugr, def)?;
+        let region: DescendantsGraph = DescendantsGraph::try_new(&hugr, def)?;
 
         assert_eq!(region.node_count(), 7);
         assert!(region.nodes().all(|n| n == def
@@ -269,7 +269,7 @@ pub(super) mod test {
             region.get_function_type(),
             Some(&FunctionType::new(type_row![NAT, QB], type_row![NAT, QB]))
         );
-        let inner_region: DescendantsGraph = DescendantsGraph::new(&hugr, inner)?;
+        let inner_region: DescendantsGraph = DescendantsGraph::try_new(&hugr, inner)?;
         assert_eq!(
             inner_region.get_function_type(),
             Some(&FunctionType::new(type_row![NAT], type_row![NAT]))

--- a/src/hugr/views/descendants.rs
+++ b/src/hugr/views/descendants.rs
@@ -25,6 +25,7 @@ type RegionGraph<'g> = portgraph::view::Region<'g, &'g MultiPortGraph>;
 /// used interchangeably with [`SiblingGraph`].
 ///
 /// [`SiblingGraph`]: super::SiblingGraph
+#[derive(Clone)]
 pub struct DescendantsGraph<'g, Root = Node> {
     /// The chosen root node.
     root: Node,
@@ -37,15 +38,6 @@ pub struct DescendantsGraph<'g, Root = Node> {
 
     /// The operation handle of the root node.
     _phantom: std::marker::PhantomData<Root>,
-}
-
-impl<'g, Root> Clone for DescendantsGraph<'g, Root>
-where
-    Root: NodeHandle,
-{
-    fn clone(&self) -> Self {
-        DescendantsGraph::new(self.hugr, self.root)
-    }
 }
 
 impl<'g, Root> HugrView for DescendantsGraph<'g, Root>

--- a/src/hugr/views/sibling.rs
+++ b/src/hugr/views/sibling.rs
@@ -179,13 +179,8 @@ where
     Root: NodeHandle,
 {
     fn new(hugr: &'a impl HugrView, root: Node) -> Result<Self, HugrError> {
-        println!("ALAN checking node {:?} against {}", root, Root::TAG);
         hugr.valid_node(root)?;
         if !Root::TAG.is_superset(hugr.get_optype(root).tag()) {
-            println!(
-                "ALAN check failed, optype was {}",
-                hugr.get_optype(root).tag()
-            );
             return Err(HugrError::InvalidNode(root));
         }
         let hugr = hugr.base_hugr();

--- a/src/hugr/views/sibling.rs
+++ b/src/hugr/views/sibling.rs
@@ -178,7 +178,7 @@ impl<'a, Root> HierarchyView<'a> for SiblingGraph<'a, Root>
 where
     Root: NodeHandle,
 {
-    fn new(hugr: &'a impl HugrView, root: Node) -> Result<Self, HugrError> {
+    fn try_new(hugr: &'a impl HugrView, root: Node) -> Result<Self, HugrError> {
         hugr.valid_node(root)?;
         if !Root::TAG.is_superset(hugr.get_optype(root).tag()) {
             return Err(HugrError::InvalidNode(root));
@@ -231,7 +231,7 @@ mod test {
     fn flat_region() -> Result<(), Box<dyn std::error::Error>> {
         let (hugr, def, inner) = make_module_hgr()?;
 
-        let region: SiblingGraph = SiblingGraph::new(&hugr, def)?;
+        let region: SiblingGraph = SiblingGraph::try_new(&hugr, def)?;
 
         assert_eq!(region.node_count(), 5);
         assert!(region
@@ -255,11 +255,11 @@ mod test {
         let h = module_builder.finish_hugr(&PRELUDE_REGISTRY)?;
         let sub_dfg = sub_dfg.node();
         // Can create a view from a child or grandchild of a hugr:
-        let dfg_view: SiblingGraph<'_, DfgID> = SiblingGraph::new(&h, sub_dfg)?;
-        let fun_view: SiblingGraph<'_, FuncID<true>> = SiblingGraph::new(&h, fun.node())?;
+        let dfg_view: SiblingGraph<'_, DfgID> = SiblingGraph::try_new(&h, sub_dfg)?;
+        let fun_view: SiblingGraph<'_, FuncID<true>> = SiblingGraph::try_new(&h, fun.node())?;
         assert_eq!(fun_view.children(sub_dfg).len(), 0);
         // And can create a view from a child of another SiblingGraph
-        let nested_dfg_view: SiblingGraph<'_, DfgID> = SiblingGraph::new(&fun_view, sub_dfg)?;
+        let nested_dfg_view: SiblingGraph<'_, DfgID> = SiblingGraph::try_new(&fun_view, sub_dfg)?;
 
         // Both ways work:
         let just_io = vec![
@@ -274,9 +274,10 @@ mod test {
         }
 
         // But cannot create a view directly as a grandchild of another SiblingGraph
-        let root_view: SiblingGraph<'_, ModuleRootID> = SiblingGraph::new(&h, h.root()).unwrap();
+        let root_view: SiblingGraph<'_, ModuleRootID> =
+            SiblingGraph::try_new(&h, h.root()).unwrap();
         assert_eq!(
-            SiblingGraph::<'_, DfgID>::new(&root_view, sub_dfg.node()).err(),
+            SiblingGraph::<'_, DfgID>::try_new(&root_view, sub_dfg.node()).err(),
             Some(HugrError::InvalidNode(sub_dfg.node()))
         );
 

--- a/src/hugr/views/sibling.rs
+++ b/src/hugr/views/sibling.rs
@@ -34,7 +34,7 @@ pub struct SiblingGraph<'g, Root = Node> {
     /// The filtered portgraph encoding the adjacency structure of the HUGR.
     graph: FlatRegionGraph<'g>,
 
-    /// View onto the underlying Hugr which this graph filters
+    /// The underlying Hugr onto which this view is a filter
     hugr: &'g Hugr,
 
     /// The operation type of the root node.

--- a/src/hugr/views/sibling.rs
+++ b/src/hugr/views/sibling.rs
@@ -25,6 +25,7 @@ type FlatRegionGraph<'g> = portgraph::view::FlatRegion<'g, &'g MultiPortGraph>;
 /// used interchangeably with [`DescendantsGraph`].
 ///
 /// [`DescendantsGraph`]: super::DescendantsGraph
+#[derive(Clone)]
 pub struct SiblingGraph<'g, Root = Node> {
     /// The chosen root node.
     root: Node,
@@ -37,15 +38,6 @@ pub struct SiblingGraph<'g, Root = Node> {
 
     /// The operation type of the root node.
     _phantom: std::marker::PhantomData<Root>,
-}
-
-impl<'g, Root> Clone for SiblingGraph<'g, Root>
-where
-    Root: NodeHandle,
-{
-    fn clone(&self) -> Self {
-        SiblingGraph::new(self.hugr, self.root)
-    }
 }
 
 impl<'g, Root> HugrView for SiblingGraph<'g, Root>

--- a/src/hugr/views/sibling.rs
+++ b/src/hugr/views/sibling.rs
@@ -8,9 +8,9 @@ use portgraph::{LinkView, MultiPortGraph, PortIndex, PortView};
 
 use crate::ops::handle::NodeHandle;
 use crate::ops::OpTrait;
-use crate::{hugr::NodeType, hugr::OpType, Direction, Hugr, Node, Port};
+use crate::{Direction, Hugr, Node, Port};
 
-use super::{sealed::HugrInternals, HierarchyView, HugrView, NodeMetadata};
+use super::{sealed::HugrInternals, HierarchyView, HugrView};
 
 type FlatRegionGraph<'g> = portgraph::view::FlatRegion<'g, &'g MultiPortGraph>;
 
@@ -92,26 +92,6 @@ where
     #[inline]
     fn contains_node(&self, node: Node) -> bool {
         self.graph.contains_node(node.index)
-    }
-
-    #[inline]
-    fn get_parent(&self, node: Node) -> Option<Node> {
-        self.hugr.get_parent(node).filter(|&n| n == self.root)
-    }
-
-    #[inline]
-    fn get_optype(&self, node: Node) -> &OpType {
-        self.hugr.get_optype(node)
-    }
-
-    #[inline]
-    fn get_nodetype(&self, node: Node) -> &NodeType {
-        self.hugr.get_nodetype(node)
-    }
-
-    #[inline]
-    fn get_metadata(&self, node: Node) -> &NodeMetadata {
-        self.hugr.get_metadata(node)
     }
 
     #[inline]

--- a/src/hugr/views/sibling_subgraph.rs
+++ b/src/hugr/views/sibling_subgraph.rs
@@ -639,9 +639,9 @@ mod tests {
     #[test]
     fn construct_subgraph() -> Result<(), InvalidSubgraph> {
         let (hugr, func_root) = build_hugr().unwrap();
-        let sibling_graph: SiblingGraph<'_> = SiblingGraph::new(&hugr, func_root).unwrap();
+        let sibling_graph: SiblingGraph<'_> = SiblingGraph::try_new(&hugr, func_root).unwrap();
         let from_root = SiblingSubgraph::from_sibling_graph(&sibling_graph)?;
-        let region: SiblingGraph<'_> = SiblingGraph::new(&hugr, func_root).unwrap();
+        let region: SiblingGraph<'_> = SiblingGraph::try_new(&hugr, func_root).unwrap();
         let from_region = SiblingSubgraph::from_sibling_graph(&region)?;
         assert_eq!(
             from_root.get_parent(&sibling_graph),
@@ -657,7 +657,7 @@ mod tests {
     #[test]
     fn construct_simple_replacement() -> Result<(), InvalidSubgraph> {
         let (mut hugr, func_root) = build_hugr().unwrap();
-        let func: SiblingGraph<'_, FuncID<true>> = SiblingGraph::new(&hugr, func_root).unwrap();
+        let func: SiblingGraph<'_, FuncID<true>> = SiblingGraph::try_new(&hugr, func_root).unwrap();
         let sub = SiblingSubgraph::try_new_dataflow_subgraph(&func)?;
 
         let empty_dfg = {
@@ -680,7 +680,7 @@ mod tests {
     #[test]
     fn test_signature() -> Result<(), InvalidSubgraph> {
         let (hugr, dfg) = build_hugr().unwrap();
-        let func: SiblingGraph<'_, FuncID<true>> = SiblingGraph::new(&hugr, dfg).unwrap();
+        let func: SiblingGraph<'_, FuncID<true>> = SiblingGraph::try_new(&hugr, dfg).unwrap();
         let sub = SiblingSubgraph::try_new_dataflow_subgraph(&func)?;
         assert_eq!(
             sub.signature(&func),
@@ -692,7 +692,7 @@ mod tests {
     #[test]
     fn construct_simple_replacement_invalid_signature() -> Result<(), InvalidSubgraph> {
         let (hugr, dfg) = build_hugr().unwrap();
-        let func: SiblingGraph<'_> = SiblingGraph::new(&hugr, dfg).unwrap();
+        let func: SiblingGraph<'_> = SiblingGraph::try_new(&hugr, dfg).unwrap();
         let sub = SiblingSubgraph::from_sibling_graph(&func)?;
 
         let empty_dfg = {
@@ -711,7 +711,7 @@ mod tests {
     #[test]
     fn convex_subgraph() {
         let (hugr, func_root) = build_hugr().unwrap();
-        let func: SiblingGraph<'_, FuncID<true>> = SiblingGraph::new(&hugr, func_root).unwrap();
+        let func: SiblingGraph<'_, FuncID<true>> = SiblingGraph::try_new(&hugr, func_root).unwrap();
         assert_eq!(
             SiblingSubgraph::try_new_dataflow_subgraph(&func)
                 .unwrap()
@@ -725,7 +725,7 @@ mod tests {
     fn convex_subgraph_2() {
         let (hugr, func_root) = build_hugr().unwrap();
         let (inp, out) = hugr.children(func_root).take(2).collect_tuple().unwrap();
-        let func: SiblingGraph<'_> = SiblingGraph::new(&hugr, func_root).unwrap();
+        let func: SiblingGraph<'_> = SiblingGraph::try_new(&hugr, func_root).unwrap();
         // All graph except input/output nodes
         SiblingSubgraph::try_new(
             hugr.node_outputs(inp)
@@ -743,7 +743,7 @@ mod tests {
     #[test]
     fn degen_boundary() {
         let (hugr, func_root) = build_hugr().unwrap();
-        let func: SiblingGraph<'_> = SiblingGraph::new(&hugr, func_root).unwrap();
+        let func: SiblingGraph<'_> = SiblingGraph::try_new(&hugr, func_root).unwrap();
         let (inp, _) = hugr.children(func_root).take(2).collect_tuple().unwrap();
         let first_cx_edge = hugr.node_outputs(inp).next().unwrap();
         // All graph but one edge
@@ -760,7 +760,7 @@ mod tests {
     #[test]
     fn non_convex_subgraph() {
         let (hugr, func_root) = build_hugr().unwrap();
-        let func: SiblingGraph<'_> = SiblingGraph::new(&hugr, func_root).unwrap();
+        let func: SiblingGraph<'_> = SiblingGraph::try_new(&hugr, func_root).unwrap();
         let (inp, out) = hugr.children(func_root).take(2).collect_tuple().unwrap();
         let first_cx_edge = hugr.node_outputs(inp).next().unwrap();
         let snd_cx_edge = hugr.node_inputs(out).next().unwrap();
@@ -779,7 +779,7 @@ mod tests {
     fn preserve_signature() {
         let (hugr, func_root) = build_hugr_classical().unwrap();
         let func_graph: SiblingGraph<'_, FuncID<true>> =
-            SiblingGraph::new(&hugr, func_root).unwrap();
+            SiblingGraph::try_new(&hugr, func_root).unwrap();
         let func = SiblingSubgraph::try_new_dataflow_subgraph(&func_graph).unwrap();
         let OpType::FuncDefn(func_defn) = hugr.get_optype(func_root) else {
             panic!()

--- a/src/hugr/views/sibling_subgraph.rs
+++ b/src/hugr/views/sibling_subgraph.rs
@@ -579,9 +579,9 @@ mod tests {
     #[test]
     fn construct_subgraph() -> Result<(), InvalidSubgraph> {
         let (hugr, func_root) = build_hugr().unwrap();
-        let sibling_graph: SiblingGraph<'_> = SiblingGraph::new(&hugr, func_root);
+        let sibling_graph: SiblingGraph<'_> = SiblingGraph::new(&hugr, func_root).unwrap();
         let from_root = SiblingSubgraph::from_sibling_graph(&sibling_graph)?;
-        let region: SiblingGraph<'_> = SiblingGraph::new(&hugr, func_root);
+        let region: SiblingGraph<'_> = SiblingGraph::new(&hugr, func_root).unwrap();
         let from_region = SiblingSubgraph::from_sibling_graph(&region)?;
         assert_eq!(
             from_root.get_parent(&sibling_graph),
@@ -597,7 +597,7 @@ mod tests {
     #[test]
     fn construct_simple_replacement() -> Result<(), InvalidSubgraph> {
         let (mut hugr, func_root) = build_hugr().unwrap();
-        let func: SiblingGraph<'_, FuncID<true>> = SiblingGraph::new(&hugr, func_root);
+        let func: SiblingGraph<'_, FuncID<true>> = SiblingGraph::new(&hugr, func_root).unwrap();
         let sub = SiblingSubgraph::try_new_dataflow_subgraph(&func)?;
 
         let empty_dfg = {
@@ -620,7 +620,7 @@ mod tests {
     #[test]
     fn test_signature() -> Result<(), InvalidSubgraph> {
         let (hugr, dfg) = build_hugr().unwrap();
-        let func: SiblingGraph<'_, FuncID<true>> = SiblingGraph::new(&hugr, dfg);
+        let func: SiblingGraph<'_, FuncID<true>> = SiblingGraph::new(&hugr, dfg).unwrap();
         let sub = SiblingSubgraph::try_new_dataflow_subgraph(&func)?;
         assert_eq!(
             sub.signature(&func),
@@ -632,7 +632,7 @@ mod tests {
     #[test]
     fn construct_simple_replacement_invalid_signature() -> Result<(), InvalidSubgraph> {
         let (hugr, dfg) = build_hugr().unwrap();
-        let func: SiblingGraph<'_> = SiblingGraph::new(&hugr, dfg);
+        let func: SiblingGraph<'_> = SiblingGraph::new(&hugr, dfg).unwrap();
         let sub = SiblingSubgraph::from_sibling_graph(&func)?;
 
         let empty_dfg = {
@@ -651,7 +651,7 @@ mod tests {
     #[test]
     fn convex_subgraph() {
         let (hugr, func_root) = build_hugr().unwrap();
-        let func: SiblingGraph<'_, FuncID<true>> = SiblingGraph::new(&hugr, func_root);
+        let func: SiblingGraph<'_, FuncID<true>> = SiblingGraph::new(&hugr, func_root).unwrap();
         assert_eq!(
             SiblingSubgraph::try_new_dataflow_subgraph(&func)
                 .unwrap()
@@ -665,7 +665,7 @@ mod tests {
     fn convex_subgraph_2() {
         let (hugr, func_root) = build_hugr().unwrap();
         let (inp, out) = hugr.children(func_root).take(2).collect_tuple().unwrap();
-        let func: SiblingGraph<'_> = SiblingGraph::new(&hugr, func_root);
+        let func: SiblingGraph<'_> = SiblingGraph::new(&hugr, func_root).unwrap();
         // All graph except input/output nodes
         SiblingSubgraph::try_new(
             hugr.node_outputs(inp)
@@ -683,7 +683,7 @@ mod tests {
     #[test]
     fn degen_boundary() {
         let (hugr, func_root) = build_hugr().unwrap();
-        let func: SiblingGraph<'_> = SiblingGraph::new(&hugr, func_root);
+        let func: SiblingGraph<'_> = SiblingGraph::new(&hugr, func_root).unwrap();
         let (inp, _) = hugr.children(func_root).take(2).collect_tuple().unwrap();
         let first_cx_edge = hugr.node_outputs(inp).next().unwrap();
         // All graph but one edge
@@ -700,7 +700,7 @@ mod tests {
     #[test]
     fn non_convex_subgraph() {
         let (hugr, func_root) = build_hugr().unwrap();
-        let func: SiblingGraph<'_> = SiblingGraph::new(&hugr, func_root);
+        let func: SiblingGraph<'_> = SiblingGraph::new(&hugr, func_root).unwrap();
         let (inp, out) = hugr.children(func_root).take(2).collect_tuple().unwrap();
         let first_cx_edge = hugr.node_outputs(inp).next().unwrap();
         let snd_cx_edge = hugr.node_inputs(out).next().unwrap();
@@ -718,7 +718,8 @@ mod tests {
     #[test]
     fn preserve_signature() {
         let (hugr, func_root) = build_hugr_classical().unwrap();
-        let func_graph: SiblingGraph<'_, FuncID<true>> = SiblingGraph::new(&hugr, func_root);
+        let func_graph: SiblingGraph<'_, FuncID<true>> =
+            SiblingGraph::new(&hugr, func_root).unwrap();
         let func = SiblingSubgraph::try_new_dataflow_subgraph(&func_graph).unwrap();
         let OpType::FuncDefn(func_defn) = hugr.get_optype(func_root) else {
             panic!()

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -52,9 +52,12 @@ pub enum OpType {
     Case,
 }
 
+/// The default OpType (as returned by [Default::default])
+pub const DEFAULT_OPTYPE: OpType = OpType::Module(Module);
+
 impl Default for OpType {
     fn default() -> Self {
-        Module.into()
+        DEFAULT_OPTYPE
     }
 }
 


### PR DESCRIPTION
* Move `valid_node` and `valid_non_root` from `HugrMutInternals` into HugrView
* HugrView provides default implementations of `get_parent`, `get_nodetype`, `get_optype` and `get_metadata` that perform node-validity checks; remove the other implementations.
* Add DEFAULT_NODETYPE + DEFAULT_OPTYPE constants
*  Change HierarchyView::new->try_new, add explicit checks that root node is valid in the base view.
* Remove manual implementations of Clone for SiblingGraph + DescendantsGraph, just derive
* Remove the `Base` parameter to SiblingGraph/DescendantsGraph - instead parameterize only constructor (via `: impl`) and cache the base's `.base_hugr()` rather than the base.
