### PR TITLE
fix(Inference): Consider shunted metas when comparing equality

### DIFF
--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -664,7 +664,9 @@ impl UnificationContext {
                 let solution =
                     ExtensionSet::from_iter(self.get_constraints(&m).unwrap().iter().filter_map(
                         |c| match c {
-                            Constraint::Plus(x, other_m) if &m == other_m => Some(x.clone()),
+                            Constraint::Plus(x, other_m) if m == self.resolve(*other_m) => {
+                                Some(x.clone())
+                            }
                             _ => None,
                         },
                     ));

--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -664,6 +664,10 @@ impl UnificationContext {
                 let solution =
                     ExtensionSet::from_iter(self.get_constraints(&m).unwrap().iter().filter_map(
                         |c| match c {
+                            // If `m` has been merged, [`self.variables`] entry
+                            // will have already been updated to the merged
+                            // value by [`self.merge_equal_metas`] so we don't
+                            // need to worry about resolving it.
                             Constraint::Plus(x, other_m) if m == self.resolve(*other_m) => {
                                 Some(x.clone())
                             }


### PR DESCRIPTION
When comparing for equality of metavars, we need to consider that they might have been merged to form a new meta, so `UnificationContext::resolve` must be used. In this case, the variable (LHS) is updated to the merged value in `UnificationContext::merge_equal_metas` so we don't need to resolve that one.