### PR TITLE
feat: insert_hugr/insert_view return node map

### DIFF
--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -1,9 +1,9 @@
+use crate::hugr::hugrmut::InsertionResult;
 use crate::hugr::validate::InterGraphEdgeError;
 use crate::hugr::views::HugrView;
 use crate::hugr::{Node, NodeMetadata, Port, ValidationError};
 use crate::ops::{self, LeafOp, OpTrait, OpType};
 
-use std::collections::HashMap;
 use std::iter;
 
 use super::FunctionBuilder;
@@ -109,16 +109,13 @@ pub trait Container {
     }
 
     /// Insert a HUGR as a child of the container.
-    fn add_hugr(&mut self, child: Hugr) -> Result<(Node, HashMap<Node, Node>), BuildError> {
+    fn add_hugr(&mut self, child: Hugr) -> Result<InsertionResult, BuildError> {
         let parent = self.container_node();
         Ok(self.hugr_mut().insert_hugr(parent, child)?)
     }
 
     /// Insert a copy of a HUGR as a child of the container.
-    fn add_hugr_view(
-        &mut self,
-        child: &impl HugrView,
-    ) -> Result<(Node, HashMap<Node, Node>), BuildError> {
+    fn add_hugr_view(&mut self, child: &impl HugrView) -> Result<InsertionResult, BuildError> {
         let parent = self.container_node();
         Ok(self.hugr_mut().insert_from_view(parent, child)?)
     }
@@ -234,7 +231,7 @@ pub trait Dataflow: Container {
         input_wires: impl IntoIterator<Item = Wire>,
     ) -> Result<BuildHandle<DataflowOpID>, BuildError> {
         let num_outputs = hugr.get_optype(hugr.root()).signature().output_count();
-        let node = self.add_hugr(hugr)?.0;
+        let node = self.add_hugr(hugr)?.new_root;
 
         let inputs = input_wires.into_iter().collect();
         wire_up_inputs(inputs, node, self)?;
@@ -255,7 +252,7 @@ pub trait Dataflow: Container {
         input_wires: impl IntoIterator<Item = Wire>,
     ) -> Result<BuildHandle<DataflowOpID>, BuildError> {
         let num_outputs = hugr.get_optype(hugr.root()).signature().output_count();
-        let node = self.add_hugr_view(hugr)?.0;
+        let node = self.add_hugr_view(hugr)?.new_root;
 
         let inputs = input_wires.into_iter().collect();
         wire_up_inputs(inputs, node, self)?;

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -110,13 +110,13 @@ pub trait Container {
     /// Insert a HUGR as a child of the container.
     fn add_hugr(&mut self, child: Hugr) -> Result<Node, BuildError> {
         let parent = self.container_node();
-        Ok(self.hugr_mut().insert_hugr(parent, child)?)
+        Ok(self.hugr_mut().insert_hugr(parent, child)?.0)
     }
 
     /// Insert a copy of a HUGR as a child of the container.
     fn add_hugr_view(&mut self, child: &impl HugrView) -> Result<Node, BuildError> {
         let parent = self.container_node();
-        Ok(self.hugr_mut().insert_from_view(parent, child)?)
+        Ok(self.hugr_mut().insert_from_view(parent, child)?.0)
     }
 
     /// Add metadata to the container node.

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -141,31 +141,19 @@ pub trait HugrMut: HugrView + HugrMutInternals {
     }
 
     /// Insert another hugr into this one, under a given root node.
-    ///
-    /// Returns a tuple of
-    /// * the root node of the inserted hugr.
-    /// * a map from each Node in `other` to the equivalent new Node in `self`
     #[inline]
-    fn insert_hugr(
-        &mut self,
-        root: Node,
-        other: Hugr,
-    ) -> Result<(Node, HashMap<Node, Node>), HugrError> {
+    fn insert_hugr(&mut self, root: Node, other: Hugr) -> Result<InsertionResult, HugrError> {
         self.valid_node(root)?;
         self.hugr_mut().insert_hugr(root, other)
     }
 
     /// Copy another hugr into this one, under a given root node.
-    ///
-    /// Returns a tuple of
-    /// * the root node of the inserted hugr.
-    /// * a map from each Node in `other` to the equivalent new Node in `self`
     #[inline]
     fn insert_from_view(
         &mut self,
         root: Node,
         other: &impl HugrView,
-    ) -> Result<(Node, HashMap<Node, Node>), HugrError> {
+    ) -> Result<InsertionResult, HugrError> {
         self.valid_node(root)?;
         self.hugr_mut().insert_from_view(root, other)
     }
@@ -176,6 +164,26 @@ pub trait HugrMut: HugrView + HugrMutInternals {
         Self: Sized,
     {
         rw.apply(self)
+    }
+}
+
+/// Records the result of inserting a Hugr or view
+/// via [HugrMut::insert_hugr] or [HugrMut::insert_from_view]
+pub struct InsertionResult {
+    /// The node, after insertion, that was the root of the inserted Hugr.
+    /// (That is, the value in [InsertionResult::node_map] under the key that was the [HugrView::root]))
+    pub new_root: Node,
+    /// Map from nodes in the Hugr/view that was inserted, to their new
+    /// positions in the Hugr into which said was inserted.
+    pub node_map: HashMap<Node, Node>,
+}
+
+impl InsertionResult {
+    fn translating_indices(new_root: Node, node_map: HashMap<NodeIndex, NodeIndex>) -> Self {
+        Self {
+            new_root,
+            node_map: HashMap::from_iter(node_map.into_iter().map(|(k, v)| (k.into(), v.into()))),
+        }
     }
 }
 
@@ -270,11 +278,7 @@ where
         Ok((src_port, dst_port))
     }
 
-    fn insert_hugr(
-        &mut self,
-        root: Node,
-        mut other: Hugr,
-    ) -> Result<(Node, HashMap<Node, Node>), HugrError> {
+    fn insert_hugr(&mut self, root: Node, mut other: Hugr) -> Result<InsertionResult, HugrError> {
         let (other_root, node_map) = insert_hugr_internal(self.as_mut(), root, &other)?;
         // Update the optypes and metadata, taking them from the other graph.
         for (&node, &new_node) in node_map.iter() {
@@ -283,17 +287,15 @@ where
             let meta = other.metadata.take(node);
             self.as_mut().set_metadata(node.into(), meta).unwrap();
         }
-        Ok((
-            other_root,
-            HashMap::from_iter(node_map.into_iter().map(|(k, v)| (k.into(), v.into()))),
-        ))
+        debug_assert_eq!(Some(&other_root.index), node_map.get(&other.root().index));
+        Ok(InsertionResult::translating_indices(other_root, node_map))
     }
 
     fn insert_from_view(
         &mut self,
         root: Node,
         other: &impl HugrView,
-    ) -> Result<(Node, HashMap<Node, Node>), HugrError> {
+    ) -> Result<InsertionResult, HugrError> {
         let (other_root, node_map) = insert_hugr_internal(self.as_mut(), root, other)?;
         // Update the optypes and metadata, copying them from the other graph.
         for (&node, &new_node) in node_map.iter() {
@@ -304,10 +306,8 @@ where
                 .set_metadata(node.into(), meta.clone())
                 .unwrap();
         }
-        Ok((
-            other_root,
-            HashMap::from_iter(node_map.into_iter().map(|(k, v)| (k.into(), v.into()))),
-        ))
+        debug_assert_eq!(Some(&other_root.index), node_map.get(&other.root().index));
+        Ok(InsertionResult::translating_indices(other_root, node_map))
     }
 }
 

--- a/src/hugr/rewrite/outline_cfg.rs
+++ b/src/hugr/rewrite/outline_cfg.rs
@@ -139,10 +139,13 @@ impl Rewrite for OutlineCfg {
             new_block_bldr
                 .set_outputs(pred_wire, cfg.outputs())
                 .unwrap();
-            let (new_block, node_map) = h
+            let ins_res = h
                 .insert_hugr(outer_cfg, new_block_bldr.hugr().clone())
                 .unwrap();
-            (new_block, *node_map.get(&cfg.node()).unwrap())
+            (
+                ins_res.new_root,
+                *ins_res.node_map.get(&cfg.node()).unwrap(),
+            )
         };
 
         // 3. Entry edges. Change any edges into entry_block from outside, to target new_block

--- a/src/hugr/rewrite/outline_cfg.rs
+++ b/src/hugr/rewrite/outline_cfg.rs
@@ -114,7 +114,7 @@ impl Rewrite for OutlineCfg {
         let outer_entry = h.children(outer_cfg).next().unwrap();
 
         // 2. new_block contains input node, sub-cfg, exit node all connected
-        let new_block = {
+        let (new_block, _) = {
             let mut new_block_bldr = BlockBuilder::new(
                 inputs.clone(),
                 vec![type_row![]],


### PR DESCRIPTION
Also corresponding builder methods. `insert_hugr_internal` already returns this, so just wrap in a new `struct InsertionResult` translating the NodeIndex's into Nodes.