### PR TITLE
HugrMut: validate nodes for set_metadata/get_metadata_mut, too

### DIFF
--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -115,12 +115,16 @@ pub trait Container {
     /// Add metadata to the container node.
     fn set_metadata(&mut self, meta: NodeMetadata) {
         let parent = self.container_node();
+        // Implementor's container_node() should be a valid node
         self.hugr_mut().set_metadata(parent, meta).unwrap();
     }
 
     /// Add metadata to a child node.
+    ///
+    /// Returns an error if the specified `child` is not a child of this container
     fn set_child_metadata(&mut self, child: Node, meta: NodeMetadata) -> Result<(), BuildError> {
-        Ok(self.hugr_mut().set_metadata(child, meta)?)
+        self.hugr_mut().set_metadata(child, meta)?;
+        Ok(())
     }
 }
 

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -115,12 +115,12 @@ pub trait Container {
     /// Add metadata to the container node.
     fn set_metadata(&mut self, meta: NodeMetadata) {
         let parent = self.container_node();
-        self.hugr_mut().set_metadata(parent, meta);
+        self.hugr_mut().set_metadata(parent, meta).unwrap();
     }
 
     /// Add metadata to a child node.
-    fn set_child_metadata(&mut self, child: Node, meta: NodeMetadata) {
-        self.hugr_mut().set_metadata(child, meta);
+    fn set_child_metadata(&mut self, child: Node, meta: NodeMetadata) -> Result<(), BuildError> {
+        Ok(self.hugr_mut().set_metadata(child, meta)?)
     }
 }
 

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -165,7 +165,7 @@ where
     }
 
     fn add_node_with_parent(&mut self, parent: Node, node: NodeType) -> Result<Node, HugrError> {
-        let node = self.add_node(node);
+        let node = self.as_mut().add_node(node);
         self.as_mut()
             .hierarchy
             .push_child(node.index, parent.index)?;
@@ -173,7 +173,7 @@ where
     }
 
     fn add_op_before(&mut self, sibling: Node, op: impl Into<OpType>) -> Result<Node, HugrError> {
-        let node = self.add_op(op);
+        let node = self.as_mut().add_op(op);
         self.as_mut()
             .hierarchy
             .insert_before(node.index, sibling.index)?;
@@ -181,7 +181,7 @@ where
     }
 
     fn add_op_after(&mut self, sibling: Node, op: impl Into<OpType>) -> Result<Node, HugrError> {
-        let node = self.add_op(op);
+        let node = self.as_mut().add_op(op);
         self.as_mut()
             .hierarchy
             .insert_after(node.index, sibling.index)?;
@@ -334,16 +334,6 @@ pub(crate) mod sealed {
                 true => Err(HugrError::InvalidNode(node)),
                 false => self.valid_node(node),
             }
-        }
-
-        /// Add a node to the graph, with the default conversion from OpType to NodeType
-        fn add_op(&mut self, op: impl Into<OpType>) -> Node {
-            self.hugr_mut().add_op(op)
-        }
-
-        /// Add a node to the graph.
-        fn add_node(&mut self, nodetype: NodeType) -> Node {
-            self.hugr_mut().add_node(nodetype)
         }
 
         /// Set the number of ports on a node. This may invalidate the node's `PortIndex`.

--- a/src/hugr/rewrite/simple_replace.rs
+++ b/src/hugr/rewrite/simple_replace.rs
@@ -90,7 +90,7 @@ impl Rewrite for SimpleReplacement {
 
             // Move the metadata
             let meta: &NodeMetadata = self.replacement.get_metadata(node);
-            h.set_metadata(node, meta.clone());
+            h.set_metadata(node, meta.clone()).unwrap();
         }
         // Add edges between all newly added nodes matching those in replacement.
         // TODO This will probably change when implicit copies are implemented.

--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -227,7 +227,7 @@ impl TryFrom<SerHugrV0> for Hugr {
 
         for (node, metadata) in metadata.into_iter().enumerate() {
             let node = NodeIndex::new(node).into();
-            hugr.set_metadata(node, metadata);
+            hugr.set_metadata(node, metadata)?;
         }
 
         let unwrap_offset = |node: Node, offset, dir, hugr: &Hugr| -> Result<usize, Self::Error> {


### PR DESCRIPTION
...bringing these in line with the other methods. Yes, this involves a `Result<&mut, ...>` but that works ok!

Also inline `HugrMutInternals::add_node` and `add_op`, these are only used once and it's fairly trivial (but against, restores uniformity)