### PR TITLE
fix: Don't insert temporary wires when extracting a subgraph

### DIFF
--- a/src/hugr/views/sibling_subgraph.rs
+++ b/src/hugr/views/sibling_subgraph.rs
@@ -418,7 +418,7 @@ impl SiblingSubgraph {
         };
         let mut builder = FunctionBuilder::new(name, signature).unwrap();
         // Take the unfinished Hugr from the builder, to avoid unnecessary
-        // validation checks that require connecting the inputs an outputs.
+        // validation checks that require connecting the inputs and outputs.
         let mut extracted = mem::take(builder.hugr_mut());
         let node_map = extracted
             .insert_subgraph(extracted.root(), hugr, self)?


### PR DESCRIPTION
We connected the temporary built graph inputs and outputs, but the logic didn't take into account reordering in the signature, or non-linear parameters.

We can avoid the headache by not validating the intermediate construct.