### PR TITLE
fix: Improve convexity checking and fix test

### DIFF
--- a/src/hugr/views/sibling_subgraph.rs
+++ b/src/hugr/views/sibling_subgraph.rs
@@ -517,16 +517,13 @@ fn validate_subgraph<H: HugrView>(
     }
 
     let mut ports_inside = inputs.iter().flatten().chain(outputs).copied();
-    let mut ports_outside = ports_inside
-        .clone()
-        .flat_map(|(n, p)| hugr.linked_ports(n, p));
     // Check incoming & outgoing ports have target resp. source inside
     let nodes = nodes.iter().copied().collect::<HashSet<_>>();
     if ports_inside.any(|(n, _)| !nodes.contains(&n)) {
         return Err(InvalidSubgraph::InvalidBoundary);
     }
-    // Check incoming & outgoing ports have source resp. target outside
-    if ports_outside.any(|(n, _)| nodes.contains(&n)) {
+    // Check that every inside port has at least one linked port outside.
+    if ports_inside.any(|(n, p)| hugr.linked_ports(n, p).all(|(n1, _)| nodes.contains(&n1))) {
         return Err(InvalidSubgraph::NotConvex);
     }
 

--- a/src/hugr/views/sibling_subgraph.rs
+++ b/src/hugr/views/sibling_subgraph.rs
@@ -911,6 +911,24 @@ mod tests {
     }
 
     #[test]
+    fn invalid_boundary() {
+        let (hugr, func_root) = build_hugr().unwrap();
+        let func: SiblingGraph<'_> = SiblingGraph::try_new(&hugr, func_root).unwrap();
+        let (inp, out) = hugr.children(func_root).take(2).collect_tuple().unwrap();
+        let cx_edges_in = hugr.node_outputs(inp);
+        let cx_edges_out = hugr.node_inputs(out);
+        // All graph but the CX
+        assert!(matches!(
+            SiblingSubgraph::try_new(
+                cx_edges_out.map(|p| vec![(out, p)]).collect(),
+                cx_edges_in.map(|p| (inp, p)).collect(),
+                &func,
+            ),
+            Err(InvalidSubgraph::InvalidBoundary)
+        ));
+    }
+
+    #[test]
     fn preserve_signature() {
         let (hugr, func_root) = build_hugr_classical().unwrap();
         let func_graph: SiblingGraph<'_, FuncID<true>> =

--- a/src/hugr/views/sibling_subgraph.rs
+++ b/src/hugr/views/sibling_subgraph.rs
@@ -474,8 +474,6 @@ fn get_edge_type<H: HugrView>(hugr: &H, ports: &[(Node, Port)]) -> Option<Type> 
 }
 
 /// Whether a subgraph is valid.
-///
-/// Does NOT check for convexity.
 fn validate_subgraph<H: HugrView>(
     hugr: &H,
     nodes: &[Node],

--- a/src/hugr/views/sibling_subgraph.rs
+++ b/src/hugr/views/sibling_subgraph.rs
@@ -527,7 +527,7 @@ fn validate_subgraph<H: HugrView>(
     }
     // Check that every inside port has at least one linked port outside.
     if ports_inside.any(|(n, p)| hugr.linked_ports(n, p).all(|(n1, _)| nodes.contains(&n1))) {
-        return Err(InvalidSubgraph::NotConvex);
+        return Err(InvalidSubgraph::InvalidBoundary);
     }
     // Check that every incoming port of a node in the subgraph whose source is not in the subgraph
     // belongs to inputs.

--- a/src/hugr/views/sibling_subgraph.rs
+++ b/src/hugr/views/sibling_subgraph.rs
@@ -474,6 +474,11 @@ fn get_edge_type<H: HugrView>(hugr: &H, ports: &[(Node, Port)]) -> Option<Type> 
 }
 
 /// Whether a subgraph is valid.
+///
+/// Verifies that input and output ports are valid subgraph boundaries, i.e. they belong
+/// to nodes within the subgraph and are linked to at least one node outside of the subgraph.
+/// This does NOT check convexity proper, i.e. whether the set of nodes form a convex
+/// induced graph.
 fn validate_subgraph<H: HugrView>(
     hugr: &H,
     nodes: &[Node],


### PR DESCRIPTION
Fixes #518 .

I changed the `non_convex_subgraph` test because the graph it was constructing seemed to meet the criteria for convexity, and replaced it with another one which doesn't. But please check -- I was a little confused by the definitions and may be missing something.