### PR TITLE
fix: enforce covariance of SiblingMut::RootHandle

### DIFF
--- a/src/hugr/views/sibling.rs
+++ b/src/hugr/views/sibling.rs
@@ -470,7 +470,6 @@ mod test {
     }
 
     #[rstest]
-    //#[should_panic] // See commented out line in test
     fn sibling_mut_covariance(mut simple_dfg_hugr: Hugr) {
         let root = simple_dfg_hugr.root();
         let case_nodetype = NodeType::open_extensions(crate::ops::Case {


### PR DESCRIPTION
When creating a SiblingMut with a root whose type is constrained by being the root of the parent, ensure the "child" SiblingMut only narrows the constraint