### PR TITLE
feat: Make TypeEnum and it's contents public

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -11,6 +11,7 @@ pub mod type_row;
 pub use check::{ConstTypeError, CustomCheckFailure};
 pub use custom::CustomType;
 pub use signature::{FunctionType, Signature, SignatureDescription};
+pub use type_param::TypeArg;
 pub use type_row::TypeRow;
 
 use derive_more::{From, Into};
@@ -23,7 +24,7 @@ use crate::ops::AliasDecl;
 use crate::type_row;
 use std::fmt::Debug;
 
-use self::primitive::PrimType;
+pub use self::primitive::PrimType;
 
 #[cfg(feature = "pyo3")]
 use pyo3::pyclass;
@@ -108,18 +109,17 @@ pub(crate) fn least_upper_bound(mut tags: impl Iterator<Item = TypeBound>) -> Ty
 /// Representation of a Sum type.
 /// Either store the types of the variants, or in the special (but common) case
 /// of a "simple predicate" (sum over empty tuples), store only the size of the predicate.
-enum SumType {
+pub enum SumType {
+    #[allow(missing_docs)]
     #[display(fmt = "SimplePredicate({})", "size")]
-    Simple {
-        size: u8,
-    },
-    General {
-        row: TypeRow,
-    },
+    Simple { size: u8 },
+    #[allow(missing_docs)]
+    General { row: TypeRow },
 }
 
 impl SumType {
-    fn new(types: impl Into<TypeRow>) -> Self {
+    /// Initialize a new sum type.
+    pub fn new(types: impl Into<TypeRow>) -> Self {
         let row: TypeRow = types.into();
 
         let len: usize = row.len();
@@ -130,7 +130,8 @@ impl SumType {
         }
     }
 
-    fn get_variant(&self, tag: usize) -> Option<&Type> {
+    /// Report the tag'th variant, if it exists.
+    pub fn get_variant(&self, tag: usize) -> Option<&Type> {
         match self {
             SumType::Simple { size } if tag < (*size as usize) => Some(Type::UNIT_REF),
             SumType::General { row } => row.get(tag),
@@ -150,10 +151,13 @@ impl From<SumType> for Type {
 
 #[derive(Clone, PartialEq, Debug, Eq, derive_more::Display)]
 /// Core types: primitive (leaf), tuple (product) or sum (co-product).
-enum TypeEnum {
+pub enum TypeEnum {
+    #[allow(missing_docs)]
     Prim(PrimType),
+    #[allow(missing_docs)]
     #[display(fmt = "Tuple({})", "_0")]
     Tuple(TypeRow),
+    #[allow(missing_docs)]
     #[display(fmt = "Sum({})", "_0")]
     Sum(SumType),
 }
@@ -260,6 +264,12 @@ impl Type {
     #[inline(always)]
     pub const fn least_upper_bound(&self) -> TypeBound {
         self.1
+    }
+
+    /// Report the component TypeEnum.
+    #[inline(always)]
+    pub const fn as_type_enum(&self) -> &TypeEnum {
+        &self.0
     }
 
     /// Report if the type is copyable - i.e.the least upper bound of the type

--- a/src/types/check.rs
+++ b/src/types/check.rs
@@ -49,6 +49,11 @@ pub enum ConstTypeError {
 }
 
 impl PrimType {
+    /// Check that a [`PrimValue`] is a valid instance of this [`PrimType`].
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if there is a type check error.
     pub fn check_type(&self, val: &PrimValue) -> Result<(), ConstTypeError> {
         if let PrimType::Alias(alias) = self {
             return Err(ConstTypeError::NoAliases(alias.name().to_string()));

--- a/src/types/primitive.rs
+++ b/src/types/primitive.rs
@@ -7,18 +7,23 @@ use super::{CustomType, FunctionType, TypeBound};
 #[derive(
     Clone, PartialEq, Debug, Eq, derive_more::Display, serde::Serialize, serde::Deserialize,
 )]
-pub(super) enum PrimType {
+/// Representation of a Primitive type, i.e. neither a Sum nor a Tuple.
+pub enum PrimType {
     // TODO optimise with Box<CustomType> ?
     // or some static version of this?
+    #[allow(missing_docs)]
     Extension(CustomType),
+    #[allow(missing_docs)]
     #[display(fmt = "Alias({})", "_0.name()")]
     Alias(AliasDecl),
+    #[allow(missing_docs)]
     #[display(fmt = "Function({})", "_0")]
     Function(Box<FunctionType>),
 }
 
 impl PrimType {
-    pub(super) fn bound(&self) -> TypeBound {
+    /// Returns the bound of this [`PrimType`].
+    pub fn bound(&self) -> TypeBound {
         match self {
             PrimType::Extension(c) => c.bound(),
             PrimType::Alias(a) => a.bound,


### PR DESCRIPTION
A missing doc is added for `PrimType::check_type` while I was there.