### PR TITLE
feat: Optional direction check when querying a port index

### DIFF
--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -28,7 +28,7 @@ use super::{
     tail_loop::TailLoopBuilder, BuildError, Wire,
 };
 
-use crate::Hugr;
+use crate::{Direction, Hugr};
 
 use crate::hugr::HugrMut;
 
@@ -662,8 +662,8 @@ fn wire_up<T: Dataflow + ?Sized>(
     dst: Node,
     dst_port: impl PortIndex,
 ) -> Result<bool, BuildError> {
-    let src_port = src_port.index();
-    let dst_port = dst_port.index();
+    let src_port = src_port.try_index(Direction::Outgoing)?;
+    let dst_port = dst_port.try_index(Direction::Incoming)?;
     let base = data_builder.hugr_mut();
     let src_offset = Port::new_outgoing(src_port);
 

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -1,7 +1,7 @@
 use crate::hugr::hugrmut::InsertionResult;
 use crate::hugr::validate::InterGraphEdgeError;
 use crate::hugr::views::HugrView;
-use crate::hugr::{Node, NodeMetadata, Port, PortIndex, ValidationError};
+use crate::hugr::{IncomingPort, Node, NodeMetadata, OutgoingPort, Port, ValidationError};
 use crate::ops::{self, LeafOp, OpTrait, OpType};
 
 use std::iter;
@@ -28,7 +28,7 @@ use super::{
     tail_loop::TailLoopBuilder, BuildError, Wire,
 };
 
-use crate::{Direction, Hugr};
+use crate::Hugr;
 
 use crate::hugr::HugrMut;
 
@@ -658,27 +658,26 @@ fn wire_up_inputs<T: Dataflow + ?Sized>(
 fn wire_up<T: Dataflow + ?Sized>(
     data_builder: &mut T,
     src: Node,
-    src_port: impl PortIndex,
+    src_port: impl TryInto<OutgoingPort>,
     dst: Node,
-    dst_port: impl PortIndex,
+    dst_port: impl TryInto<IncomingPort>,
 ) -> Result<bool, BuildError> {
-    let src_port = src_port.try_index(Direction::Outgoing)?;
-    let dst_port = dst_port.try_index(Direction::Incoming)?;
+    let src_port = Port::try_new_outgoing(src_port)?;
+    let dst_port = Port::try_new_incoming(dst_port)?;
     let base = data_builder.hugr_mut();
-    let src_offset = Port::new_outgoing(src_port);
 
     let src_parent = base.get_parent(src);
     let dst_parent = base.get_parent(dst);
     let local_source = src_parent == dst_parent;
-    if let EdgeKind::Value(typ) = base.get_optype(src).port_kind(src_offset).unwrap() {
+    if let EdgeKind::Value(typ) = base.get_optype(src).port_kind(src_port).unwrap() {
         if !local_source {
             // Non-local value sources require a state edge to an ancestor of dst
             if !typ.copyable() {
                 let val_err: ValidationError = InterGraphEdgeError::NonCopyableData {
                     from: src,
-                    from_offset: Port::new_outgoing(src_port),
+                    from_offset: src_port,
                     to: dst,
-                    to_offset: Port::new_incoming(dst_port),
+                    to_offset: dst_port,
                     ty: EdgeKind::Value(typ),
                 }
                 .into();
@@ -694,9 +693,9 @@ fn wire_up<T: Dataflow + ?Sized>(
             else {
                 let val_err: ValidationError = InterGraphEdgeError::NoRelation {
                     from: src,
-                    from_offset: Port::new_outgoing(src_port),
+                    from_offset: src_port,
                     to: dst,
-                    to_offset: Port::new_incoming(dst_port),
+                    to_offset: dst_port,
                 }
                 .into();
                 return Err(val_err.into());
@@ -705,7 +704,7 @@ fn wire_up<T: Dataflow + ?Sized>(
             // TODO: Avoid adding duplicate edges
             // This should be easy with https://github.com/CQCL-DEV/hugr/issues/130
             base.add_other_edge(src, src_sibling)?;
-        } else if !typ.copyable() & base.linked_ports(src, src_offset).next().is_some() {
+        } else if !typ.copyable() & base.linked_ports(src, src_port).next().is_some() {
             // Don't copy linear edges.
             return Err(BuildError::NoCopyLinear(typ));
         }
@@ -719,7 +718,7 @@ fn wire_up<T: Dataflow + ?Sized>(
             data_builder
                 .hugr_mut()
                 .get_optype(dst)
-                .port_kind(Port::new_incoming(dst_port))
+                .port_kind(dst_port)
                 .unwrap(),
             EdgeKind::Value(_)
         ))

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -266,9 +266,12 @@ where
         dst: Node,
         dst_port: impl PortIndex,
     ) -> Result<(), HugrError> {
-        self.as_mut()
-            .graph
-            .link_nodes(src.index, src_port.index(), dst.index, dst_port.index())?;
+        self.as_mut().graph.link_nodes(
+            src.index,
+            src_port.try_index(Direction::Outgoing)?,
+            dst.index,
+            dst_port.try_index(Direction::Incoming)?,
+        )?;
         Ok(())
     }
 

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -14,7 +14,7 @@ use crate::{Hugr, Port};
 use self::sealed::HugrMutInternals;
 
 use super::views::SiblingSubgraph;
-use super::{NodeMetadata, PortIndex, Rewrite};
+use super::{IncomingPort, NodeMetadata, OutgoingPort, PortIndex, Rewrite};
 
 /// Functions for low-level building of a HUGR.
 pub trait HugrMut: HugrView + HugrMutInternals {
@@ -110,9 +110,9 @@ pub trait HugrMut: HugrView + HugrMutInternals {
     fn connect(
         &mut self,
         src: Node,
-        src_port: impl PortIndex,
+        src_port: impl TryInto<OutgoingPort>,
         dst: Node,
-        dst_port: impl PortIndex,
+        dst_port: impl TryInto<IncomingPort>,
     ) -> Result<(), HugrError> {
         self.valid_node(src)?;
         self.valid_node(dst)?;
@@ -262,15 +262,15 @@ where
     fn connect(
         &mut self,
         src: Node,
-        src_port: impl PortIndex,
+        src_port: impl TryInto<OutgoingPort>,
         dst: Node,
-        dst_port: impl PortIndex,
+        dst_port: impl TryInto<IncomingPort>,
     ) -> Result<(), HugrError> {
         self.as_mut().graph.link_nodes(
             src.index,
-            src_port.try_index(Direction::Outgoing)?,
+            Port::try_new_outgoing(src_port)?.index(),
             dst.index,
-            dst_port.try_index(Direction::Incoming)?,
+            Port::try_new_incoming(dst_port)?.index(),
         )?;
         Ok(())
     }


### PR DESCRIPTION
So `connect` throws an error when passed invalid ports, but we still support `usize`s.

Closes #565. I choose not to allow backwards edges as that introduces a new failure mode when the directions are the same (and weird behaviour when passed one `Port` and one `usize`).