### PR TITLE
feat: Const nodes are built with some extension requirements

### DIFF
--- a/src/algorithm/nest_cfgs.rs
+++ b/src/algorithm/nest_cfgs.rs
@@ -428,8 +428,8 @@ pub(crate) mod test {
         //               \-> right -/             \-<--<-/
         let mut cfg_builder = CFGBuilder::new(FunctionType::new(type_row![NAT], type_row![NAT]))?;
 
-        let pred_const = cfg_builder.add_constant(Const::simple_predicate(0, 2))?; // Nothing here cares which
-        let const_unit = cfg_builder.add_constant(Const::simple_unary_predicate())?;
+        let pred_const = cfg_builder.add_constant(Const::simple_predicate(0, 2), None)?; // Nothing here cares which
+        let const_unit = cfg_builder.add_constant(Const::simple_unary_predicate(), None)?;
 
         let entry = n_identity(
             cfg_builder.simple_entry_builder(type_row![NAT], 1, ExtensionSet::new())?,
@@ -675,8 +675,8 @@ pub(crate) mod test {
         separate: bool,
     ) -> Result<(Hugr, BasicBlockID, BasicBlockID), BuildError> {
         let mut cfg_builder = CFGBuilder::new(FunctionType::new(type_row![NAT], type_row![NAT]))?;
-        let pred_const = cfg_builder.add_constant(Const::simple_predicate(0, 2))?; // Nothing here cares which
-        let const_unit = cfg_builder.add_constant(Const::simple_unary_predicate())?;
+        let pred_const = cfg_builder.add_constant(Const::simple_predicate(0, 2), None)?; // Nothing here cares which
+        let const_unit = cfg_builder.add_constant(Const::simple_unary_predicate(), None)?;
 
         let entry = n_identity(
             cfg_builder.simple_entry_builder(type_row![NAT], 2, ExtensionSet::new())?,
@@ -711,8 +711,8 @@ pub(crate) mod test {
 
         let mut cfg_builder = CFGBuilder::new(FunctionType::new(type_row![NAT], type_row![NAT]))?;
 
-        let pred_const = cfg_builder.add_constant(Const::simple_predicate(0, 2))?; // Nothing here cares which
-        let const_unit = cfg_builder.add_constant(Const::simple_unary_predicate())?;
+        let pred_const = cfg_builder.add_constant(Const::simple_predicate(0, 2), None)?; // Nothing here cares which
+        let const_unit = cfg_builder.add_constant(Const::simple_unary_predicate(), None)?;
 
         let entry = n_identity(
             cfg_builder.simple_entry_builder(type_row![NAT], 1, ExtensionSet::new())?,

--- a/src/algorithm/nest_cfgs.rs
+++ b/src/algorithm/nest_cfgs.rs
@@ -428,8 +428,10 @@ pub(crate) mod test {
         //               \-> right -/             \-<--<-/
         let mut cfg_builder = CFGBuilder::new(FunctionType::new(type_row![NAT], type_row![NAT]))?;
 
-        let pred_const = cfg_builder.add_constant(Const::simple_predicate(0, 2), None)?; // Nothing here cares which
-        let const_unit = cfg_builder.add_constant(Const::simple_unary_predicate(), None)?;
+        let pred_const =
+            cfg_builder.add_constant(Const::simple_predicate(0, 2), ExtensionSet::new())?; // Nothing here cares which
+        let const_unit =
+            cfg_builder.add_constant(Const::simple_unary_predicate(), ExtensionSet::new())?;
 
         let entry = n_identity(
             cfg_builder.simple_entry_builder(type_row![NAT], 1, ExtensionSet::new())?,
@@ -675,8 +677,10 @@ pub(crate) mod test {
         separate: bool,
     ) -> Result<(Hugr, BasicBlockID, BasicBlockID), BuildError> {
         let mut cfg_builder = CFGBuilder::new(FunctionType::new(type_row![NAT], type_row![NAT]))?;
-        let pred_const = cfg_builder.add_constant(Const::simple_predicate(0, 2), None)?; // Nothing here cares which
-        let const_unit = cfg_builder.add_constant(Const::simple_unary_predicate(), None)?;
+        let pred_const =
+            cfg_builder.add_constant(Const::simple_predicate(0, 2), ExtensionSet::new())?; // Nothing here cares which
+        let const_unit =
+            cfg_builder.add_constant(Const::simple_unary_predicate(), ExtensionSet::new())?;
 
         let entry = n_identity(
             cfg_builder.simple_entry_builder(type_row![NAT], 2, ExtensionSet::new())?,
@@ -711,8 +715,10 @@ pub(crate) mod test {
 
         let mut cfg_builder = CFGBuilder::new(FunctionType::new(type_row![NAT], type_row![NAT]))?;
 
-        let pred_const = cfg_builder.add_constant(Const::simple_predicate(0, 2), None)?; // Nothing here cares which
-        let const_unit = cfg_builder.add_constant(Const::simple_unary_predicate(), None)?;
+        let pred_const =
+            cfg_builder.add_constant(Const::simple_predicate(0, 2), ExtensionSet::new())?; // Nothing here cares which
+        let const_unit =
+            cfg_builder.add_constant(Const::simple_unary_predicate(), ExtensionSet::new())?;
 
         let entry = n_identity(
             cfg_builder.simple_entry_builder(type_row![NAT], 1, ExtensionSet::new())?,

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -62,10 +62,7 @@ pub trait Container {
         Ok(Wire::new(src, src_port))
     }
 
-    /// Add a constant value to the container and return a handle to it. The
-    /// `provenance` argument says which extension the type and value of the
-    /// constant comes from. If it is `None`, then the constant must be a built
-    /// in type.
+    /// Add a constant value to the container and return a handle to it.
     ///
     /// # Errors
     ///

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -17,7 +17,7 @@ use crate::{
     types::EdgeKind,
 };
 
-use crate::extension::{ExtensionId, ExtensionRegistry, ExtensionSet, PRELUDE_REGISTRY};
+use crate::extension::{ExtensionRegistry, ExtensionSet, PRELUDE_REGISTRY};
 use crate::types::{FunctionType, Signature, Type, TypeRow};
 
 use itertools::Itertools;
@@ -74,12 +74,8 @@ pub trait Container {
     fn add_constant(
         &mut self,
         constant: ops::Const,
-        provenance: Option<ExtensionId>,
+        extensions: ExtensionSet,
     ) -> Result<ConstID, BuildError> {
-        let mut extensions = ExtensionSet::new();
-        if let Some(ext) = provenance {
-            extensions.insert(&ext);
-        };
         let const_n = self.add_child_node(NodeType::new(constant, extensions))?;
 
         Ok(const_n.into())
@@ -381,9 +377,9 @@ pub trait Dataflow: Container {
     fn add_load_const(
         &mut self,
         constant: ops::Const,
-        provenance: Option<ExtensionId>,
+        extensions: ExtensionSet,
     ) -> Result<Wire, BuildError> {
-        let cid = self.add_constant(constant, provenance)?;
+        let cid = self.add_constant(constant, extensions)?;
         self.load_const(&cid)
     }
 

--- a/src/builder/cfg.rs
+++ b/src/builder/cfg.rs
@@ -383,7 +383,8 @@ mod test {
         let mut middle_b = cfg_builder
             .simple_block_builder(FunctionType::new(type_row![NAT], type_row![NAT]), 1)?;
         let middle = {
-            let c = middle_b.add_load_const(ops::Const::simple_unary_predicate(), None)?;
+            let c = middle_b
+                .add_load_const(ops::Const::simple_unary_predicate(), ExtensionSet::new())?;
             let [inw] = middle_b.input_wires_arr();
             middle_b.finish_with_outputs(c, [inw])?
         };

--- a/src/builder/cfg.rs
+++ b/src/builder/cfg.rs
@@ -383,7 +383,7 @@ mod test {
         let mut middle_b = cfg_builder
             .simple_block_builder(FunctionType::new(type_row![NAT], type_row![NAT]), 1)?;
         let middle = {
-            let c = middle_b.add_load_const(ops::Const::simple_unary_predicate())?;
+            let c = middle_b.add_load_const(ops::Const::simple_unary_predicate(), None)?;
             let [inw] = middle_b.input_wires_arr();
             middle_b.finish_with_outputs(c, [inw])?
         };

--- a/src/builder/conditional.rs
+++ b/src/builder/conditional.rs
@@ -127,9 +127,9 @@ impl<B: AsMut<Hugr> + AsRef<Hugr>> ConditionalBuilder<B> {
             // add case before any existing subsequent cases
             if let Some(&sibling_node) = self.case_nodes[case + 1..].iter().flatten().next() {
                 // TODO: Allow this to be non-pure
-                self.hugr_mut().add_op_before(sibling_node, case_op)?
+                self.hugr_mut().add_node_before(sibling_node, NodeType::open_extensions(case_op))?
             } else {
-                self.add_child_op(case_op)?
+                self.add_child_node(NodeType::open_extensions(case_op))?
             };
 
         self.case_nodes[case] = Some(case_node);
@@ -243,7 +243,7 @@ mod test {
                 "main",
                 FunctionType::new(type_row![NAT], type_row![NAT]).pure(),
             )?;
-            let tru_const = fbuild.add_constant(Const::true_val())?;
+            let tru_const = fbuild.add_constant(Const::true_val(), None)?;
             let _fdef = {
                 let const_wire = fbuild.load_const(&tru_const)?;
                 let [int] = fbuild.input_wires_arr();

--- a/src/builder/conditional.rs
+++ b/src/builder/conditional.rs
@@ -243,7 +243,7 @@ mod test {
                 "main",
                 FunctionType::new(type_row![NAT], type_row![NAT]).pure(),
             )?;
-            let tru_const = fbuild.add_constant(Const::true_val(), None)?;
+            let tru_const = fbuild.add_constant(Const::true_val(), ExtensionSet::new())?;
             let _fdef = {
                 let const_wire = fbuild.load_const(&tru_const)?;
                 let [int] = fbuild.input_wires_arr();

--- a/src/builder/tail_loop.rs
+++ b/src/builder/tail_loop.rs
@@ -97,7 +97,7 @@ mod test {
             test::{BIT, NAT},
             DataflowSubContainer, HugrBuilder, ModuleBuilder,
         },
-        extension::prelude::{ConstUsize, USIZE_T},
+        extension::prelude::{ConstUsize, PRELUDE_ID, USIZE_T},
         extension::ExtensionSet,
         hugr::ValidationError,
         ops::Const,
@@ -110,7 +110,7 @@ mod test {
         let build_result: Result<Hugr, ValidationError> = {
             let mut loop_b = TailLoopBuilder::new(vec![], vec![BIT], vec![USIZE_T])?;
             let [i1] = loop_b.input_wires_arr();
-            let const_wire = loop_b.add_load_const(ConstUsize::new(1).into())?;
+            let const_wire = loop_b.add_load_const(ConstUsize::new(1).into(), Some(PRELUDE_ID))?;
 
             let break_wire = loop_b.make_break(loop_b.loop_signature()?.clone(), [const_wire])?;
             loop_b.set_outputs(break_wire, [i1])?;
@@ -127,7 +127,8 @@ mod test {
             let mut module_builder = ModuleBuilder::new();
             let mut fbuild = module_builder.define_function(
                 "main",
-                FunctionType::new(type_row![BIT], type_row![NAT]).pure(),
+                FunctionType::new(type_row![BIT], type_row![NAT])
+                    .with_input_extensions(ExtensionSet::singleton(&PRELUDE_ID)),
             )?;
             let _fdef = {
                 let [b1] = fbuild.input_wires_arr();
@@ -135,7 +136,16 @@ mod test {
                     let mut loop_b =
                         fbuild.tail_loop_builder(vec![(BIT, b1)], vec![], type_row![NAT])?;
                     let signature = loop_b.loop_signature()?.clone();
-                    let const_wire = loop_b.add_load_const(Const::true_val())?;
+                    let const_val = Const::true_val();
+                    let const_wire = loop_b.add_load_const(Const::true_val(), None)?;
+                    let lift_node = loop_b.add_dataflow_op(
+                        ops::LeafOp::Lift {
+                            type_row: vec![const_val.const_type().clone()].into(),
+                            new_extension: PRELUDE_ID,
+                        },
+                        [const_wire],
+                    )?;
+                    let [const_wire] = lift_node.outputs_arr();
                     let [b1] = loop_b.input_wires_arr();
                     let conditional_id = {
                         let predicate_inputs = vec![type_row![]; 2];
@@ -156,16 +166,15 @@ mod test {
                         let mut branch_1 = conditional_b.case_builder(1)?;
                         let [_b1] = branch_1.input_wires_arr();
 
-                        let wire = branch_1.add_load_const(ConstUsize::new(2).into())?;
+                        let wire =
+                            branch_1.add_load_const(ConstUsize::new(2).into(), Some(PRELUDE_ID))?;
                         let break_wire = branch_1.make_break(signature, [wire])?;
                         branch_1.finish_with_outputs([break_wire])?;
 
                         conditional_b.finish_sub_container()?
                     };
-
                     loop_b.finish_with_outputs(conditional_id.out_wire(0), [])?
                 };
-
                 fbuild.finish_with_outputs(loop_id.outputs())?
             };
             module_builder.finish_prelude_hugr()

--- a/src/builder/tail_loop.rs
+++ b/src/builder/tail_loop.rs
@@ -110,7 +110,10 @@ mod test {
         let build_result: Result<Hugr, ValidationError> = {
             let mut loop_b = TailLoopBuilder::new(vec![], vec![BIT], vec![USIZE_T])?;
             let [i1] = loop_b.input_wires_arr();
-            let const_wire = loop_b.add_load_const(ConstUsize::new(1).into(), Some(PRELUDE_ID))?;
+            let const_wire = loop_b.add_load_const(
+                ConstUsize::new(1).into(),
+                ExtensionSet::singleton(&PRELUDE_ID),
+            )?;
 
             let break_wire = loop_b.make_break(loop_b.loop_signature()?.clone(), [const_wire])?;
             loop_b.set_outputs(break_wire, [i1])?;
@@ -137,7 +140,8 @@ mod test {
                         fbuild.tail_loop_builder(vec![(BIT, b1)], vec![], type_row![NAT])?;
                     let signature = loop_b.loop_signature()?.clone();
                     let const_val = Const::true_val();
-                    let const_wire = loop_b.add_load_const(Const::true_val(), None)?;
+                    let const_wire =
+                        loop_b.add_load_const(Const::true_val(), ExtensionSet::new())?;
                     let lift_node = loop_b.add_dataflow_op(
                         ops::LeafOp::Lift {
                             type_row: vec![const_val.const_type().clone()].into(),
@@ -166,8 +170,10 @@ mod test {
                         let mut branch_1 = conditional_b.case_builder(1)?;
                         let [_b1] = branch_1.input_wires_arr();
 
-                        let wire =
-                            branch_1.add_load_const(ConstUsize::new(2).into(), Some(PRELUDE_ID))?;
+                        let wire = branch_1.add_load_const(
+                            ConstUsize::new(2).into(),
+                            ExtensionSet::singleton(&PRELUDE_ID),
+                        )?;
                         let break_wire = branch_1.make_break(signature, [wire])?;
                         branch_1.finish_with_outputs([break_wire])?;
 

--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -326,7 +326,6 @@ impl UnificationContext {
             for port in hugr.node_inputs(tgt_node).filter(|src_port| {
                 matches!(sig.port_kind(*src_port), Some(EdgeKind::Value(_)))
                     || matches!(sig.port_kind(*src_port), Some(EdgeKind::Static(_)))
-                    || matches!(sig.port_kind(*src_port), Some(EdgeKind::ControlFlow))
             }) {
                 for (src_node, _) in hugr.linked_ports(tgt_node, port) {
                     let m_src = self

--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -323,10 +323,11 @@ impl UnificationContext {
         for tgt_node in hugr.nodes() {
             let sig: &OpType = hugr.get_nodetype(tgt_node).into();
             // Incoming ports with a dataflow edge
-            for port in hugr
-                .node_inputs(tgt_node)
-                .filter(|src_port| matches!(sig.port_kind(*src_port), Some(EdgeKind::Value(_))))
-            {
+            for port in hugr.node_inputs(tgt_node).filter(|src_port| {
+                matches!(sig.port_kind(*src_port), Some(EdgeKind::Value(_)))
+                    || matches!(sig.port_kind(*src_port), Some(EdgeKind::Static(_)))
+                    || matches!(sig.port_kind(*src_port), Some(EdgeKind::ControlFlow))
+            }) {
                 for (src_node, _) in hugr.linked_ports(tgt_node, port) {
                     let m_src = self
                         .extensions

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -60,6 +60,14 @@ pub trait HugrMut: HugrView + HugrMutInternals {
         self.hugr_mut().add_op_before(sibling, op)
     }
 
+    /// A generalisation of [`add_op_before`], needed temporarily until
+    /// [`add_op`] defaults to creating nodes with open extensions.
+    #[inline]
+    fn add_node_before(&mut self, sibling: Node, nodetype: NodeType) -> Result<Node, HugrError> {
+        self.valid_non_root(sibling)?;
+        self.hugr_mut().add_node_before(sibling, nodetype)
+    }
+
     /// Add a node to the graph as the next sibling of another node.
     ///
     /// The sibling node's parent becomes the new node's parent.
@@ -181,7 +189,11 @@ where
     }
 
     fn add_op_before(&mut self, sibling: Node, op: impl Into<OpType>) -> Result<Node, HugrError> {
-        let node = self.add_op(op);
+        self.add_node_before(sibling, NodeType::pure(op))
+    }
+
+    fn add_node_before(&mut self, sibling: Node, nodetype: NodeType) -> Result<Node, HugrError> {
+        let node = self.add_node(nodetype);
         self.as_mut()
             .hierarchy
             .insert_before(node.index, sibling.index)?;

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -60,8 +60,8 @@ pub trait HugrMut: HugrView + HugrMutInternals {
         self.hugr_mut().add_op_before(sibling, op)
     }
 
-    /// A generalisation of [`add_op_before`], needed temporarily until
-    /// [`add_op`] defaults to creating nodes with open extensions.
+    /// A generalisation of [`HugrMut::add_op_before`], needed temporarily until
+    /// add_op type methods all default to creating nodes with open extensions.
     #[inline]
     fn add_node_before(&mut self, sibling: Node, nodetype: NodeType) -> Result<Node, HugrError> {
         self.valid_non_root(sibling)?;

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -62,6 +62,7 @@ pub trait HugrMut: HugrView + HugrMutInternals {
 
     /// A generalisation of [`HugrMut::add_op_before`], needed temporarily until
     /// add_op type methods all default to creating nodes with open extensions.
+    /// See issue #424
     #[inline]
     fn add_node_before(&mut self, sibling: Node, nodetype: NodeType) -> Result<Node, HugrError> {
         self.valid_non_root(sibling)?;

--- a/src/hugr/rewrite/insert_identity.rs
+++ b/src/hugr/rewrite/insert_identity.rs
@@ -136,7 +136,7 @@ mod tests {
 
         assert_eq!(noop, LeafOp::Noop { ty: QB_T });
 
-        h.validate(&PRELUDE_REGISTRY).unwrap();
+        h.infer_and_validate(&PRELUDE_REGISTRY).unwrap();
     }
 
     #[test]

--- a/src/hugr/rewrite/outline_cfg.rs
+++ b/src/hugr/rewrite/outline_cfg.rs
@@ -130,7 +130,7 @@ impl Rewrite for OutlineCfg {
                 .unwrap();
             let cfg_outputs = cfg.finish_sub_container().unwrap().outputs();
             let predicate = new_block_bldr
-                .add_constant(ops::Const::simple_unary_predicate())
+                .add_constant(ops::Const::simple_unary_predicate(), None)
                 .unwrap();
             let pred_wire = new_block_bldr.load_const(&predicate).unwrap();
             let new_block_hugr = new_block_bldr

--- a/src/hugr/rewrite/outline_cfg.rs
+++ b/src/hugr/rewrite/outline_cfg.rs
@@ -130,7 +130,7 @@ impl Rewrite for OutlineCfg {
                 .unwrap();
             let cfg_outputs = cfg.finish_sub_container().unwrap().outputs();
             let predicate = new_block_bldr
-                .add_constant(ops::Const::simple_unary_predicate(), None)
+                .add_constant(ops::Const::simple_unary_predicate(), ExtensionSet::new())
                 .unwrap();
             let pred_wire = new_block_bldr.load_const(&predicate).unwrap();
             new_block_bldr.set_outputs(pred_wire, cfg_outputs).unwrap();

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -151,16 +151,19 @@ mod test {
             type_row![],
             TypeRow::from(vec![pred_ty.clone()]),
         ))?;
-        let c = b.add_constant(Const::predicate(
-            0,
-            Value::tuple([CustomTestValue(TypeBound::Eq).into(), serialized_float(5.1)]),
-            pred_rows.clone(),
-        )?)?;
+        let c = b.add_constant(
+            Const::predicate(
+                0,
+                Value::tuple([CustomTestValue(TypeBound::Eq).into(), serialized_float(5.1)]),
+                pred_rows.clone(),
+            )?,
+            None,
+        )?;
         let w = b.load_const(&c)?;
         b.finish_hugr_with_outputs([w], &test_registry()).unwrap();
 
         let mut b = DFGBuilder::new(FunctionType::new(type_row![], TypeRow::from(vec![pred_ty])))?;
-        let c = b.add_constant(Const::predicate(1, Value::unit(), pred_rows)?)?;
+        let c = b.add_constant(Const::predicate(1, Value::unit(), pred_rows)?, None)?;
         let w = b.load_const(&c)?;
         b.finish_hugr_with_outputs([w], &test_registry()).unwrap();
 

--- a/src/ops/constant.rs
+++ b/src/ops/constant.rs
@@ -124,7 +124,7 @@ mod test {
         builder::{BuildError, DFGBuilder, Dataflow, DataflowHugr},
         extension::{
             prelude::{ConstUsize, USIZE_T},
-            ExtensionId,
+            ExtensionId, ExtensionSet,
         },
         std_extensions::arithmetic::float_types::FLOAT64_TYPE,
         type_row,
@@ -157,13 +157,16 @@ mod test {
                 Value::tuple([CustomTestValue(TypeBound::Eq).into(), serialized_float(5.1)]),
                 pred_rows.clone(),
             )?,
-            None,
+            ExtensionSet::new(),
         )?;
         let w = b.load_const(&c)?;
         b.finish_hugr_with_outputs([w], &test_registry()).unwrap();
 
         let mut b = DFGBuilder::new(FunctionType::new(type_row![], TypeRow::from(vec![pred_ty])))?;
-        let c = b.add_constant(Const::predicate(1, Value::unit(), pred_rows)?, None)?;
+        let c = b.add_constant(
+            Const::predicate(1, Value::unit(), pred_rows)?,
+            ExtensionSet::new(),
+        )?;
         let w = b.load_const(&c)?;
         b.finish_hugr_with_outputs([w], &test_registry()).unwrap();
 


### PR DESCRIPTION
When using builder methods to put `Const` nodes on the graph, users must pass an extra "provenance" argument which specifies which extension the type of the constant value is coming from. The argument is an `Option`, where `None` means that the constant is of a built-in type (like our true and false predicates).

The `Const` nodes will be added to the graph with `input_extensions` which are either the empty set or the singleton set of the const value's provenance. Constant loading methods in the builder will make the `LoadConst` node's `input_extensions` match those of the constant it's connected too.

This also adds a constraint to extension inference that extension requirements are the same on both ends of `Static` and `ControlFlow` edges.

Resolves #525 