### PR TITLE
Pass &ExtensionRegistry to compute_signature (etc.)

### DIFF
--- a/src/extension.rs
+++ b/src/extension.rs
@@ -300,9 +300,10 @@ impl Extension {
         &self,
         op_name: &str,
         args: impl Into<Vec<TypeArg>>,
+        ext_reg: &ExtensionRegistry,
     ) -> Result<ExtensionOp, SignatureError> {
         let op_def = self.get_op(op_name).expect("Op not found.");
-        ExtensionOp::new(op_def.clone(), args)
+        ExtensionOp::new(op_def.clone(), args, ext_reg)
     }
 }
 

--- a/src/ops/custom.rs
+++ b/src/ops/custom.rs
@@ -110,9 +110,13 @@ pub struct ExtensionOp {
 
 impl ExtensionOp {
     /// Create a new ExtensionOp given the type arguments and specified input extensions
-    pub fn new(def: Arc<OpDef>, args: impl Into<Vec<TypeArg>>) -> Result<Self, SignatureError> {
+    pub fn new(
+        def: Arc<OpDef>,
+        args: impl Into<Vec<TypeArg>>,
+        exts: &ExtensionRegistry,
+    ) -> Result<Self, SignatureError> {
         let args = args.into();
-        let signature = def.compute_signature(&args)?;
+        let signature = def.compute_signature(&args, exts)?;
         Ok(Self {
             def,
             args,
@@ -236,7 +240,8 @@ pub fn resolve_extension_ops(
                         ));
                     };
                     let op = ExternalOp::Extension(
-                        ExtensionOp::new(def.clone(), opaque.args.clone()).unwrap(),
+                        ExtensionOp::new(def.clone(), opaque.args.clone(), extension_registry)
+                            .unwrap(),
                     );
                     if let Some(sig) = &opaque.signature {
                         if sig != &op.signature() {

--- a/src/std_extensions/collections.rs
+++ b/src/std_extensions/collections.rs
@@ -176,7 +176,7 @@ mod test {
     fn test_list_ops() {
         let reg = &[EXTENSION.to_owned()].into();
         let pop_sig = get_op(&POP_NAME)
-            .compute_signature(&[TypeArg::Type { ty: QB_T }], &reg)
+            .compute_signature(&[TypeArg::Type { ty: QB_T }], reg)
             .unwrap();
 
         let list_type = Type::new_extension(CustomType::new(
@@ -192,7 +192,7 @@ mod test {
         assert_eq!(pop_sig.output(), &both_row);
 
         let push_sig = get_op(&PUSH_NAME)
-            .compute_signature(&[TypeArg::Type { ty: FLOAT64_TYPE }], &reg)
+            .compute_signature(&[TypeArg::Type { ty: FLOAT64_TYPE }], reg)
             .unwrap();
 
         let list_type = Type::new_extension(CustomType::new(

--- a/src/std_extensions/collections.rs
+++ b/src/std_extensions/collections.rs
@@ -174,8 +174,9 @@ mod test {
 
     #[test]
     fn test_list_ops() {
+        let reg = &[EXTENSION.to_owned()].into();
         let pop_sig = get_op(&POP_NAME)
-            .compute_signature(&[TypeArg::Type { ty: QB_T }])
+            .compute_signature(&[TypeArg::Type { ty: QB_T }], &reg)
             .unwrap();
 
         let list_type = Type::new_extension(CustomType::new(
@@ -191,7 +192,7 @@ mod test {
         assert_eq!(pop_sig.output(), &both_row);
 
         let push_sig = get_op(&PUSH_NAME)
-            .compute_signature(&[TypeArg::Type { ty: FLOAT64_TYPE }])
+            .compute_signature(&[TypeArg::Type { ty: FLOAT64_TYPE }], &reg)
             .unwrap();
 
         let list_type = Type::new_extension(CustomType::new(

--- a/src/std_extensions/logic.rs
+++ b/src/std_extensions/logic.rs
@@ -108,7 +108,12 @@ lazy_static! {
 
 #[cfg(test)]
 pub(crate) mod test {
-    use crate::{extension::prelude::BOOL_T, ops::LeafOp, types::type_param::TypeArg, Extension};
+    use crate::{
+        extension::{prelude::BOOL_T, EMPTY_REG},
+        ops::LeafOp,
+        types::type_param::TypeArg,
+        Extension,
+    };
 
     use super::{extension, AND_NAME, EXTENSION, FALSE_NAME, NOT_NAME, TRUE_NAME};
 
@@ -134,7 +139,7 @@ pub(crate) mod test {
     /// Generate a logic extension and "and" operation over [`crate::prelude::BOOL_T`]
     pub(crate) fn and_op() -> LeafOp {
         EXTENSION
-            .instantiate_extension_op(AND_NAME, [TypeArg::BoundedNat { n: 2 }])
+            .instantiate_extension_op(AND_NAME, [TypeArg::BoundedNat { n: 2 }], &EMPTY_REG)
             .unwrap()
             .into()
     }
@@ -142,7 +147,7 @@ pub(crate) mod test {
     /// Generate a logic extension and "not" operation over [`crate::prelude::BOOL_T`]
     pub(crate) fn not_op() -> LeafOp {
         EXTENSION
-            .instantiate_extension_op(NOT_NAME, [])
+            .instantiate_extension_op(NOT_NAME, [], &EMPTY_REG)
             .unwrap()
             .into()
     }

--- a/src/std_extensions/quantum.rs
+++ b/src/std_extensions/quantum.rs
@@ -78,13 +78,13 @@ lazy_static! {
 
 #[cfg(test)]
 pub(crate) mod test {
-    use crate::ops::LeafOp;
+    use crate::{extension::EMPTY_REG, ops::LeafOp};
 
     use super::EXTENSION;
 
     fn get_gate(gate_name: &str) -> LeafOp {
         EXTENSION
-            .instantiate_extension_op(gate_name, [])
+            .instantiate_extension_op(gate_name, [], &EMPTY_REG)
             .unwrap()
             .into()
     }


### PR DESCRIPTION
Without this, impl's can't necessarily construct instances of custom types like List - we rely on implementations to have the definitions themselves already, by some backdoor. (And for implementations to store a reference the ExtensionRegistry, leads to cyclic data, as they are going to be part of it!)