### PR TITLE
fix: Make unification logic less strict

### DIFF
--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -672,7 +672,7 @@ mod test {
     use super::*;
     use crate::builder::test::closed_dfg_root_hugr;
     use crate::builder::{BuildError, DFGBuilder, Dataflow, DataflowHugr};
-    use crate::extension::{ExtensionSet, EMPTY_REG};
+    use crate::extension::{ExtensionSet, EMPTY_REG, PRELUDE_REGISTRY};
     use crate::hugr::{validate::ValidationError, Hugr, HugrMut, HugrView, NodeType};
     use crate::macros::const_extension_ids;
     use crate::ops::{self, dataflow::IOTrait, handle::NodeHandle, OpTrait};
@@ -680,6 +680,7 @@ mod test {
     use crate::types::{FunctionType, Type};
 
     use cool_asserts::assert_matches;
+    use itertools::Itertools;
     use portgraph::NodeIndex;
 
     const NAT: Type = crate::extension::prelude::USIZE_T;
@@ -1039,6 +1040,78 @@ mod test {
                 ExtensionSet::new()
             );
         }
+        Ok(())
+    }
+
+    #[test]
+    fn extension_adding_sequence() -> Result<(), Box<dyn Error>> {
+        fn mknode(
+            hugr: &mut Hugr,
+            root: Node,
+            sig: FunctionType,
+            ext: ExtensionId,
+        ) -> Result<Node, Box<dyn Error>> {
+            let [node, input, output] = create_with_io(
+                hugr,
+                root,
+                ops::DFG {
+                    signature: sig
+                        .clone()
+                        .with_extension_delta(&ExtensionSet::singleton(&ext)),
+                },
+            )?;
+
+            let lift = hugr.add_node_with_parent(
+                node,
+                NodeType::open_extensions(ops::LeafOp::Lift {
+                    type_row: type_row![NAT],
+                    new_extension: ext,
+                }),
+            )?;
+
+            hugr.connect(input, 0, lift, 0)?;
+            hugr.connect(lift, 0, output, 0)?;
+
+            Ok(node)
+        }
+
+        let df_sig = FunctionType::new(type_row![NAT], type_row![NAT]);
+
+        let mut hugr = Hugr::new(NodeType::open_extensions(ops::DFG {
+            signature: df_sig
+                .clone()
+                .with_extension_delta(&ExtensionSet::from_iter([A, B])),
+        }));
+
+        let root = hugr.root();
+        let input = hugr.add_node_with_parent(
+            root,
+            NodeType::open_extensions(ops::Input {
+                types: type_row![NAT],
+            }),
+        )?;
+        let output = hugr.add_node_with_parent(
+            root,
+            NodeType::open_extensions(ops::Output {
+                types: type_row![NAT],
+            }),
+        )?;
+
+        let node0 = mknode(&mut hugr, root, df_sig.clone(), A)?;
+        let node1 = mknode(&mut hugr, root, df_sig.clone(), A)?;
+        let node2 = mknode(&mut hugr, root, df_sig.clone(), B)?;
+        let node3 = mknode(&mut hugr, root, df_sig.clone(), B)?;
+        let node4 = mknode(&mut hugr, root, df_sig.clone(), A)?;
+        let node5 = mknode(&mut hugr, root, df_sig.clone(), B)?;
+
+        // Connect nodes in order (0 -> 1 -> 2 ...)
+        let nodes = [input, node0, node1, node2, node3, node4, node5, output];
+        for (src, tgt) in nodes.into_iter().tuple_windows() {
+            hugr.connect(src, 0, tgt, 0)?;
+        }
+
+        hugr.infer_and_validate(&PRELUDE_REGISTRY)?;
+
         Ok(())
     }
 }

--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -495,6 +495,12 @@ impl UnificationContext {
                 Constraint::Equal(other_meta) => {
                     self.eq_graph.register_eq(meta, *other_meta);
                 }
+                // N.B. If `meta` is already solved, we can't use that
+                // information to solve `other_meta`. This is because the Plus
+                // constraint only signifies a preorder.
+                // I.e. if meta = other_meta + 'R', it's still possible that the
+                // solution is meta = other_meta because we could be adding 'R'
+                // to a set which already contained it.
                 Constraint::Plus(r, other_meta) => {
                     if let Some(rs) = self.get_solution(other_meta) {
                         let mut rrs = rs.clone();
@@ -516,12 +522,6 @@ impl UnificationContext {
                                 solved = true;
                             }
                         };
-                    } else if let Some(_superset) = self.get_solution(&meta) {
-                        // Here, we're stuck because the Plus constraint only
-                        // signifies a preorder. I.e. if m0 = m1 + 'R', it's
-                        // still possible that the solution is m0 = m1 because
-                        // it's possible that we're adding 'R' to a set which
-                        // already contained it.
                     };
                 }
             }


### PR DESCRIPTION
The `Plus` constraint has up till now been too strict in extension unification. So far we have been deriving things like the following:
```
a := Plus("C", b)
a := {"A", "B", "C"}
implies
b := {"A", "B"}
```
(as in `minus_test`, which this PR removes)
However, plus should be meant as the union of the the singleton set that it specifies with the extension set of another metavariable. Hence in the above example the solution for `b` could be either `{"A", "B"}` or `{"A", "B", "C"}`.

This means that if we have chains of circuit operations which all add the "quantum" resource, they can all be represented as `Plus` constraints