### PR TITLE
RFC: {infer=>intern}_and_validate calls resolve_extension_ops

### DIFF
--- a/src/builder/cfg.rs
+++ b/src/builder/cfg.rs
@@ -73,7 +73,7 @@ impl HugrBuilder for CFGBuilder<Hugr> {
         mut self,
         extension_registry: &ExtensionRegistry,
     ) -> Result<Hugr, crate::hugr::ValidationError> {
-        self.base.infer_and_validate(extension_registry)?;
+        self.base.intern_and_validate(extension_registry)?;
         Ok(self.base)
     }
 }

--- a/src/builder/conditional.rs
+++ b/src/builder/conditional.rs
@@ -150,7 +150,7 @@ impl HugrBuilder for ConditionalBuilder<Hugr> {
         mut self,
         extension_registry: &ExtensionRegistry,
     ) -> Result<Hugr, crate::hugr::ValidationError> {
-        self.base.infer_and_validate(extension_registry)?;
+        self.base.intern_and_validate(extension_registry)?;
         Ok(self.base)
     }
 }

--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -90,7 +90,7 @@ impl HugrBuilder for DFGBuilder<Hugr> {
         mut self,
         extension_registry: &ExtensionRegistry,
     ) -> Result<Hugr, ValidationError> {
-        self.base.infer_and_validate(extension_registry)?;
+        self.base.intern_and_validate(extension_registry)?;
         Ok(self.base)
     }
 }

--- a/src/builder/module.rs
+++ b/src/builder/module.rs
@@ -60,7 +60,7 @@ impl HugrBuilder for ModuleBuilder<Hugr> {
         mut self,
         extension_registry: &ExtensionRegistry,
     ) -> Result<Hugr, ValidationError> {
-        self.0.infer_and_validate(extension_registry)?;
+        self.0.intern_and_validate(extension_registry)?;
         Ok(self.0)
     }
 }

