### PR TITLE
fix: Use given input extensions in `define_function`

### DIFF
--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -89,7 +89,7 @@ pub trait Container {
         let f_node = self.add_child_node(NodeType::new(
             ops::FuncDefn {
                 name: name.into(),
-                signature: signature.clone().into(),
+                signature: signature.signature.clone(),
             },
             signature.input_extensions.clone(),
         ))?;

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -86,10 +86,13 @@ pub trait Container {
         name: impl Into<String>,
         signature: Signature,
     ) -> Result<FunctionBuilder<&mut Hugr>, BuildError> {
-        let f_node = self.add_child_op(ops::FuncDefn {
-            name: name.into(),
-            signature: signature.clone().into(),
-        })?;
+        let f_node = self.add_child_node(NodeType::new(
+            ops::FuncDefn {
+                name: name.into(),
+                signature: signature.clone().into(),
+            },
+            signature.input_extensions.clone(),
+        ))?;
 
         let db = DFGBuilder::create_with_io(
             self.hugr_mut(),


### PR DESCRIPTION
`define_function` is passed a `NodeType` which contains information about input extensions. It uses this to inform the input extensions of I/O nodes, but wasn't using it for the parent node until now.