--- a/src/extension/infer.rs
+++ b/src/extension/infer.rs
@@ -853,7 +853,7 @@ mod test {
         // nodes and their parents and `report_mismatch` isn't yet smart enough
         // to handle that.
         assert_matches!(
-            hugr.infer_and_validate(&PRELUDE_REGISTRY),
+            hugr.intern_and_validate(&PRELUDE_REGISTRY),
             Err(ValidationError::CantInfer(_))
         );
         Ok(())
@@ -1134,7 +1134,7 @@ mod test {
             hugr.connect(src, 0, tgt, 0)?;
         }
 
-        hugr.infer_and_validate(&PRELUDE_REGISTRY)?;
+        hugr.intern_and_validate(&PRELUDE_REGISTRY)?;
 
         Ok(())
     }

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -223,7 +223,7 @@ pub type Direction = portgraph::Direction;
 /// Public API for HUGRs.
 impl Hugr {
     /// Resolve extension ops, run resource inference and pass the closure into validation
-    pub fn infer_and_validate(
+    pub fn intern_and_validate(
         &mut self,
         extension_registry: &ExtensionRegistry,
     ) -> Result<(), ValidationError> {

--- a/src/hugr.rs
+++ b/src/hugr.rs
@@ -29,6 +29,7 @@ pub use self::views::HugrView;
 use crate::extension::{
     infer_extensions, ExtensionRegistry, ExtensionSet, ExtensionSolution, InferExtensionError,
 };
+use crate::ops::custom::resolve_extension_ops;
 use crate::ops::{OpTag, OpTrait, OpType, DEFAULT_OPTYPE};
 use crate::types::{FunctionType, Signature};
 
@@ -221,11 +222,12 @@ pub type Direction = portgraph::Direction;
 
 /// Public API for HUGRs.
 impl Hugr {
-    /// Run resource inference and pass the closure into validation
+    /// Resolve extension ops, run resource inference and pass the closure into validation
     pub fn infer_and_validate(
         &mut self,
         extension_registry: &ExtensionRegistry,
     ) -> Result<(), ValidationError> {
+        resolve_extension_ops(self, extension_registry)?;
         let closure = self.infer_extensions()?;
         self.validate_with_extension_closure(closure, extension_registry)?;
         Ok(())

--- a/src/hugr/rewrite/insert_identity.rs
+++ b/src/hugr/rewrite/insert_identity.rs
@@ -136,7 +136,7 @@ mod tests {
 
         assert_eq!(noop, LeafOp::Noop { ty: QB_T });
 
-        h.infer_and_validate(&PRELUDE_REGISTRY).unwrap();
+        h.intern_and_validate(&PRELUDE_REGISTRY).unwrap();
     }
 
     #[test]

--- a/src/hugr/rewrite/outline_cfg.rs
+++ b/src/hugr/rewrite/outline_cfg.rs
@@ -299,7 +299,7 @@ mod test {
     #[test]
     fn test_outline_cfg() {
         let (mut h, head, tail) = build_conditional_in_loop_cfg(false).unwrap();
-        h.infer_and_validate(&PRELUDE_REGISTRY).unwrap();
+        h.intern_and_validate(&PRELUDE_REGISTRY).unwrap();
         do_outline_cfg_test(&mut h, head, tail, 1);
         h.validate(&PRELUDE_REGISTRY).unwrap();
     }

--- a/src/hugr/rewrite/simple_replace.rs
+++ b/src/hugr/rewrite/simple_replace.rs
@@ -391,7 +391,7 @@ pub(in crate::hugr::rewrite) mod test {
         // ├───┤├───┤┌─┴─┐
         // ┤ H ├┤ H ├┤ X ├
         // └───┘└───┘└───┘
-        assert_eq!(h.infer_and_validate(&PRELUDE_REGISTRY), Ok(()));
+        assert_eq!(h.intern_and_validate(&PRELUDE_REGISTRY), Ok(()));
     }
 
     #[rstest]
@@ -463,7 +463,7 @@ pub(in crate::hugr::rewrite) mod test {
         // ├───┤├───┤┌───┐
         // ┤ H ├┤ H ├┤ H ├
         // └───┘└───┘└───┘
-        assert_eq!(h.infer_and_validate(&PRELUDE_REGISTRY), Ok(()));
+        assert_eq!(h.intern_and_validate(&PRELUDE_REGISTRY), Ok(()));
     }
 
     #[test]

--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -470,7 +470,7 @@ pub mod test {
         hugr.connect(new_in, 0, out, 0).unwrap();
         hugr.move_before_sibling(new_in, old_in).unwrap();
         hugr.remove_node(old_in).unwrap();
-        hugr.infer_and_validate(&PRELUDE_REGISTRY).unwrap();
+        hugr.intern_and_validate(&PRELUDE_REGISTRY).unwrap();
 
         let ser = serde_json::to_vec(&hugr).unwrap();
         let new_hugr: Hugr = serde_json::from_slice(&ser).unwrap();

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -161,7 +161,7 @@ impl<'a, 'b> ValidationContext<'a, 'b> {
         }
 
         // Check operation-specific constraints. Firstly that type args are correct
-        // (Best if we've called `resolve_extension_ops` first, as per infer_and_validate)
+        // (Best if we've called `resolve_extension_ops` first, as per intern_and_validate)
         if let OpType::LeafOp(crate::ops::LeafOp::CustomOp(b)) = op_type {
             for arg in b.args() {
                 arg.validate(self.extension_registry)
@@ -1087,20 +1087,20 @@ mod test {
         h.connect(sub_dfg, 0, output, 0)?;
 
         assert_matches!(
-            h.infer_and_validate(&EMPTY_REG),
+            h.intern_and_validate(&EMPTY_REG),
             Err(ValidationError::UnconnectedPort { .. })
         );
 
         h.connect(input, 1, sub_op, 1)?;
         assert_matches!(
-            h.infer_and_validate(&EMPTY_REG),
+            h.intern_and_validate(&EMPTY_REG),
             Err(ValidationError::InterGraphEdgeError(
                 InterGraphEdgeError::MissingOrderEdge { .. }
             ))
         );
         //Order edge. This will need metadata indicating its purpose.
         h.add_other_edge(input, sub_dfg)?;
-        h.infer_and_validate(&EMPTY_REG).unwrap();
+        h.intern_and_validate(&EMPTY_REG).unwrap();
         Ok(())
     }
 
@@ -1117,7 +1117,7 @@ mod test {
         h.connect(input, 0, and, 0)?;
         h.connect(and, 0, output, 0)?;
         assert_eq!(
-            h.infer_and_validate(&EMPTY_REG),
+            h.intern_and_validate(&EMPTY_REG),
             Err(ValidationError::UnconnectedPort {
                 node: and,
                 port: Port::new_incoming(1),
@@ -1135,7 +1135,7 @@ mod test {
         h.connect(cst, 0, lcst, 0)?;
         h.connect(lcst, 0, and, 1)?;
         // There is no edge from Input to LoadConstant, but that's OK:
-        h.infer_and_validate(&EMPTY_REG).unwrap();
+        h.intern_and_validate(&EMPTY_REG).unwrap();
         Ok(())
     }
 

--- a/src/ops/custom.rs
+++ b/src/ops/custom.rs
@@ -235,8 +235,8 @@ pub fn resolve_extension_ops(
                     // Fail if the Extension was found but did not have the expected operation
                     let Some(def) = r.get_op(&opaque.op_name) else {
                         return Err(CustomOpError::OpNotFoundInExtension(
-                            opaque.op_name.to_string(),
-                            r.name().to_string(),
+                            opaque.op_name.clone(),
+                            r.name().clone(),
                         ));
                     };
                     let op = ExternalOp::Extension(
@@ -246,7 +246,8 @@ pub fn resolve_extension_ops(
                     if let Some(sig) = &opaque.signature {
                         if sig != &op.signature() {
                             return Err(CustomOpError::SignatureMismatch(
-                                def.name().to_string(),
+                                r.name().clone(),
+                                def.name().clone(),
                                 op.signature(),
                                 sig.clone(),
                             ));
@@ -277,10 +278,10 @@ pub enum CustomOpError {
     NoStoredSignature(SmolStr, Node),
     /// The Extension was found but did not contain the expected OpDef
     #[error("Operation {0} not found in Extension {1}")]
-    OpNotFoundInExtension(String, String),
+    OpNotFoundInExtension(SmolStr, ExtensionId),
     /// Extension and OpDef found, but computed signature did not match stored
-    #[error("Resolved {0} to a concrete implementation which computed a conflicting signature: {1:?} vs stored {2:?}")]
-    SignatureMismatch(String, FunctionType, FunctionType),
+    #[error("Conflicting signature: resolved {1} in extension {0} to a concrete implementation which computed {2:?} but stored signature was {3:?}")]
+    SignatureMismatch(ExtensionId, SmolStr, FunctionType, FunctionType),
 }
 
 #[cfg(test)]

--- a/src/ops/custom.rs
+++ b/src/ops/custom.rs
@@ -270,7 +270,7 @@ pub fn resolve_extension_ops(
 
 /// Errors that arise after loading a Hugr containing opaque ops (serialized just as their names)
 /// when trying to resolve the serialized names against a registry of known Extensions.
-#[derive(Clone, Debug, Error)]
+#[derive(Clone, Debug, Error, PartialEq)]
 pub enum CustomOpError {
     /// Extension not found, and no signature
     #[error("Unable to resolve operation {0} for node {1:?} with no saved signature")]


### PR DESCRIPTION
There are comments in validate that it'd be good to call `resolve_extension_ops` immediately before validation, and those comments are correct ;-). (Thus, fixes #508.)

Moreover, we actually have a place that mutates the Hugr immediately before validation. It's currently called `infer_and_validate`, but that can be changed, so let's use that.

To my surprise, this didn't fail any tests. I guess we don't have any that validate Hugrs containing `ExternalOp::Opaque` instances! I shall probably add some shortly, but in the meantime....

The big question here is what to call `infer_and_validate` now it also includes `resolve_extension_ops`. `resolve_infer_validate` is too long. A look in the thesaurus suggested things like `normalize`, `internalize`, `regulize` - hence what I have here. I also wonder about using the word `update` - `update_and_validate`, `update_validate`, `valid_update`, `valiupdate` (!), `upvalidate` etc....? Other ideas?

There is another alternative, which is to make validation perform the same checks as `resolve_extension_ops` (i.e. that the data in the serialized OpaqueOp is consistent with the ExtensionRegistry) but without mutating the Hugr. Given that we'd also want to keep the mutating version, this is more work, but possibly it is more consistent with principle. <strike>Please shout if you think this is worth doing?</strike>EDIT: I'll give this a try; it's an extra step to the above, that I suppose could follow in another PR, but this may not be as hard as I thought, so I may be able to just do it here